### PR TITLE
Add board layout reference in GUI design docs

### DIFF
--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -2,6 +2,8 @@
 
 This document summarizes the ongoing discussion about how to present the Mahjong board in a clear and intuitive manner. The goal is a layout that stays within typical desktop resolutions and also adapts to phone screens in landscape mode.
 
+For a detailed overview of how each player area and discard river is arranged, including an ASCII layout diagram and rotation guidelines, see [board-layout.md](./board-layout.md).
+
 ## Key Ideas
 
 - **Minimal text** – Use tile images or simple icons instead of words wherever possible so players understand the state at a glance.


### PR DESCRIPTION
## Summary
- link to `docs/board-layout.md` from `docs/gui-design.md` so readers can find the board orientation and rotation instructions

## Testing
- `flake8`
- `mypy core`
- `python -m build core`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866840aa9d4832ab7b6ae9737255c45