### PR TITLE
Add riichi scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,19 @@ status and a suggested roadmap for extending the rules.
   - `yakuhai` triplets of winds or dragons
   - `iipeikou` (two identical sequences)
   - `dora` bonus tiles from indicators
-- Seat wind assignment and dealer rotation
+  - `riichi` declaration
+  - Seat wind assignment and dealer rotation
 - Round progression with changing round winds
 
 **Not Yet Implemented**
 
 - Additional yaku and detailed fu/han scoring
-- Riichi and other advanced rules
+- Other advanced rules (kan-based yaku, etc.)
 
 **Recommended Next Steps**
 
 1. Expand the scoring system with more yaku and fu calculations
-2. Add riichi declarations for advanced rules
+2. Add support for advanced rules beyond riichi
 
 
 ### Run Tests

--- a/core/README.md
+++ b/core/README.md
@@ -15,6 +15,7 @@ Currently implemented yaku detection includes:
 - Toitoi (all triplets)
 - Iipeikou (two identical sequences)
 - Dora (bonus tiles from indicators)
+- Riichi (declaring ready hand)
 
 Fu is calculated using a simplified model based on meld composition and honor
 tiles. See `Score.ts` for details.

--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -18,6 +18,8 @@ export interface ScoreOptions {
   win?: 'ron' | 'tsumo';
   /** Dora indicator tiles to count bonus han */
   doraIndicators?: Tile[];
+  /** Adds one han if the player declared riichi */
+  riichi?: boolean;
 }
 
 export interface ScoreResult {
@@ -157,7 +159,7 @@ function countDora(hand: Tile[], indicators: Tile[]): number {
 }
 
 export function calculateScore(hand: Tile[], options: ScoreOptions = {}): ScoreResult {
-  const { dealer = false, win = 'ron', doraIndicators = [] } = options;
+  const { dealer = false, win = 'ron', doraIndicators = [], riichi = false } = options;
   const yaku: string[] = [];
   let han = 0;
   if (detectTanyao(hand)) {
@@ -187,6 +189,10 @@ export function calculateScore(hand: Tile[], options: ScoreOptions = {}): ScoreR
       yaku.push('dora');
     }
     han += doraCount;
+  }
+  if (riichi) {
+    yaku.push('riichi');
+    han += 1;
   }
   const rawFu = calculateFu(hand);
   const fu = Math.ceil(rawFu / 10) * 10;

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -182,3 +182,25 @@ test('dora indicators add han', () => {
   assert.ok(result.yaku.includes('dora'));
   assert.strictEqual(result.han, 2); // tanyao + 1 dora
 });
+
+test('riichi adds han', () => {
+  const hand = [
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 3 }),
+    new Tile({ suit: 'pin', value: 4 }),
+    new Tile({ suit: 'sou', value: 2 }),
+    new Tile({ suit: 'sou', value: 3 }),
+    new Tile({ suit: 'sou', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'man', value: 7 }),
+    new Tile({ suit: 'pin', value: 6 }),
+    new Tile({ suit: 'pin', value: 6 }),
+  ];
+  const result = calculateScore(hand, { riichi: true });
+  assert.ok(result.yaku.includes('riichi'));
+  assert.strictEqual(result.han, 2); // tanyao + riichi
+});


### PR DESCRIPTION
## Summary
- add `riichi` option to scoring
- implement riichi han calculation
- document riichi in README files
- test riichi scoring

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860e553db60832a94e77bf218fcb50f