### PR TITLE
Update board layout docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm run dev -w web
 
 Then open `http://localhost:5173` in your browser.
 
-The board layout places each player's area around the center. At this stage only
+The board layout places each player's area around the center. Discards are displayed as a traditional 河 with tiles aligned per seat. At this stage only
 the bottom player shows the actual hand and discard pile. Further layout details
 are described in [docs/board-layout.md](docs/board-layout.md).
 

--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -7,6 +7,7 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 - The local player's hand is shown along the bottom edge.
 - Tiles within each hand are laid out horizontally, matching a traditional table view.
 - Each player's discard pile (河) sits directly in front of their hand. For the bottom player this means discards appear above the hand.
+- Discards are grouped into rows of six to form a compact river. The `DiscardPile` component adds orientation classes so each seat's river aligns toward the center of the table.
 - Melded tiles (calls such as chi or pon) align to the right of that player's discard pile. This keeps the main hand centered while revealing open sets.
 - Opponents occupy the top, left and right edges, surrounding a central area used for wall tiles or indicators.
 


### PR DESCRIPTION
## Summary
- detail the river layout in board-layout docs
- note that discards show as a traditional river in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860dad00bf8832ab0d301208d714fa9