### PR TITLE
Add pon and ron support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ status and a suggested roadmap for extending the rules.
 - Generation of all 136 tiles and shuffled wall
 - Dealing, drawing and discarding tiles
 - Basic win detection for standard hands
+- Win by ron (claiming another player's discard)
+- Ability to call pon (triplet melds)
 - Scoring for:
   - `tanyao` (all simples)
   - `chiitoitsu` (seven pairs)
@@ -112,14 +114,14 @@ status and a suggested roadmap for extending the rules.
 
 **Not Yet Implemented**
 
-- Meld calls such as chi, pon, kan and winning declarations
+- Meld calls such as chi and kan
 - Round and seat wind tracking or dealer rotation
 - Additional yaku and detailed fu/han scoring
 - Riichi, dora indicators and other advanced rules
 
 **Recommended Next Steps**
 
-1. Add win detection and calls (chi/pon/kan/ron)
+1. Add remaining calls (chi/kan) and polish ron handling
 2. Expand the scoring system with more yaku and fu calculations
 3. Introduce round progression with seat winds and dealer rotation
 4. Track riichi state and dora indicators to enable more advanced rules

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -36,6 +36,26 @@ export class Game {
     return tile;
   }
 
+  callPon(playerIndex: number, fromIndex: number): void {
+    const from = this.players[fromIndex];
+    const tile = from.discards.pop();
+    if (!tile) throw new Error('No discard to claim');
+    const player = this.players[playerIndex];
+    if (!player.canPon(tile)) {
+      from.discards.push(tile);
+      throw new Error('Player cannot pon this tile');
+    }
+    player.pon(tile);
+    this.currentIndex = playerIndex;
+  }
+
+  declareRon(playerIndex: number, fromIndex: number): boolean {
+    const tile = this.players[fromIndex].discards.at(-1);
+    if (!tile) throw new Error('No discard to claim');
+    const hand = [...this.players[playerIndex].hand, tile];
+    return isWinningHand(hand);
+  }
+
   calculateScore(playerIndex = this.currentIndex): ScoreResult {
     return calculateScore(this.players[playerIndex].hand);
   }

--- a/core/src/Player.ts
+++ b/core/src/Player.ts
@@ -3,6 +3,11 @@ import { Tile } from './Tile.js';
 export class Player {
   readonly hand: Tile[] = [];
   readonly discards: Tile[] = [];
+  /**
+   * Sets of tiles the player has called from other players.
+   * Each meld is an array of tiles in the order they were claimed.
+   */
+  readonly melds: Tile[][] = [];
 
   draw(tile: Tile): void {
     this.hand.push(tile);
@@ -15,5 +20,25 @@ export class Player {
     const [tile] = this.hand.splice(index, 1);
     this.discards.push(tile);
     return tile;
+  }
+
+  canPon(tile: Tile): boolean {
+    return this.hand.filter(t => t.toString() === tile.toString()).length >= 2;
+  }
+
+  pon(tile: Tile): void {
+    if (!this.canPon(tile)) {
+      throw new Error('Cannot pon: tile not found twice in hand');
+    }
+    const meld: Tile[] = [tile];
+    let removed = 0;
+    for (let i = this.hand.length - 1; i >= 0 && removed < 2; i--) {
+      if (this.hand[i].toString() === tile.toString()) {
+        meld.push(this.hand.splice(i, 1)[0]);
+        removed++;
+      }
+    }
+    if (removed !== 2) throw new Error('Unexpected tile count when pon');
+    this.melds.push(meld);
   }
 }

--- a/core/test/pon.test.ts
+++ b/core/test/pon.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Game, Wall, Tile } from '../src/index.js';
+
+// Player 1 discards a tile, Player 2 calls pon on it
+
+test('player can call pon on a discard', () => {
+  const wall = new Wall([]);
+  const game = new Game(2, wall);
+  const tile = new Tile({ suit: 'man', value: 3 });
+  game.players[0].hand.push(tile);
+  game.players[1].hand.push(new Tile({ suit: 'man', value: 3 }));
+  game.players[1].hand.push(new Tile({ suit: 'man', value: 3 }));
+
+  game.players[0].discard(0);
+  game.callPon(1, 0);
+
+  assert.strictEqual(game.players[1].melds.length, 1);
+  assert.strictEqual(game.players[1].hand.length, 0);
+  assert.strictEqual(game.players[1].melds[0].length, 3);
+  // turn should pass to player 2
+  assert.strictEqual(game['currentIndex'], 1);
+});

--- a/core/test/ron.test.ts
+++ b/core/test/ron.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Game, Wall, Tile } from '../src/index.js';
+
+function winningTiles(): Tile[] {
+  // simple hand: 1-2-3 man, 4-5-6 man, 7-8-9 man, triplet of pin1, pair of pin2
+  return [
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'man', value: 8 }),
+    new Tile({ suit: 'man', value: 9 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 2 }),
+  ];
+}
+
+test('declareRon detects win with discard', () => {
+  const wall = new Wall([]);
+  const game = new Game(2, wall);
+  game.players[1].hand.push(...winningTiles());
+  const winningTile = new Tile({ suit: 'pin', value: 2 });
+  game.players[0].hand.push(winningTile);
+  game.players[0].discard(0);
+  assert.ok(game.declareRon(1, 0));
+});


### PR DESCRIPTION
## Summary
- allow players to store open melds
- implement `callPon` and `declareRon` in the game engine
- document new functionality in README
- cover new methods with tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860bd7df998832aab245bd71a1b21ed