### PR TITLE
Document MJAI protocol integration plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,44 @@ MyMahjong is a simple TypeScript monorepo for experimenting with a Mahjong game 
 - **cli** – a command line interface for playing the game in the terminal
 - **web** – a minimal web layer that demonstrates using the core package
 
+## Implementation status
+
+The repository currently contains documentation only. No source code has been
+published yet.
+
+### Packages
+
+- [ ] **core** – Python game engine built on top of the `mahjong` library
+- [ ] **cli** – command line interface using Click
+- [ ] **web** – FastAPI backend and React front-end
+
+### Features
+
+- [ ] Mortal AI integration
+- [ ] MJAI protocol support
+- [ ] Local single-player play via CLI
+- [ ] REST + WebSocket API
+- [ ] Web GUI served through GitHub Pages
+- [ ] Continuous integration workflow
+
+## Implementation plan
+
+1. **Create the game engine** – wrap the Python `mahjong` library and expose
+   methods for drawing, discarding and scoring.
+2. **Integrate Mortal AI** – add a module that uses the
+   [MJAI high level API](https://mjai.app/docs/highlevel-api) to communicate with
+   the AI process and execute its moves.
+3. **Build CLI** – provide commands for starting a local game against the AI and
+   for connecting to remote games.
+4. **Implement FastAPI server** – expose REST and WebSocket endpoints for game
+   management and real-time play.
+5. **Develop React front-end** – consume the API and present a board based on the
+   `docs/board-layout.md` design.
+6. **Implement MJAI adapter** – translate game state to and from
+   `docs/mjai-ai-integration.md` so AI engines can connect via the protocol.
+7. **Set up GitHub Actions** – lint, type check, run tests and deploy the built
+   web front-end to GitHub Pages.
+
 ## Deployed to
 
 https://kotarotanabe.github.io/MyMahjong/

--- a/docs/mjai-ai-integration.md
+++ b/docs/mjai-ai-integration.md
@@ -1,0 +1,11 @@
+# MJAI AI Integration
+
+This project aims to run external Mahjong AIs that communicate via the [MJAI high level API](https://mjai.app/docs/highlevel-api). Our engine will expose an adapter that converts game state into the JSON messages defined by the specification and consumes the responses produced by the AI process. The goal is to support any AI that follows this protocol, including Mortal.
+
+Key points:
+
+- The engine starts the AI as a separate process and exchanges messages over STDIN/STDOUT or a WebSocket.
+- Messages include actions such as `start_game`, `end_game`, `draw_tile`, and decisions like `discard_tile`.
+- The adapter will validate incoming messages and translate them into engine calls.
+
+This integration makes it possible to plug different AI engines into both the CLI and web server.


### PR DESCRIPTION
## Summary
- describe MJAI protocol support in implementation plan
- link to high level API and new documentation

## Testing
- `npm run lint` *(fails: package.json missing)*
- `npm run typecheck` *(fails: package.json missing)*
- `npm run build` *(fails: package.json missing)*
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652ed85dd8832a8250a686fd9386e3