### PR TITLE
Implement hand analysis utility

### DIFF
--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -1,5 +1,15 @@
 import { Tile } from './Tile.js';
 
+export interface Meld {
+  type: 'sequence' | 'triplet';
+  tiles: Tile[];
+}
+
+export interface HandAnalysis {
+  pair: Tile[];
+  melds: Meld[];
+}
+
 export interface ScoreResult {
   yaku: string[];
   han: number;
@@ -74,7 +84,30 @@ export function calculateScore(hand: Tile[]): ScoreResult {
   return { yaku, han, fu, points };
 }
 
-function canFormSets(counts: Map<string, number>, pairUsed: boolean): boolean {
+
+export function isWinningHand(hand: Tile[]): boolean {
+  if (detectSevenPairs(hand)) return true;
+  return analyzeHand(hand) !== null;
+}
+
+export function analyzeHand(hand: Tile[]): HandAnalysis | null {
+  if (hand.length !== 14) return null;
+  const counts = new Map<string, number>();
+  const samples = new Map<string, Tile>();
+  for (const tile of hand) {
+    const key = tile.toString();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (!samples.has(key)) samples.set(key, tile);
+  }
+  return search(counts, null, [], samples);
+}
+
+function search(
+  counts: Map<string, number>,
+  pair: Tile[] | null,
+  melds: Meld[],
+  samples: Map<string, Tile>
+): HandAnalysis | null {
   let first: string | undefined;
   for (const [tile, count] of counts) {
     if (count > 0) {
@@ -82,48 +115,55 @@ function canFormSets(counts: Map<string, number>, pairUsed: boolean): boolean {
       break;
     }
   }
-  if (!first) return pairUsed;
+  if (!first) {
+    if (pair && melds.length === 4) {
+      return { pair, melds: [...melds] };
+    }
+    return null;
+  }
+
   const [suit, valueStr] = first.split('-');
   const value = parseInt(valueStr, 10);
+  const tileObj = samples.get(first)!;
 
-  // try pair
-  if (!pairUsed && (counts.get(first) ?? 0) >= 2) {
+  if (!pair && (counts.get(first) ?? 0) >= 2) {
     counts.set(first, (counts.get(first) ?? 0) - 2);
-    if (canFormSets(counts, true)) return true;
+    const result = search(counts, [tileObj, tileObj], melds, samples);
+    if (result) return result;
     counts.set(first, (counts.get(first) ?? 0) + 2);
   }
 
-  // try triplet
   if ((counts.get(first) ?? 0) >= 3) {
     counts.set(first, (counts.get(first) ?? 0) - 3);
-    if (canFormSets(counts, pairUsed)) return true;
+    melds.push({ type: 'triplet', tiles: [tileObj, tileObj, tileObj] });
+    const result = search(counts, pair, melds, samples);
+    if (result) return result;
+    melds.pop();
     counts.set(first, (counts.get(first) ?? 0) + 3);
   }
 
-  // try sequence for number tiles
   if (suit === 'man' || suit === 'pin' || suit === 'sou') {
     const t1 = `${suit}-${value + 1}`;
     const t2 = `${suit}-${value + 2}`;
-    if ((counts.get(first) ?? 0) > 0 && (counts.get(t1) ?? 0) > 0 && (counts.get(t2) ?? 0) > 0) {
+    if (
+      (counts.get(first) ?? 0) > 0 &&
+      (counts.get(t1) ?? 0) > 0 &&
+      (counts.get(t2) ?? 0) > 0
+    ) {
       counts.set(first, (counts.get(first) ?? 0) - 1);
       counts.set(t1, (counts.get(t1) ?? 0) - 1);
       counts.set(t2, (counts.get(t2) ?? 0) - 1);
-      if (canFormSets(counts, pairUsed)) return true;
+      const seq = [samples.get(first)!, samples.get(t1)!, samples.get(t2)!].sort(
+        (a, b) => (a.value as number) - (b.value as number)
+      );
+      melds.push({ type: 'sequence', tiles: seq });
+      const result = search(counts, pair, melds, samples);
+      if (result) return result;
+      melds.pop();
       counts.set(first, (counts.get(first) ?? 0) + 1);
       counts.set(t1, (counts.get(t1) ?? 0) + 1);
       counts.set(t2, (counts.get(t2) ?? 0) + 1);
     }
   }
-  return false;
-}
-
-export function isWinningHand(hand: Tile[]): boolean {
-  if (detectSevenPairs(hand)) return true;
-  if (hand.length !== 14) return false;
-  const counts = new Map<string, number>();
-  for (const tile of hand) {
-    const key = tile.toString();
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return canFormSets(counts, false);
+  return null;
 }

--- a/core/test/analyze.test.ts
+++ b/core/test/analyze.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Tile, analyzeHand } from '../src/index.js';
+
+function standardWinningHand(): Tile[] {
+  return [
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'man', value: 8 }),
+    new Tile({ suit: 'man', value: 9 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 1 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 })
+  ];
+}
+
+test('analyzeHand parses standard winning hand', () => {
+  const hand = standardWinningHand();
+  const result = analyzeHand(hand);
+  assert.ok(result);
+  assert.strictEqual(result!.pair[0].toString(), 'pin-2');
+  assert.strictEqual(result!.pair[1].toString(), 'pin-2');
+  assert.strictEqual(result!.melds.length, 4);
+  const meldStrings = result!.melds.map(m => m.tiles.map(t => t.toString()).join(','));
+  assert.ok(meldStrings.includes('man-1,man-2,man-3'));
+  assert.ok(meldStrings.includes('man-4,man-5,man-6'));
+  assert.ok(meldStrings.includes('man-7,man-8,man-9'));
+  assert.ok(meldStrings.includes('pin-1,pin-1,pin-1'));
+});
+
+function mixedHand(): Tile[] {
+  return [
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'sou', value: 3 }),
+    new Tile({ suit: 'sou', value: 4 }),
+    new Tile({ suit: 'sou', value: 5 }),
+    new Tile({ suit: 'sou', value: 6 }),
+    new Tile({ suit: 'sou', value: 7 }),
+    new Tile({ suit: 'sou', value: 8 }),
+    new Tile({ suit: 'dragon', value: 'white' }),
+    new Tile({ suit: 'dragon', value: 'white' })
+  ];
+}
+
+test('analyzeHand handles mix of sequences and triplets', () => {
+  const hand = mixedHand();
+  const result = analyzeHand(hand);
+  assert.ok(result);
+  assert.strictEqual(result!.pair[0].toString(), 'dragon-white');
+  assert.strictEqual(result!.melds.length, 4);
+  const types = result!.melds.map(m => m.type);
+  assert.strictEqual(types.filter(t => t === 'triplet').length, 2);
+  assert.strictEqual(types.filter(t => t === 'sequence').length, 2);
+});


### PR DESCRIPTION
## Summary
- add `analyzeHand` helper and related types
- refactor `isWinningHand` to use new helper
- create tests for hand analysis

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860c4597ca8832a9c79ed8f06c0f224