### PR TITLE
Add implementation roadmap for full game loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ status and a suggested roadmap for extending the rules.
 1. Expand the scoring system with more yaku and fu calculations
 2. Add support for advanced rules beyond riichi
 
+## Implementation Plan: Full Game Loop
+
+Below is a high-level roadmap for integrating the **core** package with the
+web GUI so that one complete game can be played:
+
+1. **Expand the Game Loop** – create a round/hand sequence using
+   `Game.nextHand()` and `Game.rotateDealer()`.
+   Update the `useGame` hook to start new hands and advance the round.
+2. **Handle Multiple Players** – implement lightweight AI logic for the other
+   seats. Expose each hand and meld area in `GameBoard`, keeping opponents'
+   tiles hidden.
+3. **Win Conditions and Scoring** – after every action check
+   `Game.isWinningHand()` or `Game.declareRon()` and display results in
+   `ScoreBoard` before rotating to the next dealer or round.
+4. **UI Enhancements** – follow `docs/board-layout.md` for a stable table and
+   tackle the items in `docs/gui-design.md` such as icon controls and responsive
+   units.
+5. **State Synchronization** – ensure `useGame` refreshes state after each draw,
+   discard or call so React consistently re-renders, and keep the scoreboard in
+   sync.
+6. **Testing** – extend the existing `useGame` tests to cover the new game loop
+   and AI decisions.
+
 
 ### Run Tests
 


### PR DESCRIPTION
## Summary
- document plan for combining core and GUI to play through an entire game

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860fec6c110832a92feebc2d1ecf6e0