### PR TITLE
Implement Mahjong core engine

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -14,7 +14,8 @@
       ]
     },
     "baseUrl": ".",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "references": [
     {

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -1,0 +1,37 @@
+import { Player } from './Player.js';
+import { Wall } from './Wall.js';
+import { Tile } from './Tile.js';
+
+export class Game {
+  readonly wall: Wall;
+  readonly players: Player[];
+  private currentIndex = 0;
+
+  constructor(playerCount = 4, wall: Wall = Wall.createShuffled()) {
+    this.wall = wall;
+    this.players = Array.from({ length: playerCount }, () => new Player());
+  }
+
+  deal(initialHandSize = 13): void {
+    for (let i = 0; i < initialHandSize; i++) {
+      for (const player of this.players) {
+        const tile = this.wall.draw();
+        if (!tile) throw new Error('Wall exhausted');
+        player.draw(tile);
+      }
+    }
+  }
+
+  drawCurrent(): Tile {
+    const tile = this.wall.draw();
+    if (!tile) throw new Error('Wall exhausted');
+    this.players[this.currentIndex].draw(tile);
+    return tile;
+  }
+
+  discardCurrent(index: number): Tile {
+    const tile = this.players[this.currentIndex].discard(index);
+    this.currentIndex = (this.currentIndex + 1) % this.players.length;
+    return tile;
+  }
+}

--- a/core/src/Player.ts
+++ b/core/src/Player.ts
@@ -1,0 +1,16 @@
+import { Tile } from './Tile.js';
+
+export class Player {
+  readonly hand: Tile[] = [];
+  readonly discards: Tile[] = [];
+
+  draw(tile: Tile): void {
+    this.hand.push(tile);
+  }
+
+  discard(index: number): Tile {
+    const [tile] = this.hand.splice(index, 1);
+    this.discards.push(tile);
+    return tile;
+  }
+}

--- a/core/src/Tile.ts
+++ b/core/src/Tile.ts
@@ -1,0 +1,15 @@
+import type { TileType, Suit } from './types.js';
+
+export class Tile {
+  readonly suit: Suit;
+  readonly value: string | number;
+
+  constructor(type: TileType) {
+    this.suit = type.suit;
+    this.value = type.value;
+  }
+
+  toString(): string {
+    return `${this.suit}-${this.value}`;
+  }
+}

--- a/core/src/Wall.ts
+++ b/core/src/Wall.ts
@@ -1,0 +1,62 @@
+import { Tile } from './Tile.js';
+import type { Dragon, NumberSuit, Suit, TileType, Wind } from './types.js';
+
+export class Wall {
+  private tiles: Tile[];
+
+  constructor(tiles: Tile[] = []) {
+    this.tiles = tiles;
+  }
+
+  static generateTiles(): Tile[] {
+    const tiles: Tile[] = [];
+    const numberSuits: NumberSuit[] = ['man', 'pin', 'sou'];
+    for (const suit of numberSuits) {
+      for (let value = 1 as const; value <= 9; value++) {
+        for (let i = 0; i < 4; i++) {
+          tiles.push(new Tile({ suit, value: value as 1|2|3|4|5|6|7|8|9 }));
+        }
+      }
+    }
+
+    const winds: Wind[] = ['east', 'south', 'west', 'north'];
+    for (const value of winds) {
+      for (let i = 0; i < 4; i++) {
+        tiles.push(new Tile({ suit: 'wind', value }));
+      }
+    }
+
+    const dragons: Dragon[] = ['white', 'green', 'red'];
+    for (const value of dragons) {
+      for (let i = 0; i < 4; i++) {
+        tiles.push(new Tile({ suit: 'dragon', value }));
+      }
+    }
+    return tiles;
+  }
+
+  static createShuffled(random: () => number = Math.random): Wall {
+    const tiles = Wall.generateTiles();
+    // Fisher-Yates shuffle
+    for (let i = tiles.length - 1; i > 0; i--) {
+      const j = Math.floor(random() * (i + 1));
+      [tiles[i], tiles[j]] = [tiles[j], tiles[i]];
+    }
+    return new Wall(tiles);
+  }
+
+  shuffle(random: () => number = Math.random): void {
+    for (let i = this.tiles.length - 1; i > 0; i--) {
+      const j = Math.floor(random() * (i + 1));
+      [this.tiles[i], this.tiles[j]] = [this.tiles[j], this.tiles[i]];
+    }
+  }
+
+  draw(): Tile | undefined {
+    return this.tiles.pop();
+  }
+
+  get count(): number {
+    return this.tiles.length;
+  }
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,3 +1,9 @@
+export * from './types.js';
+export * from './Tile.js';
+export * from './Wall.js';
+export * from './Player.js';
+export * from './Game.js';
+
 export function sum(a: number, b: number): number {
   return a + b;
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,0 +1,22 @@
+export type NumberSuit = 'man' | 'pin' | 'sou';
+export type Wind = 'east' | 'south' | 'west' | 'north';
+export type Dragon = 'white' | 'green' | 'red';
+export type HonorSuit = 'wind' | 'dragon';
+export type Suit = NumberSuit | HonorSuit;
+
+export interface NumberTile {
+  suit: NumberSuit;
+  value: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+}
+
+export interface WindTile {
+  suit: 'wind';
+  value: Wind;
+}
+
+export interface DragonTile {
+  suit: 'dragon';
+  value: Dragon;
+}
+
+export type TileType = NumberTile | WindTile | DragonTile;

--- a/core/test/game.test.ts
+++ b/core/test/game.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Game } from '../src/index.js';
+
+test('game dealing and turn flow', () => {
+  const game = new Game(2); // two players for simplicity
+  game.deal();
+  for (const player of game.players) {
+    assert.strictEqual(player.hand.length, 13);
+  }
+  const remaining = 136 - 13 * game.players.length;
+  assert.strictEqual(game.wall.count, remaining);
+
+  const tile = game.drawCurrent();
+  assert.ok(tile);
+  assert.strictEqual(game.players[0].hand.length, 14);
+  const discarded = game.discardCurrent(game.players[0].hand.length - 1);
+  assert.strictEqual(game.players[0].hand.length, 13);
+  assert.strictEqual(game.players[0].discards[0], discarded);
+  // current player should advance
+  assert.strictEqual(game['currentIndex'], 1);
+});

--- a/core/test/player.test.ts
+++ b/core/test/player.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Player, Wall } from '../src/index.js';
+
+test('player draw and discard', () => {
+  const wall = Wall.createShuffled(() => 0.5);
+  const player = new Player();
+  const tile = wall.draw();
+  assert.ok(tile);
+  player.draw(tile!);
+  assert.strictEqual(player.hand.length, 1);
+  const discarded = player.discard(0);
+  assert.strictEqual(discarded, tile);
+  assert.strictEqual(player.hand.length, 0);
+  assert.strictEqual(player.discards.length, 1);
+});

--- a/core/test/wall.test.ts
+++ b/core/test/wall.test.ts
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Wall, Tile } from '../src/index.js';
+
+function tileCounts(tiles: Tile[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const t of tiles) {
+    const key = t.toString();
+    map.set(key, (map.get(key) || 0) + 1);
+  }
+  return map;
+}
+
+test('generateTiles creates 136 tiles with 4 of each kind', () => {
+  const tiles = Wall.generateTiles();
+  assert.strictEqual(tiles.length, 136);
+  const counts = tileCounts(tiles);
+  for (const count of counts.values()) {
+    assert.strictEqual(count, 4);
+  }
+});
+
+test('shuffled wall has same tiles but different order', () => {
+  const wall = Wall.createShuffled(() => 0.5);
+  const tiles = wall['tiles'] as unknown as Tile[]; // Access for test
+  const unshuffled = Wall.generateTiles();
+  assert.strictEqual(tiles.length, unshuffled.length);
+  const sorted1 = [...tiles].map(t => t.toString()).sort().join(',');
+  const sorted2 = unshuffled.map(t => t.toString()).sort().join(',');
+  assert.strictEqual(sorted1, sorted2);
+  // ensure order differs
+  const serial1 = tiles.map(t => t.toString()).join(',');
+  const serial2 = unshuffled.map(t => t.toString()).join(',');
+  assert.notStrictEqual(serial1, serial2);
+});

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -8,7 +8,8 @@
     "composite": true,
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "include": [
     "src",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -14,7 +14,8 @@
       ]
     },
     "baseUrl": ".",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "references": [
     {


### PR DESCRIPTION
## Summary
- implement core mahjong logic (tiles, wall, players, game)
- export new API from `@mymahjong/core`
- enable Node types in tsconfigs
- add unit tests for tile generation, shuffling, drawing, and discard flows

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f8ec76388832ab4de5f318b04ea22