### PR TITLE
Add chi and kan calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,25 +106,23 @@ status and a suggested roadmap for extending the rules.
 - Dealing, drawing and discarding tiles
 - Basic win detection for standard hands
 - Win by ron (claiming another player's discard)
-- Ability to call pon (triplet melds)
+- Ability to call pon, chi and kan (melds)
 - Scoring for:
   - `tanyao` (all simples)
   - `chiitoitsu` (seven pairs)
   - `yakuhai` triplets of winds or dragons
 
-**Not Yet Implemented**
+-**Not Yet Implemented**
 
-- Meld calls such as chi and kan
 - Round and seat wind tracking or dealer rotation
 - Additional yaku and detailed fu/han scoring
 - Riichi, dora indicators and other advanced rules
 
 **Recommended Next Steps**
 
-1. Add remaining calls (chi/kan) and polish ron handling
-2. Expand the scoring system with more yaku and fu calculations
-3. Introduce round progression with seat winds and dealer rotation
-4. Track riichi state and dora indicators to enable more advanced rules
+1. Expand the scoring system with more yaku and fu calculations
+2. Introduce round progression with seat winds and dealer rotation
+3. Track riichi state and dora indicators to enable more advanced rules
 
 
 ### Run Tests

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -49,11 +49,44 @@ export class Game {
     this.currentIndex = playerIndex;
   }
 
+  callChi(playerIndex: number, fromIndex: number): void {
+    const from = this.players[fromIndex];
+    const tile = from.discards.pop();
+    if (!tile) throw new Error('No discard to claim');
+    const player = this.players[playerIndex];
+    if (!player.canChi(tile)) {
+      from.discards.push(tile);
+      throw new Error('Player cannot chi this tile');
+    }
+    player.chi(tile);
+    this.currentIndex = playerIndex;
+  }
+
+  callKan(playerIndex: number, fromIndex: number): void {
+    const from = this.players[fromIndex];
+    const tile = from.discards.pop();
+    if (!tile) throw new Error('No discard to claim');
+    const player = this.players[playerIndex];
+    if (!player.canKan(tile)) {
+      from.discards.push(tile);
+      throw new Error('Player cannot kan this tile');
+    }
+    player.kan(tile);
+    this.currentIndex = playerIndex;
+  }
+
   declareRon(playerIndex: number, fromIndex: number): boolean {
-    const tile = this.players[fromIndex].discards.at(-1);
+    const from = this.players[fromIndex];
+    const tile = from.discards.at(-1);
     if (!tile) throw new Error('No discard to claim');
     const hand = [...this.players[playerIndex].hand, tile];
-    return isWinningHand(hand);
+    if (isWinningHand(hand)) {
+      from.discards.pop();
+      this.players[playerIndex].hand.push(tile);
+      this.currentIndex = playerIndex;
+      return true;
+    }
+    return false;
   }
 
   calculateScore(playerIndex = this.currentIndex): ScoreResult {

--- a/core/src/Player.ts
+++ b/core/src/Player.ts
@@ -41,4 +41,75 @@ export class Player {
     if (removed !== 2) throw new Error('Unexpected tile count when pon');
     this.melds.push(meld);
   }
+
+  canChi(tile: Tile): boolean {
+    if (tile.suit === 'wind' || tile.suit === 'dragon') return false;
+    const counts = new Map<number, number>();
+    for (const t of this.hand) {
+      if (t.suit === tile.suit) {
+        const v = t.value as number;
+        counts.set(v, (counts.get(v) ?? 0) + 1);
+      }
+    }
+    const v = tile.value as number;
+    const sequences: [number, number][] = [
+      [v - 2, v - 1],
+      [v - 1, v + 1],
+      [v + 1, v + 2],
+    ];
+    for (const [a, b] of sequences) {
+      if (a >= 1 && b <= 9 && (counts.get(a) ?? 0) > 0 && (counts.get(b) ?? 0) > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  chi(tile: Tile): void {
+    if (!this.canChi(tile)) {
+      throw new Error('Cannot chi: tiles not found in hand');
+    }
+    const suit = tile.suit;
+    const v = tile.value as number;
+    const sequences: [number, number][] = [
+      [v - 2, v - 1],
+      [v - 1, v + 1],
+      [v + 1, v + 2],
+    ];
+    for (const [a, b] of sequences) {
+      if (a < 1 || b > 9) continue;
+      const indexA = this.hand.findIndex(t => t.suit === suit && t.value === a);
+      if (indexA === -1) continue;
+      const indexB = this.hand.findIndex((t, idx) => t.suit === suit && t.value === b && idx !== indexA);
+      if (indexB === -1) continue;
+      const first = Math.max(indexA, indexB);
+      const second = Math.min(indexA, indexB);
+      const tileA = this.hand.splice(first, 1)[0];
+      const tileB = this.hand.splice(second, 1)[0];
+      const meld = [tileA, tile, tileB].sort((x, y) => (x.value as number) - (y.value as number));
+      this.melds.push(meld);
+      return;
+    }
+    throw new Error('Cannot chi: sequence not found');
+  }
+
+  canKan(tile: Tile): boolean {
+    return this.hand.filter(t => t.toString() === tile.toString()).length >= 3;
+  }
+
+  kan(tile: Tile): void {
+    if (!this.canKan(tile)) {
+      throw new Error('Cannot kan: tile not found three times in hand');
+    }
+    const meld: Tile[] = [tile];
+    let removed = 0;
+    for (let i = this.hand.length - 1; i >= 0 && removed < 3; i--) {
+      if (this.hand[i].toString() === tile.toString()) {
+        meld.push(this.hand.splice(i, 1)[0]);
+        removed++;
+      }
+    }
+    if (removed !== 3) throw new Error('Unexpected tile count when kan');
+    this.melds.push(meld);
+  }
 }

--- a/core/test/chi.test.ts
+++ b/core/test/chi.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Game, Wall, Tile } from '../src/index.js';
+
+test('player can call chi on a discard', () => {
+  const wall = new Wall([]);
+  const game = new Game(2, wall);
+  game.players[1].hand.push(
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 3 })
+  );
+  const tile = new Tile({ suit: 'man', value: 2 });
+  game.players[0].hand.push(tile);
+  game.players[0].discard(0);
+  game.callChi(1, 0);
+  assert.strictEqual(game.players[1].melds.length, 1);
+  assert.strictEqual(game.players[1].hand.length, 0);
+  assert.deepStrictEqual(game.players[1].melds[0].map(t => t.value), [1,2,3]);
+  assert.strictEqual(game['currentIndex'], 1);
+});

--- a/core/test/kan.test.ts
+++ b/core/test/kan.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Game, Wall, Tile } from '../src/index.js';
+
+test('player can call kan on a discard', () => {
+  const wall = new Wall([]);
+  const game = new Game(2, wall);
+  game.players[1].hand.push(
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 5 })
+  );
+  const tile = new Tile({ suit: 'man', value: 5 });
+  game.players[0].hand.push(tile);
+  game.players[0].discard(0);
+  game.callKan(1, 0);
+  assert.strictEqual(game.players[1].melds.length, 1);
+  assert.strictEqual(game.players[1].hand.length, 0);
+  assert.strictEqual(game.players[1].melds[0].length, 4);
+  assert.strictEqual(game['currentIndex'], 1);
+});

--- a/core/test/ron.test.ts
+++ b/core/test/ron.test.ts
@@ -29,4 +29,6 @@ test('declareRon detects win with discard', () => {
   game.players[0].hand.push(winningTile);
   game.players[0].discard(0);
   assert.ok(game.declareRon(1, 0));
+  assert.strictEqual(game.players[0].discards.length, 0);
+  assert.strictEqual(game.players[1].hand.length, 14);
 });


### PR DESCRIPTION
## Summary
- extend Player with chi and kan abilities
- add Game helpers for chi/kan and improve ron handling
- update rule coverage in README
- test chi/kan calls and enhanced ron logic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860bf5d8abc832ab548877ce48f1810