### PR TITLE
Add interactive CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -5,7 +5,8 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "test": "node --test dist/test"
+    "test": "node --test dist/test",
+    "start": "node dist/src/index.js"
   },
   "dependencies": {
     "@mymahjong/core": "*"

--- a/cli/src/UI.ts
+++ b/cli/src/UI.ts
@@ -1,0 +1,8 @@
+export function renderHand(hand: { toString(): string }[]): string {
+  return hand.map((tile, i) => `[${i}] ${tile.toString()}`).join(' ');
+}
+
+export async function prompt(rl: import('node:readline/promises').Interface, question: string): Promise<string> {
+  return rl.question(question);
+}
+

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,36 @@
-import { sum } from '@mymahjong/core';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { Game } from '@mymahjong/core';
+import { renderHand, prompt } from './UI.js';
 
-export function run(): number {
-  return sum(1, 2);
+export async function run(): Promise<void> {
+  const rl = readline.createInterface({ input, output });
+  const game = new Game(1);
+  game.deal();
+  const player = game.players[0];
+  console.log('Your starting hand:');
+  console.log(renderHand(player.hand));
+  while (game.wall.count > 0) {
+    await prompt(rl, 'Press Enter to draw');
+    const drawn = game.drawCurrent();
+    console.log(`You drew: ${drawn}`);
+    console.log(renderHand(player.hand));
+    const ans = await prompt(rl, 'Discard index: ');
+    const index = parseInt(ans, 10);
+    if (!Number.isFinite(index) || index < 0 || index >= player.hand.length) {
+      console.log('Invalid index, try again.');
+      continue;
+    }
+    const discarded = game.discardCurrent(index);
+    console.log(`You discarded: ${discarded}`);
+    console.log('Your hand:');
+    console.log(renderHand(player.hand));
+  }
+  console.log('Wall exhausted, game over.');
+  rl.close();
 }
+
+if (require.main === module) {
+  run();
+}
+

--- a/cli/test/UI.test.ts
+++ b/cli/test/UI.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Tile } from '@mymahjong/core';
+import { renderHand } from '../src/UI.js';
+
+function makeTile(label: string): Tile {
+  const [suit, value] = label.split('-');
+  return new Tile({ suit: suit as any, value: isNaN(Number(value)) ? value as any : Number(value) as any });
+}
+
+test('renderHand lists tiles with indexes', () => {
+  const hand = ['man-1', 'pin-2', 'sou-3'].map(makeTile);
+  const result = renderHand(hand);
+  assert.strictEqual(result, '[0] man-1 [1] pin-2 [2] sou-3');
+});
+

--- a/cli/test/index.test.ts
+++ b/cli/test/index.test.ts
@@ -1,7 +1,0 @@
-import { test } from 'node:test';
-import assert from 'node:assert';
-import { run } from '../src/index.js';
-
-test('run returns 3', () => {
-  assert.strictEqual(run(), 3);
-});


### PR DESCRIPTION
## Summary
- implement simple CLI for playing Mahjong from terminal
- add UI helpers
- provide a `start` script
- test rendering helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f90ceb59c832ab6e9a3507f3434eb