### PR TITLE
Improve scoreboard visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ to expand the rules or presentation layer to suit your needs.
 - [x] Board layout with dora indicators and wall display
 - [x] Interactive hand for the bottom player with responsive layout
 - [x] Icon buttons for calls (Pon/Chi/Kan/Ron)
+- [x] Seat winds displayed with icons in scoreboard
 - [ ] Richer graphics
 - [ ] Full interaction for all players
 - [ ] Remaining tasks from `docs/gui-design.md`

--- a/web/README.md
+++ b/web/README.md
@@ -4,6 +4,6 @@ A minimal React front end that consumes the core Mahjong logic. To develop local
 
 The web package is intentionally simple and serves as a reference for using the core logic in the browser. The game board lays out each player's area around a central stack. Currently only the bottom player's hand is interactive.
 
-A small scoreboard above the board shows each player's wind and their current points.
+A small scoreboard above the board shows each player's wind using tile icons and their current points.
 
 Tile images live under `public/tiles/`. Real graphics are omitted here because binary assets cannot be committed. Each file is a tiny SVG displaying an emoji placeholder.

--- a/web/src/components/ScoreBoard.tsx
+++ b/web/src/components/ScoreBoard.tsx
@@ -1,4 +1,5 @@
-import type { Wind } from '@mymahjong/core';
+import { Tile, type Wind } from '@mymahjong/core';
+import { TileImage } from './TileImage.js';
 
 export interface ScoreBoardProps {
   scores: { wind: Wind; points: number }[];
@@ -16,7 +17,9 @@ export function ScoreBoard({ scores }: ScoreBoardProps): JSX.Element {
       <tbody>
         {scores.map(s => (
           <tr key={s.wind}>
-            <td>{s.wind}</td>
+            <td>
+              <TileImage tile={new Tile({ suit: 'wind', value: s.wind })} />
+            </td>
             <td>{s.points}</td>
           </tr>
         ))}

--- a/web/test/ScoreBoard.test.tsx
+++ b/web/test/ScoreBoard.test.tsx
@@ -9,10 +9,10 @@ const scores = [
   { wind: 'south' as const, points: 24000 },
 ];
 
-test('ScoreBoard lists winds and points', () => {
+test('ScoreBoard lists winds as icons and points', () => {
   const html = renderToStaticMarkup(<ScoreBoard scores={scores} />);
-  assert.ok(html.includes('east'));
+  assert.ok(html.includes('wind-east.svg'));
   assert.ok(html.includes('25000'));
-  assert.ok(html.includes('south'));
+  assert.ok(html.includes('wind-south.svg'));
   assert.ok(html.includes('24000'));
 });


### PR DESCRIPTION
## Summary
- show seat winds with tile icons in the web scoreboard
- document scoreboard improvement
- update scoreboard test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68610b244e7c832a9a6d87da7425e965