### PR TITLE
Implement yakuhai scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Then open `http://localhost:5173` in your browser.
 ### Scoring
 
 After each discard the game now evaluates your hand for the simple `tanyao` yaku
-and also checks for `chiitoitsu` (seven pairs).
+and checks for `chiitoitsu` (seven pairs). The scorer also detects `yakuhai`
+triplets of winds or dragons.
 When applicable, the CLI and web UI display the possible yaku, the number of han
 and total points.
 

--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -28,6 +28,31 @@ export function detectSevenPairs(hand: Tile[]): boolean {
   );
 }
 
+/**
+ * Detects triplets of honor tiles (winds or dragons).
+ * Returns an array of yakuhai names for each qualifying triplet.
+ */
+export function detectYakuhai(hand: Tile[]): string[] {
+  const counts = new Map<string, { tile: Tile; count: number }>();
+  for (const tile of hand) {
+    const key = tile.toString();
+    const entry = counts.get(key);
+    if (entry) {
+      entry.count += 1;
+    } else {
+      counts.set(key, { tile, count: 1 });
+    }
+  }
+
+  const result: string[] = [];
+  for (const { tile, count } of counts.values()) {
+    if (count >= 3 && (tile.suit === 'wind' || tile.suit === 'dragon')) {
+      result.push(`yakuhai-${tile.value}`);
+    }
+  }
+  return result;
+}
+
 export function calculateScore(hand: Tile[]): ScoreResult {
   const yaku: string[] = [];
   let han = 0;
@@ -38,6 +63,11 @@ export function calculateScore(hand: Tile[]): ScoreResult {
   if (detectSevenPairs(hand)) {
     yaku.push('chiitoitsu');
     han += 2;
+  }
+  const yakuhai = detectYakuhai(hand);
+  if (yakuhai.length > 0) {
+    yaku.push(...yakuhai);
+    han += yakuhai.length;
   }
   const fu = 20;
   const points = han * fu;

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -29,3 +29,36 @@ test('hand with honors scores zero', () => {
   assert.strictEqual(result.han, 0);
   assert.strictEqual(result.points, 0);
 });
+
+test('yakuhai detection for dragon triplet', () => {
+  const hand = [
+    new Tile({ suit: 'dragon', value: 'white' }),
+    new Tile({ suit: 'dragon', value: 'white' }),
+    new Tile({ suit: 'dragon', value: 'white' }),
+    ...Array.from({ length: 11 }, () => new Tile({ suit: 'man', value: 2 })),
+  ];
+  const result = calculateScore(hand);
+  assert.ok(result.yaku.includes('yakuhai-white'));
+  assert.strictEqual(result.han, 1);
+  assert.strictEqual(result.points, 20);
+});
+
+test('multiple yakuhai triplets each add han', () => {
+  const hand = [
+    // dragon triplet
+    new Tile({ suit: 'dragon', value: 'green' }),
+    new Tile({ suit: 'dragon', value: 'green' }),
+    new Tile({ suit: 'dragon', value: 'green' }),
+    // wind triplet
+    new Tile({ suit: 'wind', value: 'east' }),
+    new Tile({ suit: 'wind', value: 'east' }),
+    new Tile({ suit: 'wind', value: 'east' }),
+    // rest of hand
+    ...Array.from({ length: 8 }, () => new Tile({ suit: 'man', value: 2 })),
+  ];
+  const result = calculateScore(hand);
+  assert.ok(result.yaku.includes('yakuhai-green'));
+  assert.ok(result.yaku.includes('yakuhai-east'));
+  assert.strictEqual(result.han, 2);
+  assert.strictEqual(result.points, 40);
+});


### PR DESCRIPTION
## Summary
- add yakuhai detection in Score module
- score yakuhai triplets
- test yakuhai scoring logic
- document yakuhai yaku in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68604d36836c832a9a83b8232e86b773