### PR TITLE
Remove unused React imports from components

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { GameBoard } from './components/GameBoard.js';
 import { useGame } from './hooks/useGame.js';
 

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
 

--- a/web/src/components/Hand.tsx
+++ b/web/src/components/Hand.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Tile } from '@mymahjong/core';
 
 export interface HandProps {


### PR DESCRIPTION
## Summary
- drop obsolete `React` imports in `web/src/App.tsx`
- clean up `React` imports from component files

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbe027990832aa76cb69ac418dd12