### PR TITLE
Implement basic MJAI adapter serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Future work will expand these components.
 - [ ] Mortal AI integration
 - [x] Mortal backend integration design
 - [ ] MJAI protocol support
+- [x] GameState JSON serialization
 - [x] Local single-player play via CLI
 - [ ] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)

--- a/core/ai_adapter.py
+++ b/core/ai_adapter.py
@@ -1,12 +1,27 @@
-"""Stub for MJAI adapter."""
+"""Simple MJAI protocol adapter.
 
-# TODO: implement conversion between GameState and MJAI protocol
+This module converts :class:`GameState` objects into JSON messages and sends
+them to an AI process. Only the minimal pieces required for local play are
+implemented. Full protocol support will be added incrementally.
+"""
 
 from __future__ import annotations
 
+import json
+from dataclasses import asdict
+
 from .models import GameState
+from .mortal_runner import MortalAI
 
 
-def send_state_to_ai(state: GameState) -> None:
-    """Placeholder function to send game state to an AI engine."""
-    raise NotImplementedError
+def game_state_to_json(state: GameState) -> str:
+    """Return a JSON string representation of the game state."""
+
+    return json.dumps(asdict(state))
+
+
+def send_state_to_ai(state: GameState, ai: MortalAI) -> None:
+    """Serialize ``state`` and send it to ``ai``."""
+
+    message = game_state_to_json(state)
+    ai.send(message)

--- a/tests/core/test_ai_adapter.py
+++ b/tests/core/test_ai_adapter.py
@@ -1,0 +1,32 @@
+from core.ai_adapter import game_state_to_json, send_state_to_ai
+from core.models import GameState, Tile
+from core.mortal_runner import MortalAI
+from core.player import Player
+from core.wall import Wall
+import json
+
+
+class DummyAI(MortalAI):
+    def __init__(self) -> None:
+        self.sent_messages: list[str] = []
+
+    def send(self, message: str) -> None:  # type: ignore[override]
+        self.sent_messages.append(message)
+
+
+def test_game_state_to_json() -> None:
+    state = GameState(
+        players=[Player(name="A")],
+        wall=Wall(tiles=[Tile("man", 1)]),
+    )
+    data = json.loads(game_state_to_json(state))
+    assert data["players"][0]["name"] == "A"
+    assert data["wall"]["tiles"][0]["value"] == 1
+
+
+def test_send_state_to_ai() -> None:
+    state = GameState(players=[Player(name="A")])
+    ai = DummyAI()
+    send_state_to_ai(state, ai)
+    assert len(ai.sent_messages) == 1
+    assert json.loads(ai.sent_messages[0])["players"][0]["name"] == "A"


### PR DESCRIPTION
## Summary
- serialize GameState to JSON and send messages to Mortal AI
- add tests for new ai_adapter functionality
- document GameState serialization feature in README

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868d434392c832a930739ec42ecd063