### PR TITLE
Add web GUI architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ package. Future work will expand these components. Other packages remain stubbed
 - [ ] Web GUI served through GitHub Pages
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
+- [x] GUI design documented
 
 ### Core engine capabilities
 
@@ -52,6 +53,7 @@ package. Future work will expand these components. Other packages remain stubbed
    web front-end to GitHub Pages.
 
 See `docs/detailed-design.md` for an overview of the planned architecture.
+`docs/web-gui-architecture.md` provides more details about the planned React GUI.
 
 ## Deployed to
 

--- a/docs/web-gui-architecture.md
+++ b/docs/web-gui-architecture.md
@@ -1,0 +1,33 @@
+# Web GUI Architecture
+
+This document outlines the planned front-end architecture for the MyMahjong web interface. It expands on the layout guidelines in [board-layout.md](./board-layout.md) and the principles in [gui-design.md](./gui-design.md).
+
+## Overview
+
+The web client will be implemented as a small React application bundled with Vite. The application connects to the FastAPI backend via REST calls for basic actions and a WebSocket for real-time updates. Game data mirrors the `GameState` model from the `core` package.
+
+## Component Hierarchy
+
+- **App** – top-level component that sets up routing and the WebSocket connection.
+- **GameBoard** – renders the table layout, player areas and central indicators.
+- **Hand** – displays the tiles in a player's hand and action buttons.
+- **River** – shows each player's discard pile with orientation classes.
+- **MeldArea** – lists called sets (chi/pon/kan) for a seat.
+- **Controls** – minimal buttons for drawing, discarding and declaring wins.
+
+Each component receives only the data it needs so the interface remains simple and testable. Styling is handled by a single `style.css` file using CSS grid and flexbox.
+
+## Data Flow
+
+1. After the page loads, `App` fetches the current game state via `GET /games/{id}`.
+2. `App` opens a WebSocket to `/ws/{id}` and listens for events.
+3. Incoming events update the React state, which re-renders the `GameBoard`.
+4. User actions send POST requests back to the server using the REST API.
+
+## Future Enhancements
+
+- Persist player sessions so reconnects restore the current hand.
+- Animate tile movements with CSS transitions.
+- Provide accessibility labels for screen readers.
+
+This architecture keeps the front-end lightweight while leaving room for more advanced features as the project evolves.


### PR DESCRIPTION
## Summary
- document architecture for the upcoming React web interface
- track GUI design documentation status in README

## Testing
- `flake8`
- `mypy core web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867d93d9a34832a89f911211f76d48f