### PR TITLE
Improve web GUI with icon action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ to expand the rules or presentation layer to suit your needs.
 
 - [x] Board layout with dora indicators and wall display
 - [x] Interactive hand for the bottom player with responsive layout
+- [x] Icon buttons for calls (Pon/Chi/Kan/Ron)
 - [ ] Richer graphics
 - [ ] Full interaction for all players
-- [ ] Features described in `docs/gui-design.md`
+- [ ] Remaining tasks from `docs/gui-design.md`
 
 ## Getting Started
 

--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -16,7 +16,7 @@ This document summarizes the ongoing discussion about how to present the Mahjong
 1. Provide visual assets for tiles and update the React components to render images instead of text.
 2. Update `web/src/style.css` to define fixed or minimum heights for board rows and make player areas scroll if content overflows.
 3. Add media queries that reorganize the grid on small screens (e.g. stacking side players above the center).
-4. Replace textual control labels with icons and add appropriate `aria-label` attributes.
+4. Replace textual control labels with icons and add appropriate `aria-label` attributes. **Done.**
 5. Ensure the layout uses flexible units so it remains usable on both desktops and phones.
 6. Show dora indicators and remaining wall tiles in the center display. **Done.**
 

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -43,10 +43,34 @@ export function GameBoard({ currentHand, playerDiscards, centerTiles = [], wallC
         </div>
         <Hand tiles={currentHand} onDiscard={onDiscard} />
         <div className="meld-buttons">
-          <button onClick={() => onPon?.(3)}>Pon</button>
-          <button onClick={() => onChi?.(3)}>Chi</button>
-          <button onClick={() => onKan?.(3)}>Kan</button>
-          <button onClick={() => onRon?.(3)}>Ron</button>
+          <button
+            className="icon-button"
+            aria-label="Pon"
+            onClick={() => onPon?.(3)}
+          >
+            📣
+          </button>
+          <button
+            className="icon-button"
+            aria-label="Chi"
+            onClick={() => onChi?.(3)}
+          >
+            ➡️
+          </button>
+          <button
+            className="icon-button"
+            aria-label="Kan"
+            onClick={() => onKan?.(3)}
+          >
+            ➕
+          </button>
+          <button
+            className="icon-button"
+            aria-label="Ron"
+            onClick={() => onRon?.(3)}
+          >
+            🚩
+          </button>
         </div>
       </div>
     </div>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -78,6 +78,14 @@ button {
   cursor: pointer;
 }
 
+.icon-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
 .tile-image,
 .tile-fallback {
   width: 2rem;

--- a/web/test/GameBoard.test.tsx
+++ b/web/test/GameBoard.test.tsx
@@ -29,3 +29,24 @@ test('GameBoard renders hand, discards, melds and center tiles', () => {
   assert.ok(html.includes('wind-east.svg'));
   assert.ok(html.includes('50'));
 });
+
+test('GameBoard action buttons use icons with aria-labels', () => {
+  const tiles = [new Tile({ suit: 'man', value: 1 })];
+  const discardsByPlayer = [[], [], [], []];
+  const html = renderToStaticMarkup(
+    <GameBoard
+      currentHand={tiles}
+      playerDiscards={discardsByPlayer}
+      wallCount={50}
+      onDiscard={() => {}}
+      onPon={() => {}}
+      onChi={() => {}}
+      onKan={() => {}}
+      onRon={() => {}}
+    />
+  );
+  const labels = ['Pon', 'Chi', 'Kan', 'Ron'];
+  for (const label of labels) {
+    assert.ok(html.includes(`aria-label="${label}"`));
+  }
+});

--- a/web/test/style.test.ts
+++ b/web/test/style.test.ts
@@ -44,3 +44,8 @@ test('discard pile layout rules exist', async () => {
   assert.match(css, /\.discard-pile\.right[^}]*grid-area:\s*right/);
   assert.match(css, /\.discard-pile\s+\.discard-row[^}]*display:\s*flex/);
 });
+
+test('icon-button style exists', async () => {
+  const css = await readCss();
+  assert.match(css, /\.icon-button[^}]*font-size:\s*1\.25rem/);
+});


### PR DESCRIPTION
## Summary
- use emoji-based icon buttons for Pon/Chi/Kan/Ron actions
- style icon buttons
- test presence of new aria labels and CSS rules
- document GUI progress in README
- mark GUI design task as done

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861045250f0832a95f8e4f64a0409cd