### PR TITLE
Fix CLI main check for ESM

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,6 +2,8 @@ import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { Game } from '@mymahjong/core';
 import { renderHand, prompt } from './UI.js';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 export async function run(
   game: Game = new Game(1),
@@ -31,7 +33,9 @@ export async function run(
   rl.close();
 }
 
-if (typeof require !== 'undefined' && require.main === module) {
+const thisFile = fileURLToPath(import.meta.url);
+dirname(thisFile);
+if (process.argv[1] === thisFile) {
   run();
 }
 


### PR DESCRIPTION
## Summary
- switch cli entrypoint to use `import.meta.url` based main check

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm start -w cli` *(manual run, saw starting hand prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685fbc3a5d0c832ab39ca812101b9805