### PR TITLE
Add call buttons and tests

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -16,4 +16,8 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 To conserve screen space the interface avoids lengthy text and uses small buttons or icons. The layout reserves fixed regions for each player so elements do not jump as the game progresses. Media queries can stack the side players vertically when the viewport becomes narrow, ensuring controls remain accessible on phones.
 The discard areas maintain a minimum height so a player's hand does not shift when the first tile is thrown.
 
+### Meld Buttons
+
+The bottom player area now includes small "Pon", "Chi", "Kan" and "Ron" buttons beneath the hand. These trigger calls on the most recent discard from the right-hand opponent. Future versions may allow targeting any discard or provide icon-based controls.
+
 These guidelines provide a baseline for implementing responsive components in the `web` package.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { GameBoard } from './components/GameBoard.js';
 import { useGame } from './hooks/useGame.js';
 
 export default function App(): JSX.Element {
-  const { hand, playerDiscards, wallCount, draw, discard, score } = useGame();
+  const { hand, playerDiscards, melds, wallCount, draw, discard, pon, chi, kan, ron, score } = useGame();
   return (
     <div className="app">
       <h1>My Mahjong</h1>
@@ -11,7 +11,16 @@ export default function App(): JSX.Element {
       {score.han > 0 && (
         <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
       )}
-      <GameBoard currentHand={hand} playerDiscards={playerDiscards} onDiscard={discard} />
+      <GameBoard
+        currentHand={hand}
+        playerDiscards={playerDiscards}
+        currentMelds={melds}
+        onDiscard={discard}
+        onPon={pon}
+        onChi={chi}
+        onKan={kan}
+        onRon={ron}
+      />
     </div>
   );
 }

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -9,9 +9,13 @@ export interface GameBoardProps {
   playerDiscards: Tile[][];
   currentMelds?: Tile[][];
   onDiscard: (index: number) => void;
+  onPon?: (fromIndex: number) => void;
+  onChi?: (fromIndex: number) => void;
+  onKan?: (fromIndex: number) => void;
+  onRon?: (fromIndex: number) => void;
 }
 
-export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDiscard }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDiscard, onPon, onChi, onKan, onRon }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
       <div className="player-area top">
@@ -33,6 +37,12 @@ export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDi
           <Discards tiles={playerDiscards[0] ?? []} />
         </div>
         <Hand tiles={currentHand} onDiscard={onDiscard} />
+        <div className="meld-buttons">
+          <button onClick={() => onPon?.(3)}>Pon</button>
+          <button onClick={() => onChi?.(3)}>Chi</button>
+          <button onClick={() => onKan?.(3)}>Kan</button>
+          <button onClick={() => onRon?.(3)}>Ron</button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/hooks/useGame.ts
+++ b/web/src/hooks/useGame.ts
@@ -9,6 +9,7 @@ interface GameState {
    * The first entry corresponds to the local player.
    */
   playerDiscards: Tile[][];
+  melds: Tile[][];
   wallCount: number;
   score: ScoreResult;
 }
