### PR TITLE
Add toitoi yaku and basic fu calculation

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -3,3 +3,15 @@
 The core package implements a very small subset of Mahjong mechanics in TypeScript. It defines the tiles, wall, player hands and a simple `Game` class for drawing and discarding tiles.
 
 This package is framework agnostic and can be used from Node.js or the browser. See the tests in `test/` for basic usage examples.
+
+### Scoring Features
+
+Currently implemented yaku detection includes:
+
+- Tanyao (all simples)
+- Chiitoitsu (seven pairs)
+- Yakuhai (triplets of dragons or winds)
+- Toitoi (all triplets)
+
+Fu is calculated using a simplified model based on meld composition and honor
+tiles. See `Score.ts` for details.

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -3,7 +3,22 @@ import assert from 'node:assert/strict';
 import { Tile, calculateScore } from '../src/index.js';
 
 test('tanyao detection and scoring', () => {
-  const hand = Array.from({ length: 14 }, () => new Tile({ suit: 'man', value: 2 }));
+  const hand = [
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 3 }),
+    new Tile({ suit: 'pin', value: 4 }),
+    new Tile({ suit: 'sou', value: 2 }),
+    new Tile({ suit: 'sou', value: 3 }),
+    new Tile({ suit: 'sou', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'pin', value: 6 }),
+    new Tile({ suit: 'pin', value: 6 }),
+  ];
   const result = calculateScore(hand);
   assert.deepStrictEqual(result, { yaku: ['tanyao'], han: 1, fu: 20, points: 20 });
 });
@@ -32,15 +47,29 @@ test('hand with honors scores zero', () => {
 
 test('yakuhai detection for dragon triplet', () => {
   const hand = [
+    // sequences
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'man', value: 8 }),
+    new Tile({ suit: 'man', value: 9 }),
+    // dragon triplet
     new Tile({ suit: 'dragon', value: 'white' }),
     new Tile({ suit: 'dragon', value: 'white' }),
     new Tile({ suit: 'dragon', value: 'white' }),
-    ...Array.from({ length: 11 }, () => new Tile({ suit: 'man', value: 2 })),
+    // pair
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 }),
   ];
   const result = calculateScore(hand);
   assert.ok(result.yaku.includes('yakuhai-white'));
   assert.strictEqual(result.han, 1);
-  assert.strictEqual(result.points, 20);
+  assert.strictEqual(result.fu, 24);
+  assert.strictEqual(result.points, 24);
 });
 
 test('multiple yakuhai triplets each add han', () => {
@@ -53,12 +82,47 @@ test('multiple yakuhai triplets each add han', () => {
     new Tile({ suit: 'wind', value: 'east' }),
     new Tile({ suit: 'wind', value: 'east' }),
     new Tile({ suit: 'wind', value: 'east' }),
-    // rest of hand
-    ...Array.from({ length: 8 }, () => new Tile({ suit: 'man', value: 2 })),
+    // sequences
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    // pair
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 }),
   ];
   const result = calculateScore(hand);
   assert.ok(result.yaku.includes('yakuhai-green'));
   assert.ok(result.yaku.includes('yakuhai-east'));
   assert.strictEqual(result.han, 2);
-  assert.strictEqual(result.points, 40);
+  assert.strictEqual(result.fu, 28);
+  assert.strictEqual(result.points, 56);
+});
+
+test('toitoi detection and fu calculation', () => {
+  const hand = [
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'dragon', value: 'red' }),
+    new Tile({ suit: 'dragon', value: 'red' }),
+    new Tile({ suit: 'dragon', value: 'red' }),
+    new Tile({ suit: 'wind', value: 'east' }),
+    new Tile({ suit: 'wind', value: 'east' }),
+  ];
+  const result = calculateScore(hand);
+  assert.ok(result.yaku.includes('toitoi'));
+  assert.ok(result.yaku.includes('yakuhai-red'));
+  assert.strictEqual(result.han, 3);
+  // pair of east winds adds fu, plus three simple triplets and one honor triplet
+  assert.strictEqual(result.fu, 32);
+  assert.strictEqual(result.points, 96);
 });


### PR DESCRIPTION
## Summary
- implement `detectToitoi` and `calculateFu` in core scoring
- update `calculateScore` to use new logic
- document scoring features in `core/README.md`
- expand `score.test.ts` for new yaku and fu values

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860c8812a90832a82a6f7d8fd48f8a7