### PR TITLE
Fix discard pile layout

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -15,6 +15,7 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 
 To conserve screen space the interface avoids lengthy text and uses small buttons or icons. The layout reserves fixed regions for each player so elements do not jump as the game progresses. Media queries can stack the side players vertically when the viewport becomes narrow, ensuring controls remain accessible on phones.
 The discard areas maintain a minimum height so a player's hand does not shift when the first tile is thrown.
+This is enforced via the `.discard-pile` CSS rule which reserves enough space for one row of tiles.
 
 ### Meld Buttons
 

--- a/web/src/components/DiscardPile.tsx
+++ b/web/src/components/DiscardPile.tsx
@@ -12,9 +12,9 @@ export function DiscardPile({ tiles, position }: DiscardPileProps): JSX.Element 
     rows.push(tiles.slice(i, i + 6));
   }
   return (
-    <div className={`discard-pile${position ? ` ${position}` : ''}`}> 
+    <div className={`discard-pile${position ? ` ${position}` : ''}`}>
       {rows.map((row, rowIndex) => (
-        <ul key={rowIndex}>
+        <ul key={rowIndex} className="discard-row">
           {row.map((t, i) => (
             <li key={i}>
               <TileImage tile={t} />

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -18,7 +18,7 @@ export interface GameBoardProps {
   onRon?: (fromIndex: number) => void;
 }
 
-export function GameBoard({ currentHand, playerDiscards, currentMelds = [], currentMelds = [], onDiscard, onPon, onChi, onKan, onRon }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, playerDiscards, centerTiles = [], currentMelds = [], onDiscard, onPon, onChi, onKan, onRon }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
       <div className="player-area top">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -32,6 +32,12 @@ body {
   grid-template-columns: repeat(6, auto);
   gap: 0.25rem;
   justify-content: center;
+  /* Reserve space so the hand does not shift when the first row appears */
+  min-height: calc(2rem + 0.5rem);
+}
+.discard-pile .discard-row {
+  display: flex;
+  gap: 0.25rem;
 }
 
 .discard-pile.top {

--- a/web/test/DiscardPile.test.tsx
+++ b/web/test/DiscardPile.test.tsx
@@ -15,7 +15,7 @@ function createTiles(n: number): Tile[] {
 test('DiscardPile groups tiles into rows of six', () => {
   const tiles = createTiles(8);
   const html = renderToStaticMarkup(<DiscardPile tiles={tiles} />);
-  const rowCount = (html.match(/<ul>/g) || []).length;
+  const rowCount = (html.match(/<ul class=\"discard-row\">/g) || []).length;
   assert.strictEqual(rowCount, 2);
   const firstRow = html.split('</ul>')[0];
   const imgCount = (firstRow.match(/<img/g) || []).length;
@@ -26,4 +26,10 @@ test('position prop adds orientation class', () => {
   const tiles = createTiles(1);
   const html = renderToStaticMarkup(<DiscardPile tiles={tiles} position="top" />);
   assert.ok(html.includes('class="discard-pile top"'));
+});
+
+test('rows use discard-row class for horizontal layout', () => {
+  const tiles = createTiles(4);
+  const html = renderToStaticMarkup(<DiscardPile tiles={tiles} />);
+  assert.ok(html.includes('class="discard-row"'));
 });

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -19,6 +19,7 @@ test('style.css includes height and overflow rules', async () => {
   assert.match(css, /\.player-area\.right[^}]*min-height:\s*6rem/);
   assert.match(css, /\.discards[^}]*overflow-y:\s*auto/);
   assert.match(css, /\.discards[^}]*min-height:/);
+  assert.match(css, /\.discard-pile[^}]*min-height:/);
   assert.match(css, /\.melds[^}]*overflow-y:\s*auto/);
 });
 
@@ -41,4 +42,5 @@ test('discard pile layout rules exist', async () => {
   assert.match(css, /\.discard-pile\.bottom[^}]*grid-area:\s*bottom/);
   assert.match(css, /\.discard-pile\.left[^}]*grid-area:\s*left/);
   assert.match(css, /\.discard-pile\.right[^}]*grid-area:\s*right/);
+  assert.match(css, /\.discard-pile\s+\.discard-row[^}]*display:\s*flex/);
 });


### PR DESCRIPTION
## Summary
- ensure DiscardPile rows are laid out horizontally
- fix GameBoard props default values
- reserve space for discard piles so the hand doesn't shift
- test discard rows class and style rules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860f1d5d120832a8cf908e7986fa152