### PR TITLE
Implement scoring in core engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ package. Future work will expand these components. Other packages remain stubbed
 
 - [x] draw_tile
 - [x] discard_tile
-- [ ] scoring
+- [x] scoring
 
 ## Implementation plan
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from .models import GameState, Tile
 from .player import Player
 from .wall import Wall
+from mahjong.hand_calculating.hand_response import HandResponse
 
 
 class MahjongEngine:
@@ -23,3 +24,38 @@ class MahjongEngine:
     def discard_tile(self, player_index: int, tile: Tile) -> None:
         """Discard a tile from the specified player's hand."""
         self.state.players[player_index].discard(tile)
+
+    def calculate_score(self, player_index: int, win_tile: Tile) -> HandResponse:
+        """Return scoring information for the winning hand."""
+        from mahjong.tile import TilesConverter
+        from mahjong.hand_calculating.hand import HandCalculator
+        from mahjong.hand_calculating.hand_config import HandConfig
+
+        def tile_to_index(tile: Tile) -> int:
+            if tile.suit == "man":
+                return tile.value - 1
+            if tile.suit == "pin":
+                return 9 + tile.value - 1
+            if tile.suit == "sou":
+                return 18 + tile.value - 1
+            if tile.suit == "wind":
+                return 27 + tile.value - 1
+            if tile.suit == "dragon":
+                return 31 + tile.value - 1
+            raise ValueError(f"Unknown suit: {tile.suit}")
+
+        hand_tiles = self.state.players[player_index].hand.tiles
+        counts = [0] * 34
+        for t in hand_tiles:
+            counts[tile_to_index(t)] += 1
+
+        tiles_136 = TilesConverter.to_136_array(counts)
+        win_tile_136 = TilesConverter.find_34_tile_in_136_array(
+            tile_to_index(win_tile), tiles_136
+        )
+        assert win_tile_136 is not None, "Winning tile not found in hand"
+
+        calculator = HandCalculator()
+        return calculator.estimate_hand_value(
+            tiles_136, win_tile_136, config=HandConfig(is_tsumo=True)
+        )

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -25,3 +25,27 @@ def test_discard_tile_updates_state() -> None:
     engine.discard_tile(1, tile)
     assert tile not in engine.state.players[1].hand.tiles
     assert tile in engine.state.players[1].river
+
+
+def test_calculate_score_returns_value() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    tiles = [
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("man", 7),
+        Tile("man", 8),
+        Tile("man", 9),
+        Tile("pin", 2),
+        Tile("pin", 3),
+        Tile("pin", 4),
+        Tile("sou", 5),
+        Tile("sou", 5),
+    ]
+    player.hand.tiles = tiles.copy()
+    result = engine.calculate_score(0, tiles[-1])
+    assert result.han is not None and result.han > 0


### PR DESCRIPTION
## Summary
- implement `calculate_score` in `MahjongEngine`
- mark scoring capability in README
- test scoring works for a simple hand

## Testing
- `flake8`
- `mypy core`
- `python -m build core`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686690145f50832aa3dc1ca7c0ba9546