### PR TITLE
Add DiscardPile component with tests

### DIFF
--- a/web/src/components/DiscardPile.tsx
+++ b/web/src/components/DiscardPile.tsx
@@ -1,0 +1,27 @@
+import type { Tile } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
+
+export interface DiscardPileProps {
+  tiles: Tile[];
+  position?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export function DiscardPile({ tiles, position }: DiscardPileProps): JSX.Element {
+  const rows: Tile[][] = [];
+  for (let i = 0; i < tiles.length; i += 6) {
+    rows.push(tiles.slice(i, i + 6));
+  }
+  return (
+    <div className={`discard-pile${position ? ` ${position}` : ''}`}> 
+      {rows.map((row, rowIndex) => (
+        <ul key={rowIndex}>
+          {row.map((t, i) => (
+            <li key={i}>
+              <TileImage tile={t} />
+            </li>
+          ))}
+        </ul>
+      ))}
+    </div>
+  );
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -5,3 +5,4 @@ export { GameBoard } from './components/GameBoard.js';
 export { Discards } from './components/Discards.js';
 export { Melds } from './components/Melds.js';
 export { TileImage } from './components/TileImage.js';
+export { DiscardPile } from './components/DiscardPile.js';

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -10,7 +10,8 @@ body {
 }
 
 .hand,
-.discards {
+.discards,
+.discard-pile ul {
   list-style: none;
   padding: 0;
 }
@@ -24,6 +25,26 @@ body {
   overflow-y: auto;
 }
 
+.discard-pile {
+  display: grid;
+  grid-template-columns: repeat(6, auto);
+  gap: 0.25rem;
+  justify-content: center;
+}
+
+.discard-pile.top {
+  grid-area: top;
+}
+.discard-pile.bottom {
+  grid-area: bottom;
+}
+.discard-pile.left {
+  grid-area: left;
+}
+.discard-pile.right {
+  grid-area: right;
+}
+
 .hand {
   display: flex;
   gap: 0.25rem;
@@ -32,7 +53,8 @@ body {
 }
 
 .hand li,
-.discards li {
+.discards li,
+.discard-pile li {
   margin-bottom: 0.25rem;
 }
 

--- a/web/test/DiscardPile.test.tsx
+++ b/web/test/DiscardPile.test.tsx
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DiscardPile } from '../src/components/DiscardPile.js';
+import { Tile } from '@mymahjong/core';
+
+function createTiles(n: number): Tile[] {
+  return Array.from({ length: n }, (_, i) => {
+    const value = ((i % 9) + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+    return new Tile({ suit: 'man', value });
+  });
+}
+
+test('DiscardPile groups tiles into rows of six', () => {
+  const tiles = createTiles(8);
+  const html = renderToStaticMarkup(<DiscardPile tiles={tiles} />);
+  const rowCount = (html.match(/<ul>/g) || []).length;
+  assert.strictEqual(rowCount, 2);
+  const firstRow = html.split('</ul>')[0];
+  const imgCount = (firstRow.match(/<img/g) || []).length;
+  assert.strictEqual(imgCount, 6);
+});
+
+test('position prop adds orientation class', () => {
+  const tiles = createTiles(1);
+  const html = renderToStaticMarkup(<DiscardPile tiles={tiles} position="top" />);
+  assert.ok(html.includes('class="discard-pile top"'));
+});

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -31,3 +31,13 @@ test('font sizes are reduced for small screens', async () => {
   assert.match(css, /body[^}]*font-size:\s*0\.875rem/);
   assert.match(css, /\.app h1[^}]*font-size:\s*1\.25rem/);
 });
+
+test('discard pile layout rules exist', async () => {
+  const css = await readCss();
+  assert.match(css, /\.discard-pile[^}]*display:\s*grid/);
+  assert.match(css, /\.discard-pile[^}]*grid-template-columns:\s*repeat\(6/);
+  assert.match(css, /\.discard-pile\.top[^}]*grid-area:\s*top/);
+  assert.match(css, /\.discard-pile\.bottom[^}]*grid-area:\s*bottom/);
+  assert.match(css, /\.discard-pile\.left[^}]*grid-area:\s*left/);
+  assert.match(css, /\.discard-pile\.right[^}]*grid-area:\s*right/);
+});


### PR DESCRIPTION
## Summary
- add `DiscardPile` React component for grouped discards
- export `DiscardPile` from web package
- extend stylesheet with `.discard-pile` grid layout and positional classes
- test static markup for `DiscardPile`
- check CSS for new discard pile rules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860d4b3a4a4832a838872c79c1f1f8e