### PR TITLE
Fix discard pile spacing

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -14,5 +14,6 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 ## Digital Considerations
 
 To conserve screen space the interface avoids lengthy text and uses small buttons or icons. The layout reserves fixed regions for each player so elements do not jump as the game progresses. Media queries can stack the side players vertically when the viewport becomes narrow, ensuring controls remain accessible on phones.
+The discard areas maintain a minimum height so a player's hand does not shift when the first tile is thrown.
 
 These guidelines provide a baseline for implementing responsive components in the `web` package.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -23,6 +23,8 @@ body {
   justify-content: center;
   flex-wrap: wrap;
   overflow-y: auto;
+  /* Reserve space so the hand does not shift when the first row appears */
+  min-height: calc(2rem + 0.5rem);
 }
 
 .discard-pile {

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -18,6 +18,7 @@ test('style.css includes height and overflow rules', async () => {
   assert.match(css, /\.player-area\.left[^}]*min-height:\s*6rem/);
   assert.match(css, /\.player-area\.right[^}]*min-height:\s*6rem/);
   assert.match(css, /\.discards[^}]*overflow-y:\s*auto/);
+  assert.match(css, /\.discards[^}]*min-height:/);
   assert.match(css, /\.melds[^}]*overflow-y:\s*auto/);
 });
 


### PR DESCRIPTION
## Summary
- prevent hand from shifting when first tile is discarded by reserving space for discards
- document fixed discard area height
- test new CSS rule

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860e9007388832aacc011c7de2d977d