### PR TITLE
Fix discard tile removal bug

### DIFF
--- a/core/player.py
+++ b/core/player.py
@@ -22,11 +22,18 @@ class Player:
 
     def discard(self, tile: Tile) -> None:
         """Remove a tile from the player's hand and add it to the river."""
-        self.hand.tiles.remove(tile)
+        try:
+            # prefer to remove by object identity to avoid accidentally
+            # discarding a different tile with the same suit/value
+            idx = next(i for i, t in enumerate(self.hand.tiles) if t is tile)
+            self.hand.tiles.pop(idx)
+        except StopIteration:
+            # fall back to equality-based removal for backward compatibility
+            self.hand.tiles.remove(tile)
         self.river.append(tile)
 
     def declare_riichi(self) -> None:
-        """Mark the player as having declared riichi and pay the 1000 point stick."""
+        """Declare riichi and pay the 1000 point stick."""
         if self.riichi:
             return
         self.score -= 1000

--- a/tests/core/test_player.py
+++ b/tests/core/test_player.py
@@ -18,3 +18,14 @@ def test_player_declare_riichi() -> None:
     player.declare_riichi()
     assert player.riichi
     assert player.score == start_score - 1000
+
+
+def test_discard_removes_specific_instance() -> None:
+    player = Player(name="Test")
+    tile1 = Tile(suit="man", value=1)
+    tile2 = Tile(suit="man", value=1)
+    player.draw(tile1)
+    player.draw(tile2)
+    player.discard(tile2)
+    assert all(t is not tile2 for t in player.hand.tiles)
+    assert tile1 in player.hand.tiles


### PR DESCRIPTION
## Summary
- fix `Player.discard` to remove tile by identity
- add regression test for duplicate tile discard

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868d001c928832ab7d101ebd6e5c1fb