### PR TITLE
Add player area heights and scrolling discards/melds

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -14,6 +14,7 @@ body {
   gap: 0.25rem;
   justify-content: center;
   flex-wrap: wrap;
+  overflow-y: auto;
 }
 
 .hand li,
@@ -44,17 +45,21 @@ button {
 
 .player-area.top {
   grid-area: top;
+  min-height: 6rem;
   text-align: center;
 }
 .player-area.bottom {
   grid-area: bottom;
+  min-height: 6rem;
   text-align: center;
 }
 .player-area.left {
   grid-area: left;
+  min-height: 6rem;
 }
 .player-area.right {
   grid-area: right;
+  min-height: 6rem;
 }
 .center {
   grid-area: center;
@@ -73,4 +78,5 @@ button {
   padding: 0;
   display: flex;
   gap: 0.25rem;
+  overflow-y: auto;
 }

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function readCss(): Promise<string> {
+  const cssPath = join(__dirname, '../../src/style.css');
+  return readFile(cssPath, 'utf8');
+}
+
+test('style.css includes height and overflow rules', async () => {
+  const css = await readCss();
+  assert.match(css, /\.player-area\.top[^}]*min-height:\s*6rem/);
+  assert.match(css, /\.player-area\.bottom[^}]*min-height:\s*6rem/);
+  assert.match(css, /\.player-area\.left[^}]*min-height:\s*6rem/);
+  assert.match(css, /\.player-area\.right[^}]*min-height:\s*6rem/);
+  assert.match(css, /\.discards[^}]*overflow-y:\s*auto/);
+  assert.match(css, /\.melds[^}]*overflow-y:\s*auto/);
+});


### PR DESCRIPTION
## Summary
- add min-height rules for each `player-area` grid row
- make discard and meld lists scroll if content overflows
- verify CSS updates via new unit test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860c56e7abc832ab2d100095e4866b1