### PR TITLE
Implement create_game endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ package. Future work will expand these components. Other packages remain stubbed
 - [ ] MJAI protocol support
 - [ ] Local single-player play via CLI
 - [ ] REST + WebSocket API
+- [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -11,7 +11,12 @@ def test_health_endpoint() -> None:
     assert response.json() == {"status": "ok"}
 
 
-def test_get_game_endpoint() -> None:
+def test_create_and_get_game() -> None:
+    create = client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    assert create.status_code == 200
+    data = create.json()
+    assert len(data["players"]) == 4
+
     response = client.get("/games/1")
     assert response.status_code == 200
     data = response.json()

--- a/web/server.py
+++ b/web/server.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from dataclasses import asdict
 
 from fastapi import FastAPI
+from pydantic import BaseModel
 
-from core.mahjong_engine import MahjongEngine
+from core import api
 
 app = FastAPI()
 
-_engine = MahjongEngine()
+
+class CreateGameRequest(BaseModel):
+    """Request body for creating a new game."""
+
+    players: list[str]
 
 
 @app.get("/health")
@@ -17,8 +22,15 @@ def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.post("/games")
+def create_game(req: CreateGameRequest) -> dict:
+    """Create a new game and return its state."""
+    state = api.start_game(req.players)
+    return asdict(state)
+
+
 @app.get("/games/{game_id}")
 def get_game(game_id: int) -> dict:
     """Return basic game state for the given game id."""
     # For now we ignore game_id and return the singleton engine state
-    return asdict(_engine.state)
+    return asdict(api.get_state())


### PR DESCRIPTION
## Summary
- expose `/games` POST endpoint in FastAPI server
- test server game creation
- note REST endpoints in README

## Testing
- `flake8 && mypy core web && pytest -q`
- `python -m build core`

------
https://chatgpt.com/codex/tasks/task_e_68685be71d60832aac1523262276b4d4