### PR TITLE
Add basic board layout to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ package. Future work will expand these components. Other packages remain stubbed
 - [x] Web GUI served through GitHub Pages
 - [x] Basic GUI status display
 - [x] React front-end skeleton
+- [x] Basic board layout
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -8,6 +8,7 @@ def test_index_html_exists() -> None:
     assert 'MyMahjong GUI' in text
     assert '<div id="app"></div>' in text
     assert 'main.jsx' in text
+    assert 'style.css' in text
 
 
 def test_main_js_exists() -> None:
@@ -18,3 +19,13 @@ def test_main_js_exists() -> None:
 def test_app_jsx_exists() -> None:
     app = Path('web_gui/App.jsx')
     assert app.is_file(), 'App.jsx missing'
+
+
+def test_game_board_exists() -> None:
+    board = Path('web_gui/GameBoard.jsx')
+    assert board.is_file(), 'GameBoard.jsx missing'
+
+
+def test_style_css_exists() -> None:
+    css = Path('web_gui/style.css')
+    assert css.is_file(), 'style.css missing'

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import GameBoard from './GameBoard.jsx';
+import './style.css';
 
 export default function App() {
   const [status, setStatus] = useState('Contacting server...');
@@ -23,7 +25,7 @@ export default function App() {
   return (
     <>
       <h1>MyMahjong GUI</h1>
-      <p>The interactive board will appear here in future updates.</p>
+      <GameBoard />
       <p>{status}</p>
     </>
   );

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function GameBoard() {
+  return (
+    <div className="board-grid">
+      <div className="north seat">North</div>
+      <div className="west seat">West</div>
+      <div className="center">Board</div>
+      <div className="east seat">East</div>
+      <div className="south seat">South</div>
+    </div>
+  );
+}

--- a/web_gui/index.html
+++ b/web_gui/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MyMahjong GUI</title>
+  <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
   <div id="app"></div>

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -1,0 +1,23 @@
+.board-grid {
+  display: grid;
+  grid-template-areas:
+    '. north .'
+    'west center east'
+    '. south .';
+  grid-template-columns: 1fr 2fr 1fr;
+  grid-template-rows: auto auto auto;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.seat {
+  padding: 0.5rem;
+  background-color: #f2f2f2;
+  border: 1px solid #ccc;
+}
+
+.north { grid-area: north; }
+.west { grid-area: west; }
+.center { grid-area: center; }
+.east { grid-area: east; }
+.south { grid-area: south; }


### PR DESCRIPTION
## Summary
- add a `GameBoard` React component and board styles
- render the board in the App and load CSS
- link stylesheet from `index.html`
- test that new files exist
- document board layout in README

## Testing
- `flake8`
- `mypy core web`
- `python -m build core`
- `pytest -q`
- `npm ci` && `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68686996ee60832aa2733f9e163625bf