### PR TITLE
Enable tile click to discard

### DIFF
--- a/web/src/components/Hand.tsx
+++ b/web/src/components/Hand.tsx
@@ -11,8 +11,13 @@ export function Hand({ tiles, onDiscard }: HandProps): JSX.Element {
     <ul className="hand">
       {tiles.map((tile, i) => (
         <li key={i}>
-          <TileImage tile={tile} />
-          <button aria-label="Discard" onClick={() => onDiscard(i)}>🗑️</button>
+          <button
+            className="tile-button"
+            aria-label="Discard"
+            onClick={() => onDiscard(i)}
+          >
+            <TileImage tile={tile} />
+          </button>
         </li>
       ))}
     </ul>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -62,6 +62,14 @@ button {
   margin-left: 0.5rem;
 }
 
+.hand .tile-button {
+  margin-left: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
 .board {
   display: grid;
   grid-template-areas:

--- a/web/test/Hand.test.tsx
+++ b/web/test/Hand.test.tsx
@@ -10,7 +10,8 @@ test('Hand renders tile images', () => {
   const html = renderToStaticMarkup(
     <Hand tiles={tiles} onDiscard={() => {}} />
   );
-  assert.ok(html.includes('<img')); 
+  assert.ok(html.includes('<img'));
   assert.ok(html.includes('man-1.svg'));
   assert.ok(html.includes('aria-label="Discard"'));
+  assert.ok(html.includes('class="tile-button"'));
 });


### PR DESCRIPTION
## Summary
- remove trash icon from Hand tiles
- allow discarding by clicking the tile itself
- style tile button and update test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860d6b0a1bc832abe4842e58768598e