### PR TITLE
Add chiitoitsu yaku scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Then open `http://localhost:5173` in your browser.
 
 ### Scoring
 
-After each discard the game now evaluates your hand for the simple `tanyao` yaku.
-When applicable, the CLI and web UI display the number of han and total points.
+After each discard the game now evaluates your hand for the simple `tanyao` yaku
+and also checks for `chiitoitsu` (seven pairs).
+When applicable, the CLI and web UI display the possible yaku, the number of han
+and total points.
 
 
 ### Run Tests

--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -15,12 +15,29 @@ export function detectTanyao(hand: Tile[]): boolean {
   });
 }
 
+export function detectSevenPairs(hand: Tile[]): boolean {
+  if (hand.length !== 14) return false;
+  const counts = new Map<string, number>();
+  for (const tile of hand) {
+    const key = tile.toString();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return (
+    counts.size === 7 &&
+    [...counts.values()].every((count) => count === 2)
+  );
+}
+
 export function calculateScore(hand: Tile[]): ScoreResult {
   const yaku: string[] = [];
   let han = 0;
   if (detectTanyao(hand)) {
     yaku.push('tanyao');
     han += 1;
+  }
+  if (detectSevenPairs(hand)) {
+    yaku.push('chiitoitsu');
+    han += 2;
   }
   const fu = 20;
   const points = han * fu;

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -8,6 +8,18 @@ test('tanyao detection and scoring', () => {
   assert.deepStrictEqual(result, { yaku: ['tanyao'], han: 1, fu: 20, points: 20 });
 });
 
+test('chiitoitsu detection and scoring', () => {
+  const pairs = [1,2,3,4,5,6,7];
+  const hand = pairs.flatMap(v => [
+    new Tile({ suit: 'man', value: v as 1|2|3|4|5|6|7|8|9 }),
+    new Tile({ suit: 'man', value: v as 1|2|3|4|5|6|7|8|9 }),
+  ]);
+  const result = calculateScore(hand);
+  assert.ok(result.yaku.includes('chiitoitsu'));
+  assert.strictEqual(result.han, 2);
+  assert.strictEqual(result.points, 40);
+});
+
 test('hand with honors scores zero', () => {
   const hand = [
     new Tile({ suit: 'wind', value: 'east' }),


### PR DESCRIPTION
## Summary
- extend score evaluator with chiitoitsu (seven pairs)
- document the new yaku in the README
- test chiitoitsu detection in core tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686049df2978832aaf7bbec04ca2c93e