### PR TITLE
Add pinfu yaku detection

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -14,6 +14,7 @@ Currently implemented yaku detection includes:
 - Yakuhai (triplets of dragons or winds)
 - Toitoi (all triplets)
 - Iipeikou (two identical sequences)
+- Pinfu (all sequences with no extra fu)
 - Dora (bonus tiles from indicators)
 - Riichi (declaring ready hand)
 

--- a/core/src/Score.ts
+++ b/core/src/Score.ts
@@ -112,6 +112,22 @@ export function detectIipeikou(hand: Tile[]): boolean {
 }
 
 /**
+ * Detects the "pinfu" yaku (all sequences with no extra fu). This simplified
+ * version only checks that the hand is composed entirely of sequences, the pair
+ * is not an honor tile and that fu calculation yields the base 20 fu. Wait
+ * shapes are not analysed in detail.
+ */
+export function detectPinfu(hand: Tile[]): boolean {
+  if (detectSevenPairs(hand)) return false;
+  const analysis = analyzeHand(hand);
+  if (!analysis) return false;
+  if (!analysis.melds.every(m => m.type === 'sequence')) return false;
+  const pairTile = analysis.pair[0];
+  if (pairTile.suit === 'wind' || pairTile.suit === 'dragon') return false;
+  return calculateFu(hand) === 20;
+}
+
+/**
  * Detects triplets of honor tiles (winds or dragons).
  * Returns an array of yakuhai names for each qualifying triplet.
  */
@@ -181,6 +197,10 @@ export function calculateScore(hand: Tile[], options: ScoreOptions = {}): ScoreR
   }
   if (detectIipeikou(hand)) {
     yaku.push('iipeikou');
+    han += 1;
+  }
+  if (detectPinfu(hand)) {
+    yaku.push('pinfu');
     han += 1;
   }
   if (doraIndicators.length > 0) {

--- a/core/test/score.test.ts
+++ b/core/test/score.test.ts
@@ -20,10 +20,11 @@ test('tanyao detection and scoring', () => {
     new Tile({ suit: 'pin', value: 6 }),
   ];
   const result = calculateScore(hand);
-  assert.deepStrictEqual(result.yaku, ['tanyao']);
-  assert.strictEqual(result.han, 1);
+  assert.ok(result.yaku.includes('tanyao'));
+  assert.ok(result.yaku.includes('pinfu'));
+  assert.strictEqual(result.han, 2); // tanyao + pinfu
   assert.strictEqual(result.fu, 20);
-  assert.strictEqual(result.points, 700);
+  assert.strictEqual(result.points, 1300);
 });
 
 test('chiitoitsu detection and scoring', () => {
@@ -160,6 +161,30 @@ test('iipeikou detection and scoring', () => {
   assert.strictEqual(result.points, 1000);
 });
 
+test('pinfu detection and scoring', () => {
+  const hand = [
+    new Tile({ suit: 'man', value: 1 }),
+    new Tile({ suit: 'man', value: 2 }),
+    new Tile({ suit: 'man', value: 3 }),
+    new Tile({ suit: 'pin', value: 2 }),
+    new Tile({ suit: 'pin', value: 3 }),
+    new Tile({ suit: 'pin', value: 4 }),
+    new Tile({ suit: 'sou', value: 6 }),
+    new Tile({ suit: 'sou', value: 7 }),
+    new Tile({ suit: 'sou', value: 8 }),
+    new Tile({ suit: 'man', value: 4 }),
+    new Tile({ suit: 'man', value: 5 }),
+    new Tile({ suit: 'man', value: 6 }),
+    new Tile({ suit: 'pin', value: 5 }),
+    new Tile({ suit: 'pin', value: 5 }),
+  ];
+  const result = calculateScore(hand);
+  assert.ok(result.yaku.includes('pinfu'));
+  assert.strictEqual(result.han, 1);
+  assert.strictEqual(result.fu, 20);
+  assert.strictEqual(result.points, 700);
+});
+
 test('dora indicators add han', () => {
   const hand = [
     new Tile({ suit: 'man', value: 2 }),
@@ -180,7 +205,9 @@ test('dora indicators add han', () => {
   const indicators = [new Tile({ suit: 'pin', value: 2 })];
   const result = calculateScore(hand, { doraIndicators: indicators });
   assert.ok(result.yaku.includes('dora'));
-  assert.strictEqual(result.han, 2); // tanyao + 1 dora
+  assert.ok(result.yaku.includes('tanyao'));
+  assert.ok(result.yaku.includes('pinfu'));
+  assert.strictEqual(result.han, 3); // tanyao + pinfu + 1 dora
 });
 
 test('riichi adds han', () => {
@@ -202,5 +229,7 @@ test('riichi adds han', () => {
   ];
   const result = calculateScore(hand, { riichi: true });
   assert.ok(result.yaku.includes('riichi'));
-  assert.strictEqual(result.han, 2); // tanyao + riichi
+  assert.ok(result.yaku.includes('tanyao'));
+  assert.ok(result.yaku.includes('pinfu'));
+  assert.strictEqual(result.han, 3); // tanyao + pinfu + riichi
 });


### PR DESCRIPTION
## Summary
- score detection for pinfu (all sequences, non-honor pair)
- add pinfu to calculateScore
- test pinfu behaviour and update existing tests
- document pinfu support in core README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860ec772964832a8df928cfb5913b2d