### PR TITLE
Implement additional core API functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ package. Future work will expand these components. Other packages remain stubbed
 - [x] discard_tile
 - [x] get_state
 - [x] scoring
+- [x] call_chi
+- [x] call_pon
+- [x] call_kan
+- [x] declare_tsumo
+- [x] declare_ron
+- [x] skip
+- [x] end_game
 
 ## Implementation plan
 

--- a/core/api.py
+++ b/core/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile
+from mahjong.hand_calculating.hand_response import HandResponse
 
 # Singleton engine instance used by interfaces
 _engine: MahjongEngine | None = None
@@ -34,3 +35,45 @@ def get_state() -> GameState:
     """Return the current game state."""
     assert _engine is not None, "Game not started"
     return _engine.state
+
+
+def call_chi(player_index: int, tiles: list[Tile]) -> None:
+    """Public wrapper for MahjongEngine.call_chi."""
+    assert _engine is not None, "Game not started"
+    _engine.call_chi(player_index, tiles)
+
+
+def call_pon(player_index: int, tiles: list[Tile]) -> None:
+    """Public wrapper for MahjongEngine.call_pon."""
+    assert _engine is not None, "Game not started"
+    _engine.call_pon(player_index, tiles)
+
+
+def call_kan(player_index: int, tiles: list[Tile]) -> None:
+    """Public wrapper for MahjongEngine.call_kan."""
+    assert _engine is not None, "Game not started"
+    _engine.call_kan(player_index, tiles)
+
+
+def declare_tsumo(player_index: int, tile: Tile) -> HandResponse:
+    """Declare a self-drawn win."""
+    assert _engine is not None, "Game not started"
+    return _engine.declare_tsumo(player_index, tile)
+
+
+def declare_ron(player_index: int, tile: Tile) -> HandResponse:
+    """Declare a ron win on another player's discard."""
+    assert _engine is not None, "Game not started"
+    return _engine.declare_ron(player_index, tile)
+
+
+def skip(player_index: int) -> None:
+    """Skip action for the player."""
+    assert _engine is not None, "Game not started"
+    _engine.skip(player_index)
+
+
+def end_game() -> GameState:
+    """End the current game and reset the engine."""
+    assert _engine is not None, "Game not started"
+    return _engine.end_game()

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -1,7 +1,7 @@
 """Mahjong game engine wrapper."""
 from __future__ import annotations
 
-from .models import GameState, Tile
+from .models import GameState, Tile, Meld
 from .player import Player
 from .wall import Wall
 from mahjong.hand_calculating.hand_response import HandResponse
@@ -61,3 +61,49 @@ class MahjongEngine:
         return calculator.estimate_hand_value(
             tiles_136, win_tile_136, config=HandConfig(is_tsumo=True)
         )
+
+    def call_chi(self, player_index: int, tiles: list[Tile]) -> None:
+        """Form a chi meld using the given tiles."""
+        assert len(tiles) == 3, "Chi requires three tiles"
+        player = self.state.players[player_index]
+        for t in tiles:
+            if t in player.hand.tiles:
+                player.hand.tiles.remove(t)
+        player.hand.melds.append(Meld(tiles=tiles, type="chi"))
+
+    def call_pon(self, player_index: int, tiles: list[Tile]) -> None:
+        """Form a pon meld using the given tiles."""
+        assert len(tiles) == 3, "Pon requires three tiles"
+        player = self.state.players[player_index]
+        for t in tiles:
+            if t in player.hand.tiles:
+                player.hand.tiles.remove(t)
+        player.hand.melds.append(Meld(tiles=tiles, type="pon"))
+
+    def call_kan(self, player_index: int, tiles: list[Tile]) -> None:
+        """Form a kan meld using the given tiles."""
+        assert len(tiles) == 4, "Kan requires four tiles"
+        player = self.state.players[player_index]
+        for t in tiles:
+            if t in player.hand.tiles:
+                player.hand.tiles.remove(t)
+        player.hand.melds.append(Meld(tiles=tiles, type="kan"))
+
+    def declare_tsumo(self, player_index: int, win_tile: Tile) -> HandResponse:
+        """Declare a self-drawn win and return scoring info."""
+        return self.calculate_score(player_index, win_tile)
+
+    def declare_ron(self, player_index: int, win_tile: Tile) -> HandResponse:
+        """Declare a win on another player's discard."""
+        return self.calculate_score(player_index, win_tile)
+
+    def skip(self, player_index: int) -> None:
+        """Skip action for the specified player."""
+        _ = player_index  # currently no-op
+
+    def end_game(self) -> GameState:
+        """Reset the engine and return the final state."""
+        final_state = self.state
+        self.state = GameState(wall=Wall())
+        self.state.players = [Player(name=f"Player {i}") for i in range(4)]
+        return final_state

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -21,3 +21,21 @@ def test_draw_and_discard() -> None:
 def test_get_state() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     assert api.get_state() is state
+
+
+def test_call_pon() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tiles = [models.Tile("pin", 1) for _ in range(3)]
+    player = state.players[0]
+    player.hand.tiles.extend(tiles[:2])
+    api.call_pon(0, tiles)
+    assert len(player.hand.melds) == 1
+    assert player.hand.melds[0].type == "pon"
+
+
+def test_end_game_creates_new_state() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    finished = api.end_game()
+    assert finished is state
+    new_state = api.start_game(["E", "F", "G", "H"])
+    assert new_state is not state

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -49,3 +49,21 @@ def test_calculate_score_returns_value() -> None:
     player.hand.tiles = tiles.copy()
     result = engine.calculate_score(0, tiles[-1])
     assert result.han is not None and result.han > 0
+
+
+def test_call_pon_adds_meld() -> None:
+    engine = MahjongEngine()
+    tiles = [Tile("man", 1) for _ in range(3)]
+    player = engine.state.players[0]
+    player.hand.tiles.extend(tiles[:2])
+    engine.call_pon(0, tiles)
+    assert len(player.hand.melds) == 1
+    assert player.hand.melds[0].type == "pon"
+
+
+def test_end_game_resets_state() -> None:
+    engine = MahjongEngine()
+    old_state = engine.state
+    finished = engine.end_game()
+    assert finished is old_state
+    assert engine.state is not old_state


### PR DESCRIPTION
## Summary
- implement meld and win actions in MahjongEngine
- add wrappers in core API
- test call_pon and end_game behavior
- document expanded capabilities in README

## Testing
- `flake8`
- `mypy core web`
- `python -m build core`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867da821eac832aa64f5e9ac29c00cf