### PR TITLE
Improve board layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ npm run dev -w web
 
 Then open `http://localhost:5173` in your browser.
 
+The board layout places each player's area around the center. At this stage only
+the bottom player shows the actual hand and discard pile.
+
 ### Custom Game Setup
 
 The `useGame` hook accepts an optional `Game` instance. This is handy for tests

--- a/web/README.md
+++ b/web/README.md
@@ -2,4 +2,4 @@
 
 A minimal React front end that consumes the core Mahjong logic. To develop locally run `npm run dev -w web` and open `http://localhost:5173`.
 
-The web package is intentionally simple and serves as a reference for using the core logic in the browser.
+The web package is intentionally simple and serves as a reference for using the core logic in the browser. The game board lays out each player's area around a central stack. Currently only the bottom player's hand is interactive.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,11 +11,7 @@ export default function App(): JSX.Element {
       {score.han > 0 && (
         <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
       )}
-      <GameBoard currentHand={hand} onDiscard={discard} />
-      <h2>Discards</h2>
-      <ul className="discards">
-        {discards.map((t, i) => <li key={i}>{t.toString()}</li>)}
-      </ul>
+      <GameBoard currentHand={hand} currentDiscards={discards} onDiscard={discard} />
     </div>
   );
 }

--- a/web/src/components/Discards.tsx
+++ b/web/src/components/Discards.tsx
@@ -1,0 +1,15 @@
+import type { Tile } from '@mymahjong/core';
+
+export interface DiscardsProps {
+  tiles: Tile[];
+}
+
+export function Discards({ tiles }: DiscardsProps): JSX.Element {
+  return (
+    <ul className="discards">
+      {tiles.map((t, i) => (
+        <li key={i}>{t.toString()}</li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -1,20 +1,32 @@
 import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
+import { Discards } from './Discards.js';
 
 export interface GameBoardProps {
   currentHand: Tile[];
+  currentDiscards: Tile[];
   onDiscard: (index: number) => void;
 }
 
-export function GameBoard({ currentHand, onDiscard }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, currentDiscards, onDiscard }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
-      <div className="player-area top">Player 2 Hand</div>
-      <div className="player-area left">Player 3 Hand</div>
+      <div className="player-area top">
+        <p>Player 2</p>
+        <Discards tiles={[]} />
+      </div>
+      <div className="player-area left">
+        <p>Player 3</p>
+        <Discards tiles={[]} />
+      </div>
       <div className="center">Center</div>
-      <div className="player-area right">Player 4 Hand</div>
+      <div className="player-area right">
+        <p>Player 4</p>
+        <Discards tiles={[]} />
+      </div>
       <div className="player-area bottom">
         <Hand tiles={currentHand} onDiscard={onDiscard} />
+        <Discards tiles={currentDiscards} />
       </div>
     </div>
   );

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,3 +1,5 @@
 // Re-export useful React hooks or components if needed in other packages.
 export { useGame } from './hooks/useGame.js';
 export { Hand } from './components/Hand.js';
+export { GameBoard } from './components/GameBoard.js';
+export { Discards } from './components/Discards.js';

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -9,6 +9,13 @@ body {
   padding: 0;
 }
 
+.discards {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 .hand li,
 .discards li {
   margin-bottom: 0.25rem;

--- a/web/test/Discards.test.tsx
+++ b/web/test/Discards.test.tsx
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Discards } from '../src/components/Discards.js';
+import { Tile } from '@mymahjong/core';
+
+test('Discards renders tiles', () => {
+  const tiles = [new Tile({ suit: 'sou', value: 3 })];
+  const html = renderToStaticMarkup(
+    <Discards tiles={tiles} />
+  );
+  assert.ok(html.includes('sou-3'));
+});

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -5,12 +5,14 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { GameBoard } from '../src/components/GameBoard.js';
 import { Tile } from '@mymahjong/core';
 
-test('GameBoard renders four player sections', () => {
+test('GameBoard renders hand and discards', () => {
   const tiles = [new Tile({ suit: 'man', value: 1 })];
+  const discards = [new Tile({ suit: 'pin', value: 2 })];
   const html = renderToStaticMarkup(
-    <GameBoard currentHand={tiles} onDiscard={() => {}} />
+    <GameBoard currentHand={tiles} currentDiscards={discards} onDiscard={() => {}} />
   );
   const count = (html.match(/class="player-area/g) || []).length;
   assert.equal(count, 4);
   assert.ok(html.includes('man-1'));
+  assert.ok(html.includes('pin-2'));
 });


### PR DESCRIPTION
## Summary
- show player's hand and discards on the board
- add Discards component
- adjust styles for discard piles
- update docs about the current layout
- export GameBoard and Discards for reuse
- update tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860adbb4608832aa91b95e19f1a02fa