### PR TITLE
Expose all discards in useGame

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { GameBoard } from './components/GameBoard.js';
 import { useGame } from './hooks/useGame.js';
 
 export default function App(): JSX.Element {
-  const { hand, discards, wallCount, draw, discard, score } = useGame();
+  const { hand, playerDiscards, wallCount, draw, discard, score } = useGame();
   return (
     <div className="app">
       <h1>My Mahjong</h1>
@@ -11,7 +11,7 @@ export default function App(): JSX.Element {
       {score.han > 0 && (
         <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
       )}
-      <GameBoard currentHand={hand} currentDiscards={discards} onDiscard={discard} />
+      <GameBoard currentHand={hand} playerDiscards={playerDiscards} onDiscard={discard} />
     </div>
   );
 }

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -5,31 +5,32 @@ import { Melds } from './Melds.js';
 
 export interface GameBoardProps {
   currentHand: Tile[];
-  currentDiscards: Tile[];
+  /** Discard piles for all players in game order. */
+  playerDiscards: Tile[][];
   currentMelds?: Tile[][];
   onDiscard: (index: number) => void;
 }
 
-export function GameBoard({ currentHand, currentDiscards, currentMelds = [], onDiscard }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDiscard }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
       <div className="player-area top">
         <p>Player 2</p>
-        <Discards tiles={[]} />
+        <Discards tiles={playerDiscards[1] ?? []} />
       </div>
       <div className="player-area left">
         <p>Player 3</p>
-        <Discards tiles={[]} />
+        <Discards tiles={playerDiscards[2] ?? []} />
       </div>
       <div className="center">Center</div>
       <div className="player-area right">
         <p>Player 4</p>
-        <Discards tiles={[]} />
+        <Discards tiles={playerDiscards[3] ?? []} />
       </div>
       <div className="player-area bottom">
         <div className="meld-discard">
           <Melds melds={currentMelds} />
-          <Discards tiles={currentDiscards} />
+          <Discards tiles={playerDiscards[0] ?? []} />
         </div>
         <Hand tiles={currentHand} onDiscard={onDiscard} />
       </div>

--- a/web/src/hooks/useGame.ts
+++ b/web/src/hooks/useGame.ts
@@ -4,6 +4,11 @@ import { Game, Tile, ScoreResult } from '@mymahjong/core';
 interface GameState {
   hand: Tile[];
   discards: Tile[];
+  /**
+   * Discards for every player in the order they appear in the Game instance.
+   * The first entry corresponds to the local player.
+   */
+  playerDiscards: Tile[][];
   wallCount: number;
   score: ScoreResult;
 }
@@ -23,6 +28,7 @@ export function useGame(game?: Game): GameState & {
   const [state, setState] = useState<GameState>(() => ({
     hand: [...gameInstance.players[0].hand],
     discards: [...gameInstance.players[0].discards],
+    playerDiscards: gameInstance.players.map(p => [...p.discards]),
     wallCount: gameInstance.wall.count,
     score: gameInstance.calculateScore(0),
   }));
@@ -31,6 +37,7 @@ export function useGame(game?: Game): GameState & {
     setState({
       hand: [...gameInstance.players[0].hand],
       discards: [...gameInstance.players[0].discards],
+      playerDiscards: gameInstance.players.map(p => [...p.discards]),
       wallCount: gameInstance.wall.count,
       score: gameInstance.calculateScore(0),
     });

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -8,9 +8,10 @@ import { Tile } from '@mymahjong/core';
 test('GameBoard renders hand, discards and melds', () => {
   const tiles = [new Tile({ suit: 'man', value: 1 })];
   const discards = [new Tile({ suit: 'pin', value: 2 })];
+  const discardsByPlayer = [discards, [], [], []];
   const melds = [[new Tile({ suit: 'sou', value: 3 })]];
   const html = renderToStaticMarkup(
-    <GameBoard currentHand={tiles} currentDiscards={discards} currentMelds={melds} onDiscard={() => {}} />
+    <GameBoard currentHand={tiles} playerDiscards={discardsByPlayer} currentMelds={melds} onDiscard={() => {}} />
   );
   const count = (html.match(/class="player-area/g) || []).length;
   assert.equal(count, 4);

--- a/web/test/useGame.test.tsx
+++ b/web/test/useGame.test.tsx
@@ -8,6 +8,7 @@ import { Game, Wall, Tile } from '@mymahjong/core';
 interface GameHandle {
   hand: ReturnType<typeof useGame>['hand'];
   discards: ReturnType<typeof useGame>['discards'];
+  playerDiscards: ReturnType<typeof useGame>['playerDiscards'];
   score: ReturnType<typeof useGame>['score'];
   draw: () => unknown;
   discard: (index: number) => unknown;
@@ -35,6 +36,7 @@ test('draw and discard update state', () => {
   assert.ok(ref.current);
   const initialHand = ref.current!.hand.length;
   const initialDiscards = ref.current!.discards.length;
+  const initialPlayerDiscards = ref.current!.playerDiscards.map(d => d.length);
   const initialPoints = ref.current!.score.points;
 
   act(() => {
@@ -49,6 +51,10 @@ test('draw and discard update state', () => {
   });
   assert.strictEqual(ref.current!.hand.length, initialHand);
   assert.strictEqual(ref.current!.discards.length, initialDiscards + 1);
+  assert.strictEqual(
+    ref.current!.playerDiscards[0].length,
+    initialPlayerDiscards[0] + 1
+  );
 
   renderer.unmount();
 });


### PR DESCRIPTION
## Summary
- extend `useGame` to expose discards for every player
- show other players' discards on the game board
- update App and adjust related tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860d329154c832a92685d5e2fb2c940