### PR TITLE
Add dora indicator scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,19 @@ status and a suggested roadmap for extending the rules.
   - `chiitoitsu` (seven pairs)
   - `yakuhai` triplets of winds or dragons
   - `iipeikou` (two identical sequences)
+  - `dora` bonus tiles from indicators
 - Seat wind assignment and dealer rotation
 - Round progression with changing round winds
 
 **Not Yet Implemented**
 
 - Additional yaku and detailed fu/han scoring
-- Riichi, dora indicators and other advanced rules
+- Riichi and other advanced rules
 
 **Recommended Next Steps**
 
 1. Expand the scoring system with more yaku and fu calculations
-2. Add riichi declarations and dora indicators for advanced rules
+2. Add riichi declarations for advanced rules
 
 
 ### Run Tests

--- a/core/README.md
+++ b/core/README.md
@@ -14,6 +14,7 @@ Currently implemented yaku detection includes:
 - Yakuhai (triplets of dragons or winds)
 - Toitoi (all triplets)
 - Iipeikou (two identical sequences)
+- Dora (bonus tiles from indicators)
 
 Fu is calculated using a simplified model based on meld composition and honor
 tiles. See `Score.ts` for details.

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -159,3 +159,26 @@ test('iipeikou detection and scoring', () => {
   assert.strictEqual(result.fu, 30);
   assert.strictEqual(result.points, 1000);
 });
+
+test('dora indicators add han', () => {
+  const hand = [
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 3 }),
+    new Tile({ suit: 'pin', value: 4 }),
+    new Tile({ suit: 'sou', value: 2 }),
+    new Tile({ suit: 'sou', value: 3 }),
+    new Tile({ suit: 'sou', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'pin', value: 6 }),
+    new Tile({ suit: 'pin', value: 6 }),
+  ];
+  const indicators = [new Tile({ suit: 'pin', value: 2 })];
+  const result = calculateScore(hand, { doraIndicators: indicators });
+  assert.ok(result.yaku.includes('dora'));
+  assert.strictEqual(result.han, 2); // tanyao + 1 dora
+});


### PR DESCRIPTION
## Summary
- support dora indicators in ScoreOptions
- count dora tiles when calculating score
- document new feature in core README and repo README
- test dora indicator scoring logic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860de3b949c832a986ce3fccba88eb3