### PR TITLE
Add iipeikou scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,19 @@ status and a suggested roadmap for extending the rules.
   - `tanyao` (all simples)
   - `chiitoitsu` (seven pairs)
   - `yakuhai` triplets of winds or dragons
+  - `iipeikou` (two identical sequences)
 - Seat wind assignment and dealer rotation
-
--**Not Yet Implemented**
-
 - Round progression with changing round winds
+
+**Not Yet Implemented**
+
 - Additional yaku and detailed fu/han scoring
 - Riichi, dora indicators and other advanced rules
 
 **Recommended Next Steps**
 
 1. Expand the scoring system with more yaku and fu calculations
-2. Introduce round progression with seat winds and dealer rotation
-3. Track riichi state and dora indicators to enable more advanced rules
+2. Add riichi declarations and dora indicators for advanced rules
 
 
 ### Run Tests

--- a/core/README.md
+++ b/core/README.md
@@ -13,6 +13,7 @@ Currently implemented yaku detection includes:
 - Chiitoitsu (seven pairs)
 - Yakuhai (triplets of dragons or winds)
 - Toitoi (all triplets)
+- Iipeikou (two identical sequences)
 
 Fu is calculated using a simplified model based on meld composition and honor
 tiles. See `Score.ts` for details.

--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -89,6 +89,24 @@ export function detectSevenPairs(hand: Tile[]): boolean {
 }
 
 /**
+ * Detects the "iipeikou" yaku (two identical sequences).
+ * Sequences are identified using {@link analyzeHand} results.
+ */
+export function detectIipeikou(hand: Tile[]): boolean {
+  if (detectSevenPairs(hand)) return false;
+  const analysis = analyzeHand(hand);
+  if (!analysis) return false;
+  const sequences = analysis.melds
+    .filter(m => m.type === 'sequence')
+    .map(m => m.tiles.map(t => t.toString()).join(','));
+  const counts = new Map<string, number>();
+  for (const seq of sequences) {
+    counts.set(seq, (counts.get(seq) ?? 0) + 1);
+  }
+  return [...counts.values()].some(c => c >= 2);
+}
+
+/**
  * Detects triplets of honor tiles (winds or dragons).
  * Returns an array of yakuhai names for each qualifying triplet.
  */
@@ -133,6 +151,10 @@ export function calculateScore(hand: Tile[], options: ScoreOptions = {}): ScoreR
   if (detectToitoi(hand)) {
     yaku.push('toitoi');
     han += 2;
+  }
+  if (detectIipeikou(hand)) {
+    yaku.push('iipeikou');
+    han += 1;
   }
   const rawFu = calculateFu(hand);
   const fu = Math.ceil(rawFu / 10) * 10;

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -132,3 +132,30 @@ test('toitoi detection and fu calculation', () => {
   assert.strictEqual(result.fu, 40);
   assert.strictEqual(result.points, 5200);
 });
+
+test('iipeikou detection and scoring', () => {
+  const hand = [
+    // identical sequences
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    // additional sequences
+    new Tile({ suit: 'pin', value: 3 }),
+    new Tile({ suit: 'pin', value: 4 }),
+    new Tile({ suit: 'pin', value: 5 }),
+    new Tile({ suit: 'sou', value: 7 }),
+    new Tile({ suit: 'sou', value: 8 }),
+    new Tile({ suit: 'sou', value: 9 }),
+    // pair
+    new Tile({ suit: 'dragon', value: 'green' }),
+    new Tile({ suit: 'dragon', value: 'green' }),
+  ];
+  const result = calculateScore(hand);
+  assert.ok(result.yaku.includes('iipeikou'));
+  assert.strictEqual(result.han, 1);
+  assert.strictEqual(result.fu, 30);
+  assert.strictEqual(result.points, 1000);
+});


### PR DESCRIPTION
## Summary
- implement `detectIipeikou` and integrate into scoring
- document the new yaku
- update roadmap
- test iipeikou detection

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860dbf29698832a90b586f08ac3e6d8