### PR TITLE
Add remote play commands to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Future work will expand these components.
 - [x] Mortal backend integration design
 - [ ] MJAI protocol support
 - [x] Local single-player play via CLI
+- [x] Basic remote game creation via CLI
 - [ ] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,5 +1,6 @@
 import click
 
+from . import remote_game
 from .local_game import run_game
 
 
@@ -10,17 +11,33 @@ def cli() -> None:
 
 @cli.command()
 @click.argument("players", nargs=-1)
-def start(players: tuple[str, ...]) -> None:
-    """Start a local game with the given PLAYERS."""
+@click.option("--server", "server", "-s", help="Base URL of remote server")
+def start(players: tuple[str, ...], server: str | None) -> None:
+    """Start a game with the given PLAYERS."""
     if not players:
         players = ("You", "AI1", "AI2", "AI3")
+    if server:
+        data = remote_game.create_game(server, list(players))
+        names = ", ".join(p["name"] for p in data.get("players", []))
+        click.echo(f"Remote game created with players: {names}")
+        return
     run_game(list(players))
 
 
 @cli.command()
-def join() -> None:
-    """Join an existing game (not implemented)."""
-    click.echo("Join command is not implemented yet.")
+@click.argument("game_id", type=int)
+@click.option(
+    "--server",
+    "server",
+    "-s",
+    required=True,
+    help="Base URL of remote server",
+)
+def join(game_id: int, server: str) -> None:
+    """Join an existing remote game."""
+    data = remote_game.get_game(server, game_id)
+    names = ", ".join(p["name"] for p in data.get("players", []))
+    click.echo(f"Joined game {game_id} with players: {names}")
 
 
 if __name__ == "__main__":

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -10,6 +10,8 @@ readme = "../README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click",
+    "requests",
+    "types-requests",
     "mymahjong-core",
 ]
 

--- a/cli/remote_game.py
+++ b/cli/remote_game.py
@@ -1,0 +1,20 @@
+"""Helpers for interacting with the web server."""
+from __future__ import annotations
+
+import requests
+
+
+def create_game(server: str, players: list[str]) -> dict:
+    """Create a remote game and return the JSON response."""
+    url = f"{server.rstrip('/')}/games"
+    resp = requests.post(url, json={"players": players})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_game(server: str, game_id: int) -> dict:
+    """Retrieve the game state for ``game_id`` from the server."""
+    url = f"{server.rstrip('/')}/games/{game_id}"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -11,8 +11,23 @@ def test_start_command_runs() -> None:
     assert "Game ended" in result.output
 
 
-def test_join_command_placeholder() -> None:
+def test_start_command_remote(monkeypatch) -> None:
+    def fake_create(server: str, players: list[str]) -> dict:
+        return {"players": [{"name": p} for p in players]}
+
+    monkeypatch.setattr("cli.remote_game.create_game", fake_create)
     runner = CliRunner()
-    result = runner.invoke(cli, ["join"])
+    result = runner.invoke(cli, ["start", "A", "B", "-s", "http://host"])
     assert result.exit_code == 0
-    assert "not implemented" in result.output
+    assert "Remote game created" in result.output
+
+
+def test_join_command_remote(monkeypatch) -> None:
+    def fake_get(server: str, game_id: int) -> dict:
+        return {"players": [{"name": "A"}, {"name": "B"}]}
+
+    monkeypatch.setattr("cli.remote_game.get_game", fake_get)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["join", "1", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "Joined game 1" in result.output


### PR DESCRIPTION
## Summary
- implement `remote_game` helpers for HTTP calls
- enhance CLI to create/join games on a server
- depend on `requests` and its type stubs
- test new CLI options
- document remote game creation in README

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868d42ef800832aae7df90ae558beeb