### PR TITLE
Fix packaging and lint

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -25,7 +25,9 @@ class MahjongEngine:
         """Discard a tile from the specified player's hand."""
         self.state.players[player_index].discard(tile)
 
-    def calculate_score(self, player_index: int, win_tile: Tile) -> HandResponse:
+    def calculate_score(
+        self, player_index: int, win_tile: Tile
+    ) -> HandResponse:
         """Return scoring information for the winning hand."""
         from mahjong.tile import TilesConverter
         from mahjong.hand_calculating.hand import HandCalculator

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -11,8 +11,13 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi",
     "uvicorn",
-    "mymahjong-core @ file://../core"
+    "mymahjong-core",
+    "httpx",
 ]
 
 [tool.hatch.build]
 packages = ["web"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+


### PR DESCRIPTION
## Summary
- allow building `web` package with Hatch
- add `httpx` runtime dependency for testing
- reformat long method to satisfy flake8

## Testing
- `flake8`
- `mypy core web`
- `python -m build core`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d4f59f58832a845729a48b1e3b54