### PR TITLE
Add basic winning hand detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ status and a suggested roadmap for extending the rules.
 
 - Generation of all 136 tiles and shuffled wall
 - Dealing, drawing and discarding tiles
+- Basic win detection for standard hands
 - Scoring for:
   - `tanyao` (all simples)
   - `chiitoitsu` (seven pairs)

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -1,7 +1,7 @@
 import { Player } from './Player.js';
 import { Wall } from './Wall.js';
 import { Tile } from './Tile.js';
-import { calculateScore, ScoreResult } from './Score.js';
+import { calculateScore, ScoreResult, isWinningHand } from './Score.js';
 
 export class Game {
   readonly wall: Wall;
@@ -38,5 +38,9 @@ export class Game {
 
   calculateScore(playerIndex = this.currentIndex): ScoreResult {
     return calculateScore(this.players[playerIndex].hand);
+  }
+
+  isWinningHand(playerIndex = this.currentIndex): boolean {
+    return isWinningHand(this.players[playerIndex].hand);
   }
 }

--- a/core/test/win.test.ts
+++ b/core/test/win.test.ts
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Tile, Game, Wall, isWinningHand } from '../src/index.js';
+
+function standardWinningHand(): Tile[] {
+  return [
+    // sequences
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'man', value: 8 }),
+    new Tile({ suit: 'man', value: 9 }),
+    // triplet
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    // pair
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 })
+  ];
+}
+
+test('detects standard winning hand', () => {
+  const hand = standardWinningHand();
+  assert.ok(isWinningHand(hand));
+});
+
+test('game reports winning hand', () => {
+  const hand = standardWinningHand();
+  const game = new Game(1, new Wall([]));
+  game.players[0].hand.push(...hand);
+  assert.ok(game.isWinningHand(0));
+});
+
+test('non-winning hand returns false', () => {
+  const hand = [
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'man', value: 8 }),
+    new Tile({ suit: 'man', value: 9 }),
+    new Tile({ suit: 'pin', value: 1 })
+  ];
+  assert.ok(!isWinningHand(hand));
+});


### PR DESCRIPTION
## Summary
- implement `isWinningHand` in core score logic
- expose Game.isWinningHand for player checks
- document basic win detection capability
- add tests covering win detection

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860bb6373e4832ab873da60837c5183