### PR TITLE
Fix UI text size and horizontal hand layout

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -5,6 +5,7 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 ## Orientation
 
 - The local player's hand is shown along the bottom edge.
+- Tiles within each hand are laid out horizontally, matching a traditional table view.
 - Each player's discard pile (河) sits directly in front of their hand. For the bottom player this means discards appear above the hand.
 - Melded tiles (calls such as chi or pon) align to the right of that player's discard pile. This keeps the main hand centered while revealing open sets.
 - Opponents occupy the top, left and right edges, surrounding a central area used for wall tiles or indicators.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1,6 +1,12 @@
 body {
   font-family: sans-serif;
   padding: 1rem;
+  font-size: 0.875rem;
+}
+
+.app h1 {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
 }
 
 .hand,
@@ -9,12 +15,20 @@ body {
   padding: 0;
 }
 
+
 .discards {
   display: flex;
   gap: 0.25rem;
   justify-content: center;
   flex-wrap: wrap;
   overflow-y: auto;
+}
+
+.hand {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .hand li,

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -20,3 +20,14 @@ test('style.css includes height and overflow rules', async () => {
   assert.match(css, /\.discards[^}]*overflow-y:\s*auto/);
   assert.match(css, /\.melds[^}]*overflow-y:\s*auto/);
 });
+
+test('hand layout is horizontal', async () => {
+  const css = await readCss();
+  assert.match(css, /\.hand[^}]*display:\s*flex/);
+});
+
+test('font sizes are reduced for small screens', async () => {
+  const css = await readCss();
+  assert.match(css, /body[^}]*font-size:\s*0\.875rem/);
+  assert.match(css, /\.app h1[^}]*font-size:\s*1\.25rem/);
+});


### PR DESCRIPTION
## Summary
- keep GUI text small so everything fits on screen
- arrange tiles horizontally in the player hand
- document horizontal hand layout in board-layout guide
- test new CSS rules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860d04837e8832a89d352d4a894f83e