### PR TITLE
Add standard wall initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ package. Future work will expand these components. Other packages remain stubbed
 - [x] declare_ron
 - [x] skip
 - [x] end_game
+- [x] standard wall initialization
 
 ## Implementation plan
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -14,6 +14,12 @@ class MahjongEngine:
         self.state = GameState(wall=Wall())
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
 
+    @property
+    def remaining_tiles(self) -> int:
+        """Number of tiles left in the wall."""
+        assert self.state.wall is not None
+        return self.state.wall.remaining_tiles
+
     def draw_tile(self, player_index: int) -> Tile:
         """Draw a tile for the specified player."""
         assert self.state.wall is not None

--- a/core/wall.py
+++ b/core/wall.py
@@ -1,10 +1,25 @@
 """Tile wall management."""
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass, field
 from typing import List
 
 from .models import Tile
+
+
+def create_standard_wall() -> list[Tile]:
+    """Return a shuffled list containing the full set of 136 tiles."""
+    tiles: list[Tile] = []
+    for suit in ("man", "pin", "sou"):
+        for value in range(1, 10):
+            tiles.extend([Tile(suit=suit, value=value) for _ in range(4)])
+    for value in range(1, 5):
+        tiles.extend([Tile(suit="wind", value=value) for _ in range(4)])
+    for value in range(1, 4):
+        tiles.extend([Tile(suit="dragon", value=value) for _ in range(4)])
+    random.shuffle(tiles)
+    return tiles
 
 
 @dataclass
@@ -12,6 +27,19 @@ class Wall:
     """Represents the tile wall and dora indicators."""
 
     tiles: List[Tile] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.tiles:
+            self.reset()
+
+    def reset(self) -> None:
+        """Fill the wall with a freshly shuffled standard tile set."""
+        self.tiles = create_standard_wall()
+
+    @property
+    def remaining_tiles(self) -> int:
+        """Return the number of tiles left in the wall."""
+        return len(self.tiles)
 
     def draw_tile(self) -> Tile:
         """Draw and return the next tile from the wall."""

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -67,3 +67,10 @@ def test_end_game_resets_state() -> None:
     finished = engine.end_game()
     assert finished is old_state
     assert engine.state is not old_state
+
+
+def test_remaining_tiles_property() -> None:
+    engine = MahjongEngine()
+    remaining = engine.remaining_tiles
+    engine.draw_tile(0)
+    assert engine.remaining_tiles == remaining - 1

--- a/tests/core/test_wall.py
+++ b/tests/core/test_wall.py
@@ -9,3 +9,20 @@ def test_wall_draw_tile() -> None:
     drawn = wall.draw_tile()
     assert drawn == tile2
     assert wall.tiles == [tile1]
+
+
+def test_wall_initializes_standard_set() -> None:
+    wall = Wall()
+    assert wall.remaining_tiles == 136
+    counts: dict[tuple[str, int], int] = {}
+    for t in wall.tiles:
+        key = (t.suit, t.value)
+        counts[key] = counts.get(key, 0) + 1
+    assert all(c == 4 for c in counts.values())
+
+
+def test_wall_remaining_decreases() -> None:
+    wall = Wall()
+    before = wall.remaining_tiles
+    wall.draw_tile()
+    assert wall.remaining_tiles == before - 1


### PR DESCRIPTION
## Summary
- add a standard tile set generator in `Wall`
- expose `remaining_tiles` property on `Wall` and `MahjongEngine`
- update tests for wall and engine
- document the new capability in the README

## Testing
- `flake8`
- `mypy core web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686863abd294832abe55a33ef6c41eee