### PR TITLE
Add center tile display

### DIFF
--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -12,6 +12,7 @@ export class Game {
   private currentIndex = 0;
   private dealerIndex = 0;
   private roundWindIndex = 0;
+  readonly doraIndicators: Tile[] = [];
 
   /**
    * Seat winds assigned to each player in the same order as `players`.
@@ -26,6 +27,8 @@ export class Game {
     this.wall = wall;
     this.players = Array.from({ length: playerCount }, () => new Player());
     this.assignSeatWinds();
+    const indicator = this.wall.peek();
+    if (indicator) this.doraIndicators.push(indicator);
   }
 
   private assignSeatWinds(): void {
@@ -120,6 +123,7 @@ export class Game {
     return calculateScore(this.players[playerIndex].hand, {
       seatWind: player.seatWind,
       roundWind: this.roundWind,
+      doraIndicators: this.doraIndicators,
       ...options,
     });
   }

--- a/core/src/Wall.ts
+++ b/core/src/Wall.ts
@@ -56,6 +56,11 @@ export class Wall {
     return this.tiles.pop();
   }
 
+  /** Peek at a tile without removing it. 0 refers to the next tile to be drawn. */
+  peek(index = 0): Tile | undefined {
+    return this.tiles[this.tiles.length - 1 - index];
+  }
+
   get count(): number {
     return this.tiles.length;
   }

--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -18,5 +18,6 @@ This document summarizes the ongoing discussion about how to present the Mahjong
 3. Add media queries that reorganize the grid on small screens (e.g. stacking side players above the center).
 4. Replace textual control labels with icons and add appropriate `aria-label` attributes.
 5. Ensure the layout uses flexible units so it remains usable on both desktops and phones.
+6. Show dora indicators and remaining wall tiles in the center display.
 
 These tasks will gradually evolve the prototype toward a more intuitive and responsive interface.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { GameBoard } from './components/GameBoard.js';
 import { useGame } from './hooks/useGame.js';
 
 export default function App(): JSX.Element {
-  const { hand, playerDiscards, wallCount, draw, discard, score } = useGame();
+  const { hand, playerDiscards, wallCount, doraIndicators, draw, discard, score } = useGame();
   return (
     <div className="app">
       <h1>My Mahjong</h1>
@@ -11,7 +11,12 @@ export default function App(): JSX.Element {
       {score.han > 0 && (
         <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
       )}
-      <GameBoard currentHand={hand} playerDiscards={playerDiscards} onDiscard={discard} />
+      <GameBoard
+        currentHand={hand}
+        playerDiscards={playerDiscards}
+        centerTiles={doraIndicators}
+        onDiscard={discard}
+      />
     </div>
   );
 }

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -2,16 +2,19 @@ import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
 import { Discards } from './Discards.js';
 import { Melds } from './Melds.js';
+import { TileImage } from './TileImage.js';
 
 export interface GameBoardProps {
   currentHand: Tile[];
   /** Discard piles for all players in game order. */
   playerDiscards: Tile[][];
+  /** Tiles shown in the center such as dora indicators. */
+  centerTiles?: Tile[];
   currentMelds?: Tile[][];
   onDiscard: (index: number) => void;
 }
 
-export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDiscard }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, playerDiscards, centerTiles = [], currentMelds = [], onDiscard }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
       <div className="player-area top">
@@ -22,7 +25,11 @@ export function GameBoard({ currentHand, playerDiscards, currentMelds = [], onDi
         <p>Player 3</p>
         <Discards tiles={playerDiscards[2] ?? []} />
       </div>
-      <div className="center">Center</div>
+      <div className="center">
+        {centerTiles.map((t, i) => (
+          <TileImage key={i} tile={t} />
+        ))}
+      </div>
       <div className="player-area right">
         <p>Player 4</p>
         <Discards tiles={playerDiscards[3] ?? []} />

--- a/web/src/hooks/useGame.ts
+++ b/web/src/hooks/useGame.ts
@@ -10,6 +10,7 @@ interface GameState {
    */
   playerDiscards: Tile[][];
   wallCount: number;
+  doraIndicators: Tile[];
   score: ScoreResult;
 }
 
@@ -30,6 +31,7 @@ export function useGame(game?: Game): GameState & {
     discards: [...gameInstance.players[0].discards],
     playerDiscards: gameInstance.players.map(p => [...p.discards]),
     wallCount: gameInstance.wall.count,
+    doraIndicators: [...gameInstance.doraIndicators],
     score: gameInstance.calculateScore(0),
   }));
 
@@ -39,6 +41,7 @@ export function useGame(game?: Game): GameState & {
       discards: [...gameInstance.players[0].discards],
       playerDiscards: gameInstance.players.map(p => [...p.discards]),
       wallCount: gameInstance.wall.count,
+      doraIndicators: [...gameInstance.doraIndicators],
       score: gameInstance.calculateScore(0),
     });
   };

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -5,17 +5,25 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { GameBoard } from '../src/components/GameBoard.js';
 import { Tile } from '@mymahjong/core';
 
-test('GameBoard renders hand, discards and melds', () => {
+test('GameBoard renders hand, discards, melds and center tiles', () => {
   const tiles = [new Tile({ suit: 'man', value: 1 })];
   const discards = [new Tile({ suit: 'pin', value: 2 })];
   const discardsByPlayer = [discards, [], [], []];
   const melds = [[new Tile({ suit: 'sou', value: 3 })]];
+  const center = [new Tile({ suit: 'wind', value: 'east' })];
   const html = renderToStaticMarkup(
-    <GameBoard currentHand={tiles} playerDiscards={discardsByPlayer} currentMelds={melds} onDiscard={() => {}} />
+    <GameBoard
+      currentHand={tiles}
+      playerDiscards={discardsByPlayer}
+      currentMelds={melds}
+      centerTiles={center}
+      onDiscard={() => {}}
+    />
   );
   const count = (html.match(/class="player-area/g) || []).length;
   assert.equal(count, 4);
   assert.ok(html.includes('man-1.svg'));
   assert.ok(html.includes('pin-2.svg'));
   assert.ok(html.includes('sou-3.svg'));
+  assert.ok(html.includes('wind-east.svg'));
 });

--- a/web/test/useGame.test.tsx
+++ b/web/test/useGame.test.tsx
@@ -9,6 +9,7 @@ interface GameHandle {
   hand: ReturnType<typeof useGame>['hand'];
   discards: ReturnType<typeof useGame>['discards'];
   playerDiscards: ReturnType<typeof useGame>['playerDiscards'];
+  doraIndicators: ReturnType<typeof useGame>['doraIndicators'];
   score: ReturnType<typeof useGame>['score'];
   draw: () => unknown;
   discard: (index: number) => unknown;
@@ -34,6 +35,7 @@ test('draw and discard update state', () => {
   const ref = React.createRef<GameHandle>();
   const renderer = create(<GameHarness ref={ref} />);
   assert.ok(ref.current);
+  assert.ok(ref.current!.doraIndicators.length >= 0);
   const initialHand = ref.current!.hand.length;
   const initialDiscards = ref.current!.discards.length;
   const initialPlayerDiscards = ref.current!.playerDiscards.map(d => d.length);


### PR DESCRIPTION
## Summary
- show tiles in the center of `GameBoard`
- surface dora indicators via `useGame`
- add peek helper on `Wall` and store indicator in `Game`
- update docs with center display task
- extend tests for new props

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860ec7ebdb8832a930ab636e745d855