### PR TITLE
Implement kan replacement draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ status and a suggested roadmap for extending the rules.
 - Basic win detection for standard hands
 - Win by ron (claiming another player's discard)
 - Ability to call pon, chi and kan (melds)
+- Replacement tile draw and extra dora indicator after kan
 - Scoring for:
   - `tanyao` (all simples)
   - `chiitoitsu` (seven pairs)

--- a/core/README.md
+++ b/core/README.md
@@ -18,6 +18,7 @@ Currently implemented yaku detection includes:
 - Pinfu (all sequences with no extra fu)
 - Dora (bonus tiles from indicators)
 - Riichi (declaring ready hand)
+- Kan draws a replacement tile and reveals an extra dora indicator
 
 Fu is calculated using a simplified model based on meld composition and honor
 tiles. See `Score.ts` for details.

--- a/core/src/Game.ts
+++ b/core/src/Game.ts
@@ -99,6 +99,11 @@ export class Game {
     }
     player.kan(tile);
     this.currentIndex = playerIndex;
+    const indicator = this.wall.peek(this.doraIndicators.length);
+    if (indicator) this.doraIndicators.push(indicator);
+    const drawn = this.wall.draw();
+    if (!drawn) throw new Error('Wall exhausted');
+    player.draw(drawn);
   }
 
   declareRon(playerIndex: number, fromIndex: number): boolean {

--- a/core/test/kan.test.ts
+++ b/core/test/kan.test.ts
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict';
 import { Game, Wall, Tile } from '../src/index.js';
 
 test('player can call kan on a discard', () => {
-  const wall = new Wall([]);
+  const wall = new Wall([
+    new Tile({ suit: 'sou', value: 1 }),
+    new Tile({ suit: 'pin', value: 9 }),
+  ]);
   const game = new Game(2, wall);
   game.players[1].hand.push(
     new Tile({ suit: 'man', value: 5 }),
@@ -13,9 +16,11 @@ test('player can call kan on a discard', () => {
   const tile = new Tile({ suit: 'man', value: 5 });
   game.players[0].hand.push(tile);
   game.players[0].discard(0);
+  const indicatorsBefore = game.doraIndicators.length;
   game.callKan(1, 0);
   assert.strictEqual(game.players[1].melds.length, 1);
-  assert.strictEqual(game.players[1].hand.length, 0);
+  assert.strictEqual(game.players[1].hand.length, 1);
   assert.strictEqual(game.players[1].melds[0].length, 4);
+  assert.strictEqual(game.doraIndicators.length, indicatorsBefore + 1);
   assert.strictEqual(game['currentIndex'], 1);
 });


### PR DESCRIPTION
## Summary
- add replacement draw and reveal new dora indicator when calling kan
- adjust kan test for the new behaviour
- document kan effects in READMEs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860f98f1fe8832a877ed55cf7793902