### PR TITLE
Add center wall count display

### DIFF
--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -18,6 +18,6 @@ This document summarizes the ongoing discussion about how to present the Mahjong
 3. Add media queries that reorganize the grid on small screens (e.g. stacking side players above the center).
 4. Replace textual control labels with icons and add appropriate `aria-label` attributes.
 5. Ensure the layout uses flexible units so it remains usable on both desktops and phones.
-6. Show dora indicators and remaining wall tiles in the center display.
+6. Show dora indicators and remaining wall tiles in the center display. **Done.**
 
 These tasks will gradually evolve the prototype toward a more intuitive and responsive interface.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,6 @@ export default function App(): JSX.Element {
   return (
     <div className="app">
       <h1>My Mahjong</h1>
-      <p>Wall tiles left: {wallCount}</p>
       <button onClick={draw} disabled={wallCount === 0} aria-label="Draw">🀄</button>
       {score.han > 0 && (
         <p className="score">{`${score.yaku.join(', ')}: ${score.points} points`}</p>
@@ -17,6 +16,7 @@ export default function App(): JSX.Element {
         currentHand={hand}
         playerDiscards={playerDiscards}
         centerTiles={doraIndicators}
+        wallCount={wallCount}
         currentMelds={melds}
         onDiscard={discard}
         onPon={pon}

--- a/web/src/components/CenterDisplay.tsx
+++ b/web/src/components/CenterDisplay.tsx
@@ -1,0 +1,24 @@
+import type { Tile } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
+
+export interface CenterDisplayProps {
+  /** Tiles shown in the center such as dora indicators. */
+  tiles: Tile[];
+  /** Number of tiles remaining in the wall. */
+  wallCount: number;
+}
+
+export function CenterDisplay({ tiles, wallCount }: CenterDisplayProps): JSX.Element {
+  return (
+    <div className="center">
+      <div className="dora-indicators">
+        {tiles.map((t, i) => (
+          <TileImage key={i} tile={t} />
+        ))}
+      </div>
+      <p className="wall-count" aria-label="Tiles left">
+        {wallCount}
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -2,7 +2,7 @@ import type { Tile } from '@mymahjong/core';
 import { Hand } from './Hand.js';
 import { DiscardPile } from './DiscardPile.js';
 import { Melds } from './Melds.js';
-import { TileImage } from './TileImage.js';
+import { CenterDisplay } from './CenterDisplay.js';
 
 export interface GameBoardProps {
   currentHand: Tile[];
@@ -10,6 +10,8 @@ export interface GameBoardProps {
   playerDiscards: Tile[][];
   /** Tiles shown in the center such as dora indicators. */
   centerTiles?: Tile[];
+  /** Number of tiles remaining in the wall. */
+  wallCount: number;
   currentMelds?: Tile[][];
   onDiscard: (index: number) => void;
   onPon?: (fromIndex: number) => void;
@@ -18,7 +20,7 @@ export interface GameBoardProps {
   onRon?: (fromIndex: number) => void;
 }
 
-export function GameBoard({ currentHand, playerDiscards, centerTiles = [], currentMelds = [], onDiscard, onPon, onChi, onKan, onRon }: GameBoardProps): JSX.Element {
+export function GameBoard({ currentHand, playerDiscards, centerTiles = [], wallCount, currentMelds = [], onDiscard, onPon, onChi, onKan, onRon }: GameBoardProps): JSX.Element {
   return (
     <div className="board">
       <div className="player-area top">
@@ -29,11 +31,7 @@ export function GameBoard({ currentHand, playerDiscards, centerTiles = [], curre
         <p>Player 3</p>
         <DiscardPile tiles={playerDiscards[2] ?? []} position="left" />
       </div>
-      <div className="center">
-        {centerTiles.map((t, i) => (
-          <TileImage key={i} tile={t} />
-        ))}
-      </div>
+      <CenterDisplay tiles={centerTiles} wallCount={wallCount} />
       <div className="player-area right">
         <p>Player 4</p>
         <DiscardPile tiles={playerDiscards[3] ?? []} position="right" />

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -7,3 +7,4 @@ export { Melds } from './components/Melds.js';
 export { TileImage } from './components/TileImage.js';
 export { DiscardPile } from './components/DiscardPile.js';
 export { ScoreBoard } from './components/ScoreBoard.js';
+export { CenterDisplay } from './components/CenterDisplay.js';

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -127,6 +127,14 @@ button {
   grid-area: center;
   text-align: center;
 }
+.center .dora-indicators {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+}
+.center .wall-count {
+  margin-top: 0.25rem;
+}
 
 .meld-discard {
   display: flex;

--- a/web/test/CenterDisplay.test.tsx
+++ b/web/test/CenterDisplay.test.tsx
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CenterDisplay } from '../src/components/CenterDisplay.js';
+import { Tile } from '@mymahjong/core';
+
+test('CenterDisplay shows dora indicators and wall count', () => {
+  const tiles = [new Tile({ suit: 'man', value: 5 })];
+  const html = renderToStaticMarkup(
+    <CenterDisplay tiles={tiles} wallCount={70} />
+  );
+  assert.ok(html.includes('man-5.svg'));
+  assert.ok(html.includes('70'));
+});

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -17,6 +17,7 @@ test('GameBoard renders hand, discards, melds and center tiles', () => {
       playerDiscards={discardsByPlayer}
       currentMelds={melds}
       centerTiles={center}
+      wallCount={50}
       onDiscard={() => {}}
     />
   );
@@ -26,4 +27,5 @@ test('GameBoard renders hand, discards, melds and center tiles', () => {
   assert.ok(html.includes('pin-2.svg'));
   assert.ok(html.includes('sou-3.svg'));
   assert.ok(html.includes('wind-east.svg'));
+  assert.ok(html.includes('50'));
 });


### PR DESCRIPTION
## Summary
- display dora indicators and wall tile count in a new `CenterDisplay` component
- use the new component in `GameBoard`
- remove wall text from `App`
- style the new center area
- update GUI design doc
- add tests for `CenterDisplay`
- adjust `GameBoard` tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860fa808714832a8948a7f89fdc25f3