### PR TITLE
Add basic scoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ npm run dev -w web
 
 Then open `http://localhost:5173` in your browser.
 
+### Scoring
+
+After each discard the game now evaluates your hand for the simple `tanyao` yaku.
+When applicable, the CLI and web UI display the number of han and total points.
+
 
 ### Run Tests
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,6 @@
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
-import { Game } from '@mymahjong/core';
+import { Game, ScoreResult } from '@mymahjong/core';
 import { renderHand, renderDiscards, prompt } from './UI.js';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
@@ -28,6 +28,11 @@ export async function run(
     console.log(`You discarded: ${discarded}`);
     console.log('Your hand:');
     console.log(renderHand(player.hand));
+    const score: ScoreResult = game.calculateScore(0);
+    if (score.han > 0) {
+      console.log(`Possible yaku: ${score.yaku.join(', ')}`);
+      console.log(`Han: ${score.han} Fu: ${score.fu} -> ${score.points} points`);
+    }
     console.log('Your discards:');
     console.log(renderDiscards(player.discards));
   }

--- a/cli/test/run.test.ts
+++ b/cli/test/run.test.ts
@@ -12,6 +12,7 @@ test('run processes a single turn', async () => {
     drawCurrent() { this.wall.count = 0; return 'drawn'; },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     discardCurrent(index: number) { return 'discarded'; },
+    calculateScore() { return { han: 0, fu: 20, points: 0, yaku: [] }; },
   } as any;
 
   const answers = ['', '0'];
@@ -31,6 +32,7 @@ test('run prints discards', async () => {
     deal() {},
     drawCurrent() { this.wall.count = 0; return 'drawn'; },
     discardCurrent() { this.players[0].discards.push('discarded'); return 'discarded'; },
+    calculateScore() { return { han: 1, fu: 20, points: 20, yaku: ['tanyao'] }; },
   } as any;
 
   const answers = ['', '0'];

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -1,6 +1,7 @@
 import { Player } from './Player.js';
 import { Wall } from './Wall.js';
 import { Tile } from './Tile.js';
+import { calculateScore, ScoreResult } from './Score.js';
 
 export class Game {
   readonly wall: Wall;
@@ -33,5 +34,9 @@ export class Game {
     const tile = this.players[this.currentIndex].discard(index);
     this.currentIndex = (this.currentIndex + 1) % this.players.length;
     return tile;
+  }
+
+  calculateScore(playerIndex = this.currentIndex): ScoreResult {
+    return calculateScore(this.players[playerIndex].hand);
   }
 }

--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -1,0 +1,28 @@
+import { Tile } from './Tile.js';
+
+export interface ScoreResult {
+  yaku: string[];
+  han: number;
+  fu: number;
+  points: number;
+}
+
+export function detectTanyao(hand: Tile[]): boolean {
+  return hand.every(t => {
+    if (t.suit === 'wind' || t.suit === 'dragon') return false;
+    const v = t.value as number;
+    return v >= 2 && v <= 8;
+  });
+}
+
+export function calculateScore(hand: Tile[]): ScoreResult {
+  const yaku: string[] = [];
+  let han = 0;
+  if (detectTanyao(hand)) {
+    yaku.push('tanyao');
+    han += 1;
+  }
+  const fu = 20;
+  const points = han * fu;
+  return { yaku, han, fu, points };
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './Tile.js';
 export * from './Wall.js';
 export * from './Player.js';
 export * from './Game.js';
+export * from './Score.js';
 
 export function sum(a: number, b: number): number {
   return a + b;

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Tile, calculateScore } from '../src/index.js';
+
+test('tanyao detection and scoring', () => {
+  const hand = Array.from({ length: 14 }, () => new Tile({ suit: 'man', value: 2 }));
+  const result = calculateScore(hand);
+  assert.deepStrictEqual(result, { yaku: ['tanyao'], han: 1, fu: 20, points: 20 });
+});
+
+test('hand with honors scores zero', () => {
+  const hand = [
+    new Tile({ suit: 'wind', value: 'east' }),
+    ...Array.from({ length: 13 }, () => new Tile({ suit: 'man', value: 2 })),
+  ];
+  const result = calculateScore(hand);
+  assert.strictEqual(result.han, 0);
+  assert.strictEqual(result.points, 0);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,12 +2,15 @@ import { GameBoard } from './components/GameBoard.js';
 import { useGame } from './hooks/useGame.js';
 
 export default function App(): JSX.Element {
-  const { hand, discards, wallCount, draw, discard } = useGame();
+  const { hand, discards, wallCount, draw, discard, score } = useGame();
   return (
     <div className="app">
       <h1>My Mahjong</h1>
       <p>Wall tiles left: {wallCount}</p>
       <button onClick={draw} disabled={wallCount === 0}>Draw</button>
+      {score.han > 0 && (
+        <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
+      )}
       <GameBoard currentHand={hand} onDiscard={discard} />
       <h2>Discards</h2>
       <ul className="discards">

--- a/web/src/hooks/useGame.ts
+++ b/web/src/hooks/useGame.ts
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Game, Tile } from '@mymahjong/core';
+import { Game, Tile, ScoreResult } from '@mymahjong/core';
 
 interface GameState {
   hand: Tile[];
   discards: Tile[];
   wallCount: number;
+  score: ScoreResult;
 }
 
 export function useGame(): GameState & {
@@ -21,6 +22,7 @@ export function useGame(): GameState & {
     hand: [...game.players[0].hand],
     discards: [...game.players[0].discards],
     wallCount: game.wall.count,
+    score: game.calculateScore(0),
   }));
 
   const sync = () => {
@@ -28,6 +30,7 @@ export function useGame(): GameState & {
       hand: [...game.players[0].hand],
       discards: [...game.players[0].discards],
       wallCount: game.wall.count,
+      score: game.calculateScore(0),
     });
   };
 

--- a/web/test/useGame.test.tsx
+++ b/web/test/useGame.test.tsx
@@ -7,6 +7,7 @@ import { useGame } from '../src/hooks/useGame.js';
 interface GameHandle {
   hand: ReturnType<typeof useGame>['hand'];
   discards: ReturnType<typeof useGame>['discards'];
+  score: ReturnType<typeof useGame>['score'];
   draw: () => unknown;
   discard: (index: number) => unknown;
 }
@@ -25,12 +26,14 @@ test('draw and discard update state', () => {
   assert.ok(ref.current);
   const initialHand = ref.current!.hand.length;
   const initialDiscards = ref.current!.discards.length;
+  const initialPoints = ref.current!.score.points;
 
   act(() => {
     ref.current!.draw();
   });
   // after draw, hand should increase
   assert.strictEqual(ref.current!.hand.length, initialHand + 1);
+  assert.ok(ref.current!.score.points >= initialPoints);
 
   act(() => {
     ref.current!.discard(ref.current!.hand.length - 1);


### PR DESCRIPTION
## Summary
- implement a tiny scoring system in `core`
- show possible yaku and score in the CLI and web UI
- expose score via the `useGame` hook
- document scoring in the README
- cover scoring logic with tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fd7b74cfc832aa2a2be3562f54944