### PR TITLE
Add board layout doc and melds component

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ npm run dev -w web
 Then open `http://localhost:5173` in your browser.
 
 The board layout places each player's area around the center. At this stage only
-the bottom player shows the actual hand and discard pile.
+the bottom player shows the actual hand and discard pile. Further layout details
+are described in [docs/board-layout.md](docs/board-layout.md).
 
 ### Custom Game Setup
 

--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -1,0 +1,16 @@
+# Board Layout Details
+
+This document outlines how the Mahjong board is arranged in the web UI. The design follows the conventions of a physical table while making small adjustments for digital screens.
+
+## Orientation
+
+- The local player's hand is shown along the bottom edge.
+- Each player's discard pile (河) sits directly in front of their hand. For the bottom player this means discards appear above the hand.
+- Melded tiles (calls such as chi or pon) align to the right of that player's discard pile. This keeps the main hand centered while revealing open sets.
+- Opponents occupy the top, left and right edges, surrounding a central area used for wall tiles or indicators.
+
+## Digital Considerations
+
+To conserve screen space the interface avoids lengthy text and uses small buttons or icons. The layout reserves fixed regions for each player so elements do not jump as the game progresses. Media queries can stack the side players vertically when the viewport becomes narrow, ensuring controls remain accessible on phones.
+
+These guidelines provide a baseline for implementing responsive components in the `web` package.

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -1,14 +1,16 @@
 import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
 import { Discards } from './Discards.js';
+import { Melds } from './Melds.js';
 
 export interface GameBoardProps {
   currentHand: Tile[];
   currentDiscards: Tile[];
+  currentMelds?: Tile[][];
   onDiscard: (index: number) => void;
 }
 
-export function GameBoard({ currentHand, currentDiscards, onDiscard }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, currentDiscards, currentMelds = [], onDiscard }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
       <div className="player-area top">
@@ -25,8 +27,11 @@ export function GameBoard({ currentHand, currentDiscards, onDiscard }: GameBoard
         <Discards tiles={[]} />
       </div>
       <div className="player-area bottom">
+        <div className="meld-discard">
+          <Melds melds={currentMelds} />
+          <Discards tiles={currentDiscards} />
+        </div>
         <Hand tiles={currentHand} onDiscard={onDiscard} />
-        <Discards tiles={currentDiscards} />
       </div>
     </div>
   );

--- a/web/src/components/Melds.tsx
+++ b/web/src/components/Melds.tsx
@@ -1,0 +1,15 @@
+import type { Tile } from '@mymahjong/core';
+
+export interface MeldsProps {
+  melds: Tile[][];
+}
+
+export function Melds({ melds }: MeldsProps): JSX.Element {
+  return (
+    <ul className="melds">
+      {melds.map((set, i) => (
+        <li key={i}>{set.map(t => t.toString()).join(' ')}</li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -3,3 +3,4 @@ export { useGame } from './hooks/useGame.js';
 export { Hand } from './components/Hand.js';
 export { GameBoard } from './components/GameBoard.js';
 export { Discards } from './components/Discards.js';
+export { Melds } from './components/Melds.js';

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -60,3 +60,17 @@ button {
   grid-area: center;
   text-align: center;
 }
+
+.meld-discard {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.melds {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 0.25rem;
+}

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -5,14 +5,16 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { GameBoard } from '../src/components/GameBoard.js';
 import { Tile } from '@mymahjong/core';
 
-test('GameBoard renders hand and discards', () => {
+test('GameBoard renders hand, discards and melds', () => {
   const tiles = [new Tile({ suit: 'man', value: 1 })];
   const discards = [new Tile({ suit: 'pin', value: 2 })];
+  const melds = [[new Tile({ suit: 'sou', value: 3 })]];
   const html = renderToStaticMarkup(
-    <GameBoard currentHand={tiles} currentDiscards={discards} onDiscard={() => {}} />
+    <GameBoard currentHand={tiles} currentDiscards={discards} currentMelds={melds} onDiscard={() => {}} />
   );
   const count = (html.match(/class="player-area/g) || []).length;
   assert.equal(count, 4);
   assert.ok(html.includes('man-1'));
   assert.ok(html.includes('pin-2'));
+  assert.ok(html.includes('sou-3'));
 });

--- a/web/test/Melds.test.tsx
+++ b/web/test/Melds.test.tsx
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Melds } from '../src/components/Melds.js';
+import { Tile } from '@mymahjong/core';
+
+test('Melds renders sets of tiles', () => {
+  const melds = [[
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+  ]];
+  const html = renderToStaticMarkup(<Melds melds={melds} />);
+  assert.ok(html.includes('man-1'));
+  assert.ok(html.includes('man-2'));
+  assert.ok(html.includes('man-3'));
+});


### PR DESCRIPTION
## Summary
- document standard board layout in docs/board-layout.md
- reference the new document in README
- add `Melds` component and update `GameBoard` to display melds
- tweak CSS for meld area
- add corresponding tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860bd05bfd0832a93d7a3cdecdf1763