### PR TITLE
Implement seat winds

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ status and a suggested roadmap for extending the rules.
   - `tanyao` (all simples)
   - `chiitoitsu` (seven pairs)
   - `yakuhai` triplets of winds or dragons
+- Seat wind assignment and dealer rotation
 
 -**Not Yet Implemented**
 
-- Round and seat wind tracking or dealer rotation
+- Round progression with changing round winds
 - Additional yaku and detailed fu/han scoring
 - Riichi, dora indicators and other advanced rules
 

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -2,15 +2,32 @@ import { Player } from './Player.js';
 import { Wall } from './Wall.js';
 import { Tile } from './Tile.js';
 import { calculateScore, ScoreResult, isWinningHand } from './Score.js';
+import type { Wind } from './types.js';
 
 export class Game {
   readonly wall: Wall;
   readonly players: Player[];
   private currentIndex = 0;
+  private dealerIndex = 0;
+
+  /**
+   * Seat winds assigned to each player in the same order as `players`.
+   */
+  readonly seatWinds: Wind[] = [];
 
   constructor(playerCount = 4, wall: Wall = Wall.createShuffled()) {
     this.wall = wall;
     this.players = Array.from({ length: playerCount }, () => new Player());
+    this.assignSeatWinds();
+  }
+
+  private assignSeatWinds(): void {
+    const winds: Wind[] = ['east', 'south', 'west', 'north'];
+    for (let i = 0; i < this.players.length; i++) {
+      const wind = winds[i % winds.length];
+      this.players[i].seatWind = wind;
+      this.seatWinds[i] = wind;
+    }
   }
 
   deal(initialHandSize = 13): void {
@@ -98,5 +115,19 @@ export class Game {
 
   isWinningHand(playerIndex = this.currentIndex): boolean {
     return isWinningHand(this.players[playerIndex].hand);
+  }
+
+  /**
+   * Rotate the dealer position to the next player and update each player's
+   * seat wind accordingly.
+   */
+  rotateDealer(): void {
+    this.dealerIndex = (this.dealerIndex + 1) % this.players.length;
+    const winds: Wind[] = ['east', 'south', 'west', 'north'];
+    for (let i = 0; i < this.players.length; i++) {
+      const player = this.players[(this.dealerIndex + i) % this.players.length];
+      player.seatWind = winds[i];
+      this.seatWinds[(this.dealerIndex + i) % this.players.length] = winds[i];
+    }
   }
 }

--- a/core/src/Player.ts
+++ b/core/src/Player.ts
@@ -1,4 +1,5 @@
 import { Tile } from './Tile.js';
+import type { Wind } from './types.js';
 
 export class Player {
   readonly hand: Tile[] = [];
@@ -8,6 +9,12 @@ export class Player {
    * Each meld is an array of tiles in the order they were claimed.
    */
   readonly melds: Tile[][] = [];
+
+  /**
+   * The player's current seat wind. This is assigned by the Game
+   * instance when a round begins and rotates after each hand.
+   */
+  seatWind?: Wind;
 
   draw(tile: Tile): void {
     this.hand.push(tile);

--- a/core/test/dealer.test.ts
+++ b/core/test/dealer.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Game } from '../src/index.js';
+
+const winds = ['east','south','west','north'] as const;
+
+test('game assigns seat winds to players', () => {
+  const game = new Game();
+  for (let i = 0; i < game.players.length; i++) {
+    assert.strictEqual(game.players[i].seatWind, winds[i]);
+  }
+});
+
+test('rotateDealer advances dealer and seat winds', () => {
+  const game = new Game();
+  game.rotateDealer();
+  const expected = ['north','east','south','west'] as const;
+  for (let i = 0; i < game.players.length; i++) {
+    assert.strictEqual(game.players[i].seatWind, expected[i]);
+  }
+  assert.strictEqual(game['dealerIndex'], 1);
+});


### PR DESCRIPTION
## Summary
- track each player's seat wind in the core game
- allow dealer rotation and update seat winds
- document the new functionality
- test dealer rotation logic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860d11a70a8832a948f623e06dc9c58