### PR TITLE
Update GameBoard to use DiscardPile

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -7,6 +7,7 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 - The local player's hand is shown along the bottom edge.
 - Tiles within each hand are laid out horizontally, matching a traditional table view.
 - Each player's discard pile (河) sits directly in front of their hand. For the bottom player this means discards appear above the hand.
+- Discards are arranged in rows of up to six tiles using a grid layout.
 - Melded tiles (calls such as chi or pon) align to the right of that player's discard pile. This keeps the main hand centered while revealing open sets.
 - Opponents occupy the top, left and right edges, surrounding a central area used for wall tiles or indicators.
 

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -1,6 +1,6 @@
 import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
-import { Discards } from './Discards.js';
+import { DiscardPile } from './DiscardPile.js';
 import { Melds } from './Melds.js';
 
 export interface GameBoardProps {
@@ -16,21 +16,21 @@ export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDi
     <div className="board">
       <div className="player-area top">
         <p>Player 2</p>
-        <Discards tiles={playerDiscards[1] ?? []} />
+        <DiscardPile tiles={playerDiscards[1] ?? []} position="top" />
       </div>
       <div className="player-area left">
         <p>Player 3</p>
-        <Discards tiles={playerDiscards[2] ?? []} />
+        <DiscardPile tiles={playerDiscards[2] ?? []} position="left" />
       </div>
       <div className="center">Center</div>
       <div className="player-area right">
         <p>Player 4</p>
-        <Discards tiles={playerDiscards[3] ?? []} />
+        <DiscardPile tiles={playerDiscards[3] ?? []} position="right" />
       </div>
       <div className="player-area bottom">
         <div className="meld-discard">
           <Melds melds={currentMelds} />
-          <Discards tiles={playerDiscards[0] ?? []} />
+          <DiscardPile tiles={playerDiscards[0] ?? []} position="bottom" />
         </div>
         <Hand tiles={currentHand} onDiscard={onDiscard} />
       </div>

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { GameBoard } from '../src/components/GameBoard.js';
 import { Tile } from '@mymahjong/core';
 
-test('GameBoard renders hand, discards and melds', () => {
+test('GameBoard renders hand, discard piles and melds', () => {
   const tiles = [new Tile({ suit: 'man', value: 1 })];
   const discards = [new Tile({ suit: 'pin', value: 2 })];
   const discardsByPlayer = [discards, [], [], []];
@@ -18,4 +18,6 @@ test('GameBoard renders hand, discards and melds', () => {
   assert.ok(html.includes('man-1.svg'));
   assert.ok(html.includes('pin-2.svg'));
   assert.ok(html.includes('sou-3.svg'));
+  assert.ok(html.includes('class="discard-pile bottom"'));
+  assert.ok(html.includes('class="discard-pile top"'));
 });


### PR DESCRIPTION
## Summary
- integrate `DiscardPile` into `GameBoard`
- test updated layout with discard piles
- document discard pile grid layout

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860dbfa9c24832a89842a157629258e