### PR TITLE
Add placeholder tile images and TileImage component

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -3,3 +3,5 @@
 A minimal React front end that consumes the core Mahjong logic. To develop locally run `npm run dev -w web` and open `http://localhost:5173`.
 
 The web package is intentionally simple and serves as a reference for using the core logic in the browser. The game board lays out each player's area around a central stack. Currently only the bottom player's hand is interactive.
+
+Tile images live under `public/tiles/`. Real graphics are omitted here because binary assets cannot be committed. Each file is a tiny SVG displaying an emoji placeholder.

--- a/web/public/tiles/README.md
+++ b/web/public/tiles/README.md
@@ -1,0 +1,1 @@
+These files would normally contain tile images. Because binary assets can't be committed in this environment, each tile is represented by a small SVG showing an emoji placeholder.

--- a/web/public/tiles/dragon-green.svg
+++ b/web/public/tiles/dragon-green.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/dragon-red.svg
+++ b/web/public/tiles/dragon-red.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/dragon-white.svg
+++ b/web/public/tiles/dragon-white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-1.svg
+++ b/web/public/tiles/man-1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-2.svg
+++ b/web/public/tiles/man-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-3.svg
+++ b/web/public/tiles/man-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-4.svg
+++ b/web/public/tiles/man-4.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-5.svg
+++ b/web/public/tiles/man-5.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-6.svg
+++ b/web/public/tiles/man-6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-7.svg
+++ b/web/public/tiles/man-7.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-8.svg
+++ b/web/public/tiles/man-8.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/man-9.svg
+++ b/web/public/tiles/man-9.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-1.svg
+++ b/web/public/tiles/pin-1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-2.svg
+++ b/web/public/tiles/pin-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-3.svg
+++ b/web/public/tiles/pin-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-4.svg
+++ b/web/public/tiles/pin-4.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-5.svg
+++ b/web/public/tiles/pin-5.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-6.svg
+++ b/web/public/tiles/pin-6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-7.svg
+++ b/web/public/tiles/pin-7.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-8.svg
+++ b/web/public/tiles/pin-8.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/pin-9.svg
+++ b/web/public/tiles/pin-9.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-1.svg
+++ b/web/public/tiles/sou-1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-2.svg
+++ b/web/public/tiles/sou-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-3.svg
+++ b/web/public/tiles/sou-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-4.svg
+++ b/web/public/tiles/sou-4.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-5.svg
+++ b/web/public/tiles/sou-5.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-6.svg
+++ b/web/public/tiles/sou-6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-7.svg
+++ b/web/public/tiles/sou-7.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-8.svg
+++ b/web/public/tiles/sou-8.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/sou-9.svg
+++ b/web/public/tiles/sou-9.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀄</text>
+</svg>

--- a/web/public/tiles/wind-east.svg
+++ b/web/public/tiles/wind-east.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀀</text>
+</svg>

--- a/web/public/tiles/wind-north.svg
+++ b/web/public/tiles/wind-north.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀀</text>
+</svg>

--- a/web/public/tiles/wind-south.svg
+++ b/web/public/tiles/wind-south.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀀</text>
+</svg>

--- a/web/public/tiles/wind-west.svg
+++ b/web/public/tiles/wind-west.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60">🀀</text>
+</svg>

