### PR TITLE
Add basic GUI status display

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ package. Future work will expand these components. Other packages remain stubbed
  - [x] core
  - [ ] cli
  - [x] web
+ - [x] web_gui
 
 ### Features
 
@@ -25,6 +26,7 @@ package. Future work will expand these components. Other packages remain stubbed
 - [ ] Local single-player play via CLI
 - [ ] REST + WebSocket API
 - [x] Web GUI served through GitHub Pages
+- [x] Basic GUI status display
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -6,3 +6,9 @@ def test_index_html_exists() -> None:
     assert index.is_file(), 'index.html missing'
     text = index.read_text()
     assert 'MyMahjong GUI' in text
+    assert 'main.js' in text
+
+
+def test_main_js_exists() -> None:
+    script = Path('web_gui/main.js')
+    assert script.is_file(), 'main.js missing'

--- a/web_gui/index.html
+++ b/web_gui/index.html
@@ -8,5 +8,7 @@
 <body>
   <h1>MyMahjong GUI</h1>
   <p>The interactive board will appear here in future updates.</p>
+  <p id="status">Contacting server...</p>
+  <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/web_gui/main.js
+++ b/web_gui/main.js
@@ -1,0 +1,17 @@
+export async function init() {
+  const statusEl = document.getElementById('status');
+  if (!statusEl) return;
+  try {
+    const resp = await fetch('http://localhost:8000/health');
+    if (resp.ok) {
+      const data = await resp.json();
+      statusEl.textContent = `Server status: ${data.status}`;
+    } else {
+      statusEl.textContent = `Server error: ${resp.status}`;
+    }
+  } catch (err) {
+    statusEl.textContent = 'Failed to contact server';
+  }
+}
+
+init();


### PR DESCRIPTION
## Summary
- display backend status in web GUI
- test the new script and entry point
- document web_gui package and new feature status in README

## Testing
- `flake8`
- `mypy core web`
- `python -m build core`
- `pytest -q`
- `npm ci --prefix web_gui`
- `npm run build --prefix web_gui`


------
https://chatgpt.com/codex/tasks/task_e_68685bef3d18832a86786ffdff3269ec