### PR TITLE
Enhance CLI output with discards

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ npm run build -w cli
 npm start -w cli
 ```
 
+### Running the Web Demo
+
+Start the Vite development server:
+
+```bash
+npm run dev -w web
+```
+
+Then open `http://localhost:5173` in your browser.
+
 
 ### Run Tests
 

--- a/cli/src/UI.ts
+++ b/cli/src/UI.ts
@@ -2,6 +2,11 @@ export function renderHand(hand: { toString(): string }[]): string {
   return hand.map((tile, i) => `[${i}] ${tile.toString()}`).join(' ');
 }
 
+export function renderDiscards(discards: { toString(): string }[]): string {
+  if (discards.length === 0) return '(none)';
+  return discards.map((tile) => tile.toString()).join(' ');
+}
+
 export async function prompt(rl: import('node:readline/promises').Interface, question: string): Promise<string> {
   return rl.question(question);
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,7 +1,7 @@
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { Game } from '@mymahjong/core';
-import { renderHand, prompt } from './UI.js';
+import { renderHand, renderDiscards, prompt } from './UI.js';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 
@@ -28,6 +28,8 @@ export async function run(
     console.log(`You discarded: ${discarded}`);
     console.log('Your hand:');
     console.log(renderHand(player.hand));
+    console.log('Your discards:');
+    console.log(renderDiscards(player.discards));
   }
   console.log('Wall exhausted, game over.');
   rl.close();

--- a/cli/test/UI.test.ts
+++ b/cli/test/UI.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { Tile } from '@mymahjong/core';
-import { renderHand } from '../src/UI.js';
+import { renderHand, renderDiscards } from '../src/UI.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -14,5 +14,16 @@ test('renderHand lists tiles with indexes', () => {
   const hand = ['man-1', 'pin-2', 'sou-3'].map(makeTile);
   const result = renderHand(hand);
   assert.strictEqual(result, '[0] man-1 [1] pin-2 [2] sou-3');
+});
+
+test('renderDiscards joins tiles', () => {
+  const discards = ['man-1', 'sou-9'].map(makeTile);
+  const result = renderDiscards(discards);
+  assert.strictEqual(result, 'man-1 sou-9');
+});
+
+test('renderDiscards handles empty list', () => {
+  const result = renderDiscards([]);
+  assert.strictEqual(result, '(none)');
 });
 

--- a/cli/test/run.test.ts
+++ b/cli/test/run.test.ts
@@ -23,3 +23,31 @@ test('run processes a single turn', async () => {
   await run(game, rl);
   assert.strictEqual(game.wall.count, 0);
 });
+
+test('run prints discards', async () => {
+  const game = {
+    wall: { count: 1 },
+    players: [{ hand: ['tile'], discards: [] }],
+    deal() {},
+    drawCurrent() { this.wall.count = 0; return 'drawn'; },
+    discardCurrent() { this.players[0].discards.push('discarded'); return 'discarded'; },
+  } as any;
+
+  const answers = ['', '0'];
+  const rl: any = {
+    question() { return Promise.resolve(answers.shift()); },
+    close() {},
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg?: unknown) => { logs.push(String(msg)); };
+  try {
+    await run(game, rl);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(logs.includes('Your discards:'));
+  assert.ok(logs.includes('discarded'));
+});


### PR DESCRIPTION
## Summary
- show player's discard pile each turn in the CLI
- add `renderDiscards` helper
- test CLI discard printing and helper output
- document how to run the web demo

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fcf1f1638832a8c01a1d4aa86ad5c