### PR TITLE
Add GameBoard component and integrate into app

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Hand } from './components/Hand.js';
+import { GameBoard } from './components/GameBoard.js';
 import { useGame } from './hooks/useGame.js';
 
 export default function App(): JSX.Element {
@@ -9,8 +9,7 @@ export default function App(): JSX.Element {
       <h1>My Mahjong</h1>
       <p>Wall tiles left: {wallCount}</p>
       <button onClick={draw} disabled={wallCount === 0}>Draw</button>
-      <h2>Your Hand</h2>
-      <Hand tiles={hand} onDiscard={discard} />
+      <GameBoard currentHand={hand} onDiscard={discard} />
       <h2>Discards</h2>
       <ul className="discards">
         {discards.map((t, i) => <li key={i}>{t.toString()}</li>)}

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { Tile } from '@mymahjong/core';
+import { Hand } from './Hand.js';
+
+export interface GameBoardProps {
+  currentHand: Tile[];
+  onDiscard: (index: number) => void;
+}
+
+export function GameBoard({ currentHand, onDiscard }: GameBoardProps): JSX.Element {
+  return (
+    <div className="board">
+      <div className="player-area top">Player 2 Hand</div>
+      <div className="player-area left">Player 3 Hand</div>
+      <div className="center">Center</div>
+      <div className="player-area right">Player 4 Hand</div>
+      <div className="player-area bottom">
+        <Hand tiles={currentHand} onDiscard={onDiscard} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -17,3 +17,39 @@ body {
 button {
   margin-left: 0.5rem;
 }
+
+.board {
+  display: grid;
+  grid-template-areas:
+    '. top .'
+    'left center right'
+    '. bottom .';
+  grid-template-columns: 1fr 2fr 1fr;
+  grid-template-rows: auto 1fr auto;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.player-area {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+}
+
+.player-area.top {
+  grid-area: top;
+  text-align: center;
+}
+.player-area.bottom {
+  grid-area: bottom;
+  text-align: center;
+}
+.player-area.left {
+  grid-area: left;
+}
+.player-area.right {
+  grid-area: right;
+}
+.center {
+  grid-area: center;
+  text-align: center;
+}

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { GameBoard } from '../src/components/GameBoard.js';
+import { Tile } from '@mymahjong/core';
+
+test('GameBoard renders four player sections', () => {
+  const tiles = [new Tile({ suit: 'man', value: 1 })];
+  const html = renderToStaticMarkup(
+    <GameBoard currentHand={tiles} onDiscard={() => {}} />
+  );
+  const count = (html.match(/class="player-area/g) || []).length;
+  assert.equal(count, 4);
+  assert.ok(html.includes('man-1'));
+});


### PR DESCRIPTION
## Summary
- add `GameBoard` component with four player areas
- update `App` to use new `GameBoard`
- apply board layout styles
- add a unit test for `GameBoard`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fac8fd52c832a9ebf8aa013c8b303