@@ -16,6 +17,10 @@ interface GameState {
 export function useGame(game?: Game): GameState & {
   draw: () => Tile;
   discard: (index: number) => Tile;
+  pon: (fromIndex: number) => void;
+  chi: (fromIndex: number) => void;
+  kan: (fromIndex: number) => void;
+  ron: (fromIndex: number) => boolean;
 } {
   const [gameInstance] = useState(() => {
     const g = game ?? new Game(1);
@@ -29,6 +34,7 @@ export function useGame(game?: Game): GameState & {
     hand: [...gameInstance.players[0].hand],
     discards: [...gameInstance.players[0].discards],
     playerDiscards: gameInstance.players.map(p => [...p.discards]),
+    melds: gameInstance.players[0].melds.map(m => [...m]),
     wallCount: gameInstance.wall.count,
     score: gameInstance.calculateScore(0),
   }));
@@ -38,6 +44,7 @@ export function useGame(game?: Game): GameState & {
       hand: [...gameInstance.players[0].hand],
       discards: [...gameInstance.players[0].discards],
       playerDiscards: gameInstance.players.map(p => [...p.discards]),
+      melds: gameInstance.players[0].melds.map(m => [...m]),
       wallCount: gameInstance.wall.count,
       score: gameInstance.calculateScore(0),
     });
@@ -55,5 +62,26 @@ export function useGame(game?: Game): GameState & {
     return tile;
   };
 
-  return { ...state, draw, discard };
+  const pon = (fromIndex: number) => {
+    gameInstance.callPon(0, fromIndex);
+    sync();
+  };
+
+  const chi = (fromIndex: number) => {
+    gameInstance.callChi(0, fromIndex);
+    sync();
+  };
+
+  const kan = (fromIndex: number) => {
+    gameInstance.callKan(0, fromIndex);
+    sync();
+  };
+
+  const ron = (fromIndex: number) => {
+    const result = gameInstance.declareRon(0, fromIndex);
+    sync();
+    return result;
+  };
+
+  return { ...state, draw, discard, pon, chi, kan, ron };
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -129,6 +129,13 @@ button {
   flex-wrap: wrap;
 }
 
+.meld-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
 .melds {
   list-style: none;
   padding: 0;

--- a/web/test/useGame.test.tsx
+++ b/web/test/useGame.test.tsx
@@ -12,6 +12,8 @@ interface GameHandle {
   score: ReturnType<typeof useGame>['score'];
   draw: () => unknown;
   discard: (index: number) => unknown;
+  pon: (fromIndex: number) => unknown;
+  chi: (fromIndex: number) => unknown;
 }
 
 function createFixedGame(): Game {
@@ -22,6 +24,26 @@ function createFixedGame(): Game {
   return g;
 }
 
+function createPonGame(): Game {
+  const wall = new Wall([]);
+  const g = new Game(2, wall);
+  g.players[0].hand.push(new Tile({ suit: 'man', value: 3 }), new Tile({ suit: 'man', value: 3 }));
+  const discarded = new Tile({ suit: 'man', value: 3 });
+  g.players[1].hand.push(discarded);
+  g.players[1].discard(0);
+  return g;
+}
+
+function createChiGame(): Game {
+  const wall = new Wall([]);
+  const g = new Game(2, wall);
+  g.players[0].hand.push(new Tile({ suit: 'man', value: 1 }), new Tile({ suit: 'man', value: 3 }));
+  const discarded = new Tile({ suit: 'man', value: 2 });
+  g.players[1].hand.push(discarded);
+  g.players[1].discard(0);
+  return g;
+}
+
 const GameHarness = forwardRef<GameHandle>((_props, ref) => {
   const state = useGame(createFixedGame());
   useImperativeHandle(ref, () => state);
@@ -29,6 +51,22 @@ const GameHarness = forwardRef<GameHandle>((_props, ref) => {
 });
 
 GameHarness.displayName = 'GameHarness';
+
+const PonHarness = forwardRef<GameHandle>((_props, ref) => {
+  const state = useGame(createPonGame());
+  useImperativeHandle(ref, () => state);
+  return null;
+});
+
+PonHarness.displayName = 'PonHarness';
+
+const ChiHarness = forwardRef<GameHandle>((_props, ref) => {
+  const state = useGame(createChiGame());
+  useImperativeHandle(ref, () => state);
+  return null;
+});
+
+ChiHarness.displayName = 'ChiHarness';
 
 test('draw and discard update state', () => {
   const ref = React.createRef<GameHandle>();
@@ -55,6 +93,40 @@ test('draw and discard update state', () => {
     ref.current!.playerDiscards[0].length,
     initialPlayerDiscards[0] + 1
   );
+
+  renderer.unmount();
+});
+
+test('pon updates melds and discards', () => {
+  const ref = React.createRef<GameHandle>();
+  const renderer = create(<PonHarness ref={ref} />);
+  assert.ok(ref.current);
+  const initialHand = ref.current!.hand.length;
+  const initialOpponentDiscards = ref.current!.playerDiscards[1].length;
+
+  act(() => {
+    ref.current!.pon(1);
+  });
+
+  assert.strictEqual(ref.current!.playerDiscards[1].length, initialOpponentDiscards - 1);
+  assert.strictEqual(ref.current!.hand.length, initialHand - 2);
+
+  renderer.unmount();
+});
+
+test('chi updates melds and discards', () => {
+  const ref = React.createRef<GameHandle>();
+  const renderer = create(<ChiHarness ref={ref} />);
+  assert.ok(ref.current);
+  const initialHand = ref.current!.hand.length;
+  const initialOpponentDiscards = ref.current!.playerDiscards[1].length;
+
+  act(() => {
+    ref.current!.chi(1);
+  });
+
+  assert.strictEqual(ref.current!.playerDiscards[1].length, initialOpponentDiscards - 1);
+  assert.strictEqual(ref.current!.hand.length, initialHand - 2);
 
   renderer.unmount();
 });


### PR DESCRIPTION
## Summary
- expose meld controls from the `useGame` hook
- add Pon/Chi/Kan/Ron buttons to the bottom player area
- wire App to pass meld actions to the board
- style and document the new buttons
- test pon and chi logic in `useGame`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860ec853548832ab5f0dc10aeab59d3