### PR TITLE
Advance GUI with Hand and River components

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Future work will expand these components.
 - [x] Basic GUI status display
 - [x] React front-end skeleton
 - [x] Basic board layout
+- [x] Hand & River components
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -26,6 +26,16 @@ def test_game_board_exists() -> None:
     assert board.is_file(), 'GameBoard.jsx missing'
 
 
+def test_hand_component_exists() -> None:
+    hand = Path('web_gui/Hand.jsx')
+    assert hand.is_file(), 'Hand.jsx missing'
+
+
+def test_river_component_exists() -> None:
+    river = Path('web_gui/River.jsx')
+    assert river.is_file(), 'River.jsx missing'
+
+
 def test_style_css_exists() -> None:
     css = Path('web_gui/style.css')
     assert css.is_file(), 'style.css missing'

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,13 +1,28 @@
 import React from 'react';
+import Hand from './Hand.jsx';
+import River from './River.jsx';
 
 export default function GameBoard() {
+  const hand = Array(13).fill('🀫');
   return (
     <div className="board-grid">
-      <div className="north seat">North</div>
-      <div className="west seat">West</div>
+      <div className="north seat">
+        <River tiles={[]} />
+        <Hand tiles={hand} />
+      </div>
+      <div className="west seat">
+        <River tiles={[]} />
+        <Hand tiles={hand} />
+      </div>
       <div className="center">Board</div>
-      <div className="east seat">East</div>
-      <div className="south seat">South</div>
+      <div className="east seat">
+        <River tiles={[]} />
+        <Hand tiles={hand} />
+      </div>
+      <div className="south seat">
+        <River tiles={[]} />
+        <Hand tiles={hand} />
+      </div>
     </div>
   );
 }

--- a/web_gui/Hand.jsx
+++ b/web_gui/Hand.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function Hand({ tiles = [] }) {
+  return (
+    <div className="hand">
+      {tiles.map((t, i) => (
+        <span key={i} className="tile">{t}</span>
+      ))}
+    </div>
+  );
+}

--- a/web_gui/River.jsx
+++ b/web_gui/River.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function River({ tiles = [] }) {
+  return (
+    <div className="river">
+      {tiles.map((t, i) => (
+        <span key={i} className="tile">{t}</span>
+      ))}
+    </div>
+  );
+}

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -21,3 +21,30 @@
 .center { grid-area: center; }
 .east { grid-area: east; }
 .south { grid-area: south; }
+
+.hand {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.river {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.25rem;
+  min-height: 24px;
+}
+
+.tile {
+  display: inline-block;
+  width: 24px;
+  height: 32px;
+  background-color: white;
+  border: 1px solid #333;
+  border-radius: 2px;
+}
+
+.east .river { transform: rotate(90deg); }
+.north .river { transform: rotate(180deg); }
+.west .river { transform: rotate(-90deg); }


### PR DESCRIPTION
## Summary
- add `Hand` and `River` React components
- show placeholder hands and discard rivers in `GameBoard`
- style new components with basic layout and rotation
- update README feature checklist
- add tests for new component files

## Testing
- `python -m flake8 && python -m mypy core web cli && pytest -q`
- `npm ci --prefix web_gui`
- `npm run build --prefix web_gui`
- `python -m build core`
- `python -m build cli`


------
https://chatgpt.com/codex/tasks/task_e_6868cdcb4c78832a8bf081e3d114b714