### PR TITLE
Add basic core API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ package. Future work will expand these components. Other packages remain stubbed
 
 ### Core engine capabilities
 
+- [x] start_game
 - [x] draw_tile
 - [x] discard_tile
+- [x] get_state
 - [x] scoring
 
 ## Implementation plan

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -8,5 +8,6 @@ __all__ = [
     "player",
     "wall",
     "ai_adapter",
+    "api",
     "models",
 ]

--- a/core/api.py
+++ b/core/api.py
@@ -1,0 +1,36 @@
+"""High-level core API functions."""
+from __future__ import annotations
+
+from .mahjong_engine import MahjongEngine
+from .models import GameState, Tile
+
+# Singleton engine instance used by interfaces
+_engine: MahjongEngine | None = None
+
+
+def start_game(player_names: list[str]) -> GameState:
+    """Initialize a new game and return its state."""
+    global _engine
+    _engine = MahjongEngine()
+    for i, name in enumerate(player_names):
+        if i < len(_engine.state.players):
+            _engine.state.players[i].name = name
+    return _engine.state
+
+
+def draw_tile(player_index: int) -> Tile:
+    """Draw a tile for the given player."""
+    assert _engine is not None, "Game not started"
+    return _engine.draw_tile(player_index)
+
+
+def discard_tile(player_index: int, tile: Tile) -> None:
+    """Discard a tile from the player's hand."""
+    assert _engine is not None, "Game not started"
+    _engine.discard_tile(player_index, tile)
+
+
+def get_state() -> GameState:
+    """Return the current game state."""
+    assert _engine is not None, "Game not started"
+    return _engine.state

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -1,0 +1,23 @@
+from core import api, models
+
+
+def test_start_game() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    assert len(state.players) == 4
+    assert state.players[0].name == "A"
+
+
+def test_draw_and_discard() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    assert state.wall is not None
+    tile = models.Tile(suit="sou", value=9)
+    state.wall.tiles.append(tile)
+    drawn = api.draw_tile(0)
+    assert drawn == tile
+    api.discard_tile(0, tile)
+    assert tile in state.players[0].river
+
+
+def test_get_state() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    assert api.get_state() is state


### PR DESCRIPTION
## Summary
- implement `core.api` with basic start_game, draw/discard, and state helpers
- expose the API in package exports
- document new core features in README
- add unit tests for the API module

## Testing
- `flake8 && mypy core web && pytest -q`
- `python -m build core`

------
https://chatgpt.com/codex/tasks/task_e_6867d8bc2adc832ab9f2724e11c42899