### PR TITLE
Add TileImage emoji fallback

### DIFF
--- a/web/src/components/TileImage.tsx
+++ b/web/src/components/TileImage.tsx
@@ -1,4 +1,5 @@
 import type { Tile } from '@mymahjong/core';
+import { useState } from 'react';
 
 // Images under public/tiles are emoji-based placeholders because
 // binary assets cannot be committed in this environment.
@@ -12,5 +13,17 @@ export function TileImage({ tile }: TileImageProps): JSX.Element {
   const base = (import.meta as any).env?.BASE_URL ?? '/';
   const src = `${base}tiles/${tile.toString()}.svg`;
   const alt = `${tile.suit} ${tile.value}`;
-  return <img src={src} alt={alt} />;
+  const [error, setError] = useState(false);
+
+  if (error) {
+    return (
+      <span className="tile-fallback" role="img" aria-label={alt}>
+        🀄
+      </span>
+    );
+  }
+
+  return (
+    <img className="tile-image" src={src} alt={alt} onError={() => setError(true)} />
+  );
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -70,6 +70,16 @@ button {
   cursor: pointer;
 }
 
+.tile-image,
+.tile-fallback {
+  width: 2rem;
+  height: 2rem;
+  display: inline-block;
+  text-align: center;
+  line-height: 2rem;
+  font-size: 1.5rem;
+}
+
 .board {
   display: grid;
   grid-template-areas:

--- a/web/test/TileImage.test.tsx
+++ b/web/test/TileImage.test.tsx
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { create, act } from 'react-test-renderer';
+import { TileImage } from '../src/components/TileImage.js';
+import { Tile } from '@mymahjong/core';
+
+test('TileImage falls back to emoji when image fails', () => {
+  const tile = new Tile({ suit: 'man', value: 1 });
+  const renderer = create(<TileImage tile={tile} />);
+  const img = renderer.root.findByType('img');
+  act(() => {
+    img.props.onError();
+  });
+  const span = renderer.root.findByType('span');
+  assert.equal(span.props.role, 'img');
+  assert.equal(span.props['aria-label'], 'man 1');
+  assert.equal(span.children[0], '🀄');
+  renderer.unmount();
+});


### PR DESCRIPTION
## Summary
- show a placeholder emoji if tile images fail to load
- style tile images and fallback so they retain a consistent size
- test TileImage fallback behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860dd640c04832ab5bb827e7f539a4e