--- a/web/src/components/Discards.tsx
+++ b/web/src/components/Discards.tsx
@@ -1,4 +1,5 @@
 import type { Tile } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
 
 export interface DiscardsProps {
   tiles: Tile[];
@@ -8,7 +9,9 @@ export function Discards({ tiles }: DiscardsProps): JSX.Element {
   return (
     <ul className="discards">
       {tiles.map((t, i) => (
-        <li key={i}>{t.toString()}</li>
+        <li key={i}>
+          <TileImage tile={t} />
+        </li>
       ))}
     </ul>
   );

--- a/web/src/components/Hand.tsx
+++ b/web/src/components/Hand.tsx
@@ -1,4 +1,5 @@
 import type { Tile } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
 
 export interface HandProps {
   tiles: Tile[];
@@ -10,7 +11,7 @@ export function Hand({ tiles, onDiscard }: HandProps): JSX.Element {
     <ul className="hand">
       {tiles.map((tile, i) => (
         <li key={i}>
-          {tile.toString()}
+          <TileImage tile={tile} />
           <button aria-label="Discard" onClick={() => onDiscard(i)}>🗑️</button>
         </li>
       ))}

--- a/web/src/components/Melds.tsx
+++ b/web/src/components/Melds.tsx
@@ -1,4 +1,5 @@
 import type { Tile } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
 
 export interface MeldsProps {
   melds: Tile[][];
@@ -8,7 +9,11 @@ export function Melds({ melds }: MeldsProps): JSX.Element {
   return (
     <ul className="melds">
       {melds.map((set, i) => (
-        <li key={i}>{set.map(t => t.toString()).join(' ')}</li>
+        <li key={i}>
+          {set.map((t, j) => (
+            <TileImage key={j} tile={t} />
+          ))}
+        </li>
       ))}
     </ul>
   );

--- a/web/src/components/TileImage.tsx
+++ b/web/src/components/TileImage.tsx
@@ -1,0 +1,16 @@
+import type { Tile } from '@mymahjong/core';
+
+// Images under public/tiles are emoji-based placeholders because
+// binary assets cannot be committed in this environment.
+
+export interface TileImageProps {
+  tile: Tile;
+}
+
+export function TileImage({ tile }: TileImageProps): JSX.Element {
+  // During node-based tests import.meta.env is undefined, so fall back to '/'.
+  const base = (import.meta as any).env?.BASE_URL ?? '/';
+  const src = `${base}tiles/${tile.toString()}.svg`;
+  const alt = `${tile.suit} ${tile.value}`;
+  return <img src={src} alt={alt} />;
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -4,3 +4,4 @@ export { Hand } from './components/Hand.js';
 export { GameBoard } from './components/GameBoard.js';
 export { Discards } from './components/Discards.js';
 export { Melds } from './components/Melds.js';
+export { TileImage } from './components/TileImage.js';

--- a/web/test/Discards.test.tsx
+++ b/web/test/Discards.test.tsx
@@ -10,5 +10,6 @@ test('Discards renders tiles', () => {
   const html = renderToStaticMarkup(
     <Discards tiles={tiles} />
   );
-  assert.ok(html.includes('sou-3'));
+  assert.ok(html.includes('<img'));
+  assert.ok(html.includes('sou-3.svg'));
 });

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -14,7 +14,7 @@ test('GameBoard renders hand, discards and melds', () => {
   );
   const count = (html.match(/class="player-area/g) || []).length;
   assert.equal(count, 4);
-  assert.ok(html.includes('man-1'));
-  assert.ok(html.includes('pin-2'));
-  assert.ok(html.includes('sou-3'));
+  assert.ok(html.includes('man-1.svg'));
+  assert.ok(html.includes('pin-2.svg'));
+  assert.ok(html.includes('sou-3.svg'));
 });

--- a/web/test/Hand.test.tsx
+++ b/web/test/Hand.test.tsx
@@ -5,11 +5,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { Hand } from '../src/components/Hand.js';
 import { Tile } from '@mymahjong/core';
 
-test('Hand renders tile strings', () => {
+test('Hand renders tile images', () => {
   const tiles = [new Tile({ suit: 'man', value: 1 })];
   const html = renderToStaticMarkup(
     <Hand tiles={tiles} onDiscard={() => {}} />
   );
-  assert.ok(html.includes('man-1'));
+  assert.ok(html.includes('<img')); 
+  assert.ok(html.includes('man-1.svg'));
   assert.ok(html.includes('aria-label="Discard"'));
 });

--- a/web/test/Melds.test.tsx
+++ b/web/test/Melds.test.tsx
@@ -12,7 +12,8 @@ test('Melds renders sets of tiles', () => {
     new Tile({ suit: 'man', value: 3 }),
   ]];
   const html = renderToStaticMarkup(<Melds melds={melds} />);
-  assert.ok(html.includes('man-1'));
-  assert.ok(html.includes('man-2'));
-  assert.ok(html.includes('man-3'));
+  assert.ok(html.includes('<img'));
+  assert.ok(html.includes('man-1.svg'));
+  assert.ok(html.includes('man-2.svg'));
+  assert.ok(html.includes('man-3.svg'));
 });

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -15,7 +15,10 @@
     },
     "baseUrl": ".",
     "moduleResolution": "node",
-    "types": ["node"],
+    "types": [
+      "node",
+      "vite/client"
+    ],
     "jsx": "react-jsx"
   },
   "references": [


### PR DESCRIPTION
## Summary
- add `web/public/tiles` with emoji-based SVG placeholders for tiles
- create `TileImage` component for rendering tile images
- update `Hand`, `Discards`, and `Melds` to use `TileImage`
- adjust tests to expect image elements
- note placeholder graphics in web README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860caa3ba64832a9631c200d01587a6