### PR TITLE
Implement discard tile in core

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ package. Future work will expand these components. Other packages remain stubbed
 - [ ] Web GUI served through GitHub Pages
 - [x] Continuous integration workflow
 
+### Core engine capabilities
+
+- [x] draw_tile
+- [x] discard_tile
+- [ ] scoring
+
 ## Implementation plan
 
 1. **Create the game engine** – wrap the Python `mahjong` library and expose

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -19,3 +19,7 @@ class MahjongEngine:
         tile = self.state.wall.draw_tile()
         self.state.players[player_index].draw(tile)
         return tile
+
+    def discard_tile(self, player_index: int, tile: Tile) -> None:
+        """Discard a tile from the specified player's hand."""
+        self.state.players[player_index].discard(tile)

--- a/core/player.py
+++ b/core/player.py
@@ -13,11 +13,13 @@ class Player:
     name: str
     hand: Hand = field(default_factory=Hand)
     score: int = 25000
+    river: list[Tile] = field(default_factory=list)
 
     def draw(self, tile: Tile) -> None:
         """Add a tile to the player's hand."""
         self.hand.tiles.append(tile)
 
     def discard(self, tile: Tile) -> None:
-        """Remove a tile from the player's hand."""
+        """Remove a tile from the player's hand and add it to the river."""
         self.hand.tiles.remove(tile)
+        self.river.append(tile)

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -15,3 +15,13 @@ def test_draw_tile_updates_state() -> None:
     engine.state.wall.tiles.append(tile)
     engine.draw_tile(0)
     assert tile in engine.state.players[0].hand.tiles
+
+
+def test_discard_tile_updates_state() -> None:
+    engine = MahjongEngine()
+    tile = Tile(suit="pin", value=4)
+    # Add tile to player's hand directly for simplicity
+    engine.state.players[1].draw(tile)
+    engine.discard_tile(1, tile)
+    assert tile not in engine.state.players[1].hand.tiles
+    assert tile in engine.state.players[1].river

--- a/tests/core/test_player.py
+++ b/tests/core/test_player.py
@@ -9,3 +9,4 @@ def test_player_draw_and_discard() -> None:
     assert tile in player.hand.tiles
     player.discard(tile)
     assert tile not in player.hand.tiles
+    assert tile in player.river


### PR DESCRIPTION
## Summary
- add `discard_tile` method to MahjongEngine
- extend Player to track the river of discarded tiles
- test new discard behaviour
- document engine capabilities in README

## Testing
- `flake8`
- `mypy core`
- `pytest -q`
- `python -m build core`


------
https://chatgpt.com/codex/tasks/task_e_6866884307f8832aa68e895eb21c5d69