### PR TITLE
Fix Pages deploy and test determinism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,18 +54,14 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
-      - name: Remove symlinks before deployment
-        run: find web/dist -type l -delete
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: github-pages
           path: web/dist
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
-          artifact_name: github-pages
   auto-merge:
     runs-on: ubuntu-latest
     needs: [build, test]

--- a/web/src/hooks/useGame.ts
+++ b/web/src/hooks/useGame.ts
@@ -8,40 +8,42 @@ interface GameState {
   score: ScoreResult;
 }
 
-export function useGame(): GameState & {
+export function useGame(game?: Game): GameState & {
   draw: () => Tile;
   discard: (index: number) => Tile;
 } {
-  const [game] = useState(() => {
-    const g = new Game(1);
-    g.deal();
+  const [gameInstance] = useState(() => {
+    const g = game ?? new Game(1);
+    if (g.players[0].hand.length === 0) {
+      g.deal();
+    }
     return g;
   });
 
   const [state, setState] = useState<GameState>(() => ({
-    hand: [...game.players[0].hand],
-    discards: [...game.players[0].discards],
-    wallCount: game.wall.count,
-    score: game.calculateScore(0),
+    hand: [...gameInstance.players[0].hand],
+    discards: [...gameInstance.players[0].discards],
+    wallCount: gameInstance.wall.count,
+    score: gameInstance.calculateScore(0),
   }));
 
   const sync = () => {
     setState({
-      hand: [...game.players[0].hand],
-      discards: [...game.players[0].discards],
-      wallCount: game.wall.count,
-      score: game.calculateScore(0),
+      hand: [...gameInstance.players[0].hand],
+      discards: [...gameInstance.players[0].discards],
+      wallCount: gameInstance.wall.count,
+      score: gameInstance.calculateScore(0),
     });
   };
 
   const draw = () => {
-    const tile = game.drawCurrent();
+    const tile = gameInstance.drawCurrent();
     sync();
     return tile;
   };
 
   const discard = (index: number) => {
-    const tile = game.discardCurrent(index);
+    const tile = gameInstance.discardCurrent(index);
     sync();
     return tile;
   };

--- a/web/test/useGame.test.tsx
+++ b/web/test/useGame.test.tsx
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import React, { forwardRef, useImperativeHandle } from 'react';
 import { create, act } from 'react-test-renderer';
 import { useGame } from '../src/hooks/useGame.js';
+import { Game, Wall, Tile } from '@mymahjong/core';
 
 interface GameHandle {
   hand: ReturnType<typeof useGame>['hand'];
@@ -12,8 +13,16 @@ interface GameHandle {
   discard: (index: number) => unknown;
 }
 
+function createFixedGame(): Game {
+  const tiles = Array.from({ length: 20 }, () => new Tile({ suit: 'man', value: 2 }));
+  const wall = new Wall(tiles);
+  const g = new Game(1, wall);
+  g.deal();
+  return g;
+}
+
 const GameHarness = forwardRef<GameHandle>((_props, ref) => {
-  const state = useGame();
+  const state = useGame(createFixedGame());
   useImperativeHandle(ref, () => state);
   return null;
 });


### PR DESCRIPTION
## Summary
- allow providing a custom `Game` instance to `useGame`
- update `useGame` tests to use a deterministic wall
- switch CI to `upload-pages-artifact` for Pages deploy

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860a25ea408832ab984a6078fdd22a3