### PR TITLE
Add DiscardPile component

### DIFF
--- a/web/src/components/DiscardPile.tsx
+++ b/web/src/components/DiscardPile.tsx
@@ -1,0 +1,19 @@
+import type { Tile } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
+
+export interface DiscardPileProps {
+  tiles: Tile[];
+  position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export function DiscardPile({ tiles, position }: DiscardPileProps): JSX.Element {
+  return (
+    <ul className={`discard-pile ${position}`}>
+      {tiles.map((t, i) => (
+        <li key={i}>
+          <TileImage tile={t} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -1,6 +1,6 @@
 import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
-import { Discards } from './Discards.js';
+import { DiscardPile } from './DiscardPile.js';
 import { Melds } from './Melds.js';
 
 export interface GameBoardProps {
@@ -15,21 +15,21 @@ export function GameBoard({ currentHand, currentDiscards, currentMelds = [], onD
     <div className="board">
       <div className="player-area top">
         <p>Player 2</p>
-        <Discards tiles={[]} />
+        <DiscardPile tiles={[]} position="top" />
       </div>
       <div className="player-area left">
         <p>Player 3</p>
-        <Discards tiles={[]} />
+        <DiscardPile tiles={[]} position="left" />
       </div>
       <div className="center">Center</div>
       <div className="player-area right">
         <p>Player 4</p>
-        <Discards tiles={[]} />
+        <DiscardPile tiles={[]} position="right" />
       </div>
       <div className="player-area bottom">
         <div className="meld-discard">
           <Melds melds={currentMelds} />
-          <Discards tiles={currentDiscards} />
+          <DiscardPile tiles={currentDiscards} position="bottom" />
         </div>
         <Hand tiles={currentHand} onDiscard={onDiscard} />
       </div>

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -2,6 +2,6 @@
 export { useGame } from './hooks/useGame.js';
 export { Hand } from './components/Hand.js';
 export { GameBoard } from './components/GameBoard.js';
-export { Discards } from './components/Discards.js';
+export { DiscardPile } from './components/DiscardPile.js';
 export { Melds } from './components/Melds.js';
 export { TileImage } from './components/TileImage.js';

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -4,7 +4,8 @@ body {
 }
 
 .hand,
-.discards {
+.discards,
+.discard-pile {
   list-style: none;
   padding: 0;
 }
@@ -17,8 +18,36 @@ body {
   overflow-y: auto;
 }
 
+.discard-pile {
+  display: grid;
+  grid-template-columns: repeat(6, auto);
+  gap: 0.25rem;
+  justify-content: center;
+  overflow-y: auto;
+}
+
+.discard-pile.left,
+.discard-pile.right {
+  grid-template-columns: none;
+  grid-template-rows: repeat(6, auto);
+  grid-auto-flow: column;
+}
+
+.discard-pile.top img {
+  transform: rotate(180deg);
+}
+
+.discard-pile.left img {
+  transform: rotate(90deg);
+}
+
+.discard-pile.right img {
+  transform: rotate(-90deg);
+}
+
 .hand li,
-.discards li {
+.discards li,
+.discard-pile li {
   margin-bottom: 0.25rem;
 }
 

--- a/web/test/DiscardPile.test.tsx
+++ b/web/test/DiscardPile.test.tsx
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DiscardPile } from '../src/components/DiscardPile.js';
+import { Tile } from '@mymahjong/core';
+
+test('DiscardPile renders with orientation class', () => {
+  const tiles = [new Tile({ suit: 'sou', value: 3 })];
+  const html = renderToStaticMarkup(
+    <DiscardPile tiles={tiles} position="left" />
+  );
+  assert.ok(html.includes('class="discard-pile left"'));
+  assert.ok(html.includes('sou-3.svg'));
+});

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -10,11 +10,20 @@ test('GameBoard renders hand, discards and melds', () => {
   const discards = [new Tile({ suit: 'pin', value: 2 })];
   const melds = [[new Tile({ suit: 'sou', value: 3 })]];
   const html = renderToStaticMarkup(
-    <GameBoard currentHand={tiles} currentDiscards={discards} currentMelds={melds} onDiscard={() => {}} />
+    <GameBoard
+      currentHand={tiles}
+      currentDiscards={discards}
+      currentMelds={melds}
+      onDiscard={() => {}}
+    />
   );
   const count = (html.match(/class="player-area/g) || []).length;
   assert.equal(count, 4);
   assert.ok(html.includes('man-1.svg'));
   assert.ok(html.includes('pin-2.svg'));
   assert.ok(html.includes('sou-3.svg'));
+  assert.ok(html.includes('class="discard-pile bottom"'));
+  assert.ok(html.includes('class="discard-pile top"'));
+  assert.ok(html.includes('class="discard-pile left"'));
+  assert.ok(html.includes('class="discard-pile right"'));
 });

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -19,4 +19,7 @@ test('style.css includes height and overflow rules', async () => {
   assert.match(css, /\.player-area\.right[^}]*min-height:\s*6rem/);
   assert.match(css, /\.discards[^}]*overflow-y:\s*auto/);
   assert.match(css, /\.melds[^}]*overflow-y:\s*auto/);
+  assert.match(css, /\.discard-pile[^}]*grid-template-columns/);
+  assert.match(css, /\.discard-pile\.left/);
+  assert.match(css, /\.discard-pile\.right/);
 });


### PR DESCRIPTION
## Summary
- display player discards with new `DiscardPile` React component
- orient discard tiles for each seat
- integrate `DiscardPile` into `GameBoard`
- support new styles and tests for discard piles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860d1554e44832aa5ad666bb0b34553