### PR TITLE
Use icons for draw/discard actions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,7 @@ export default function App(): JSX.Element {
     <div className="app">
       <h1>My Mahjong</h1>
       <p>Wall tiles left: {wallCount}</p>
-      <button onClick={draw} disabled={wallCount === 0}>Draw</button>
+      <button onClick={draw} disabled={wallCount === 0} aria-label="Draw">🀄</button>
       {score.han > 0 && (
         <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
       )}

--- a/web/src/components/Hand.tsx
+++ b/web/src/components/Hand.tsx
@@ -11,7 +11,7 @@ export function Hand({ tiles, onDiscard }: HandProps): JSX.Element {
       {tiles.map((tile, i) => (
         <li key={i}>
           {tile.toString()}
-          <button onClick={() => onDiscard(i)}>Discard</button>
+          <button aria-label="Discard" onClick={() => onDiscard(i)}>🗑️</button>
         </li>
       ))}
     </ul>

--- a/web/test/App.test.tsx
+++ b/web/test/App.test.tsx
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import App from '../src/App.js';
+
+test('App draw button has aria-label', () => {
+  const html = renderToStaticMarkup(<App />);
+  assert.ok(html.includes('aria-label="Draw"'));
+});

--- a/web/test/Hand.test.tsx
+++ b/web/test/Hand.test.tsx
@@ -11,4 +11,5 @@ test('Hand renders tile strings', () => {
     <Hand tiles={tiles} onDiscard={() => {}} />
   );
   assert.ok(html.includes('man-1'));
+  assert.ok(html.includes('aria-label="Discard"'));
 });


### PR DESCRIPTION
## Summary
- swap text labels for emoji icons on draw and discard buttons
- test that these buttons expose appropriate `aria-label` attributes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860c82ae250832abd60992c2608fb83