### PR TITLE
Implement responsive board layout

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -74,3 +74,15 @@ button {
   display: flex;
   gap: 0.25rem;
 }
+
+@media (max-width: 600px) {
+  .board {
+    grid-template-areas:
+      'top'
+      'left'
+      'right'
+      'center'
+      'bottom';
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/test/responsiveCSS.test.ts
+++ b/web/test/responsiveCSS.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const cssPath = path.join(__dirname, '../../src/style.css');
+
+const css = fs.readFileSync(cssPath, 'utf8');
+
+test('style.css includes responsive media query', () => {
+  assert.match(css, /@media\s*\(max-width:\s*600px\)/);
+  assert.match(css, /grid-template-areas:[^}]*'top'[\s\S]*'left'[\s\S]*'right'[\s\S]*'center'[\s\S]*'bottom'/);
+});


### PR DESCRIPTION
## Summary
- stack side players vertically on narrow screens
- test for responsive CSS rules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860c6740bbc832aa5cbaedec5ae5b84