### PR TITLE
Support yakuhai winds

### DIFF
--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -116,7 +116,12 @@ export class Game {
     playerIndex = this.currentIndex,
     options: import('./Score.js').ScoreOptions = {}
   ): ScoreResult {
-    return calculateScore(this.players[playerIndex].hand, options);
+    const player = this.players[playerIndex];
+    return calculateScore(this.players[playerIndex].hand, {
+      seatWind: player.seatWind,
+      roundWind: this.roundWind,
+      ...options,
+    });
   }
 
   isWinningHand(playerIndex = this.currentIndex): boolean {

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -97,13 +97,35 @@ test('multiple yakuhai triplets each add han', () => {
     new Tile({ suit: 'pin', value: 2 }),
     new Tile({ suit: 'pin', value: 2 }),
   ];
-  const result = calculateScore(hand);
+  const result = calculateScore(hand, { seatWind: 'east', roundWind: 'south' });
   assert.ok(result.yaku.includes('yakuhai-green'));
   assert.ok(result.yaku.includes('yakuhai-east'));
   assert.strictEqual(result.han, 2);
   assert.strictEqual(result.rawFu, 28);
   assert.strictEqual(result.fu, 30);
   assert.strictEqual(result.points, 2000);
+});
+
+test('wind triplet not matching seat or round wind gives no yakuhai', () => {
+  const hand = [
+    // non-yakuhai wind triplet
+    new Tile({ suit: 'wind', value: 'west' }),
+    new Tile({ suit: 'wind', value: 'west' }),
+    new Tile({ suit: 'wind', value: 'west' }),
+    // sequences
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    // pair
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 2 }),
+  ];
+  const result = calculateScore(hand, { seatWind: 'east', roundWind: 'south' });
+  assert.strictEqual(result.han, 0);
+  assert.ok(!result.yaku.includes('yakuhai-west'));
 });
 
 test('toitoi detection and fu calculation', () => {


### PR DESCRIPTION
## Summary
- add `seatWind` and `roundWind` to `ScoreOptions`
- use the winds when detecting yakuhai
- supply winds from `Game.calculateScore`
- test yakuhai seat/round wind behaviour

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860eae9e84c832ab0e6d813d0dcea49