### PR TITLE
Implement basic payment calculation

### DIFF
--- a/cli/test/run.test.ts
+++ b/cli/test/run.test.ts
@@ -12,7 +12,17 @@ test('run processes a single turn', async () => {
     drawCurrent() { this.wall.count = 0; return 'drawn'; },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     discardCurrent(index: number) { return 'discarded'; },
-    calculateScore() { return { han: 0, fu: 20, points: 0, yaku: [] }; },
+    calculateScore() {
+      return {
+        han: 0,
+        fu: 20,
+        rawFu: 20,
+        basePoints: 0,
+        rawPoints: 0,
+        points: 0,
+        yaku: [],
+      };
+    },
   } as any;
 
   const answers = ['', '0'];
@@ -32,7 +42,17 @@ test('run prints discards', async () => {
     deal() {},
     drawCurrent() { this.wall.count = 0; return 'drawn'; },
     discardCurrent() { this.players[0].discards.push('discarded'); return 'discarded'; },
-    calculateScore() { return { han: 1, fu: 20, points: 20, yaku: ['tanyao'] }; },
+    calculateScore() {
+      return {
+        han: 1,
+        fu: 20,
+        rawFu: 20,
+        basePoints: 160,
+        rawPoints: 640,
+        points: 700,
+        yaku: ['tanyao'],
+      };
+    },
   } as any;
 
   const answers = ['', '0'];

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -89,8 +89,11 @@ export class Game {
     return false;
   }
 
-  calculateScore(playerIndex = this.currentIndex): ScoreResult {
-    return calculateScore(this.players[playerIndex].hand);
+  calculateScore(
+    playerIndex = this.currentIndex,
+    options: import('./Score.js').ScoreOptions = {}
+  ): ScoreResult {
+    return calculateScore(this.players[playerIndex].hand, options);
   }
 
   isWinningHand(playerIndex = this.currentIndex): boolean {

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -20,7 +20,10 @@ test('tanyao detection and scoring', () => {
     new Tile({ suit: 'pin', value: 6 }),
   ];
   const result = calculateScore(hand);
-  assert.deepStrictEqual(result, { yaku: ['tanyao'], han: 1, fu: 20, points: 20 });
+  assert.deepStrictEqual(result.yaku, ['tanyao']);
+  assert.strictEqual(result.han, 1);
+  assert.strictEqual(result.fu, 20);
+  assert.strictEqual(result.points, 700);
 });
 
 test('chiitoitsu detection and scoring', () => {
@@ -32,7 +35,7 @@ test('chiitoitsu detection and scoring', () => {
   const result = calculateScore(hand);
   assert.ok(result.yaku.includes('chiitoitsu'));
   assert.strictEqual(result.han, 2);
-  assert.strictEqual(result.points, 40);
+  assert.strictEqual(result.points, 1300);
 });
 
 test('hand with honors scores zero', () => {
@@ -68,8 +71,9 @@ test('yakuhai detection for dragon triplet', () => {
   const result = calculateScore(hand);
   assert.ok(result.yaku.includes('yakuhai-white'));
   assert.strictEqual(result.han, 1);
-  assert.strictEqual(result.fu, 24);
-  assert.strictEqual(result.points, 24);
+  assert.strictEqual(result.rawFu, 24);
+  assert.strictEqual(result.fu, 30);
+  assert.strictEqual(result.points, 1000);
 });
 
 test('multiple yakuhai triplets each add han', () => {
@@ -97,8 +101,9 @@ test('multiple yakuhai triplets each add han', () => {
   assert.ok(result.yaku.includes('yakuhai-green'));
   assert.ok(result.yaku.includes('yakuhai-east'));
   assert.strictEqual(result.han, 2);
-  assert.strictEqual(result.fu, 28);
-  assert.strictEqual(result.points, 56);
+  assert.strictEqual(result.rawFu, 28);
+  assert.strictEqual(result.fu, 30);
+  assert.strictEqual(result.points, 2000);
 });
 
 test('toitoi detection and fu calculation', () => {
@@ -123,6 +128,7 @@ test('toitoi detection and fu calculation', () => {
   assert.ok(result.yaku.includes('yakuhai-red'));
   assert.strictEqual(result.han, 3);
   // pair of east winds adds fu, plus three simple triplets and one honor triplet
-  assert.strictEqual(result.fu, 32);
-  assert.strictEqual(result.points, 96);
+  assert.strictEqual(result.rawFu, 32);
+  assert.strictEqual(result.fu, 40);
+  assert.strictEqual(result.points, 5200);
 });


### PR DESCRIPTION
## Summary
- extend scoring system to handle dealer/tsumo differences
- return raw fu and points for more detailed results
- update Game API and tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860cb76978c832a9b2d8245e4d6644b