### PR TITLE
Add meld area component to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Future work will expand these components.
 - [x] React front-end skeleton
 - [x] Basic board layout
 - [x] Hand & River components
+- [x] Meld area component
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -36,6 +36,11 @@ def test_river_component_exists() -> None:
     assert river.is_file(), 'River.jsx missing'
 
 
+def test_meld_area_component_exists() -> None:
+    meld = Path('web_gui/MeldArea.jsx')
+    assert meld.is_file(), 'MeldArea.jsx missing'
+
+
 def test_style_css_exists() -> None:
     css = Path('web_gui/style.css')
     assert css.is_file(), 'style.css missing'

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,27 +1,32 @@
 import React from 'react';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
+import MeldArea from './MeldArea.jsx';
 
 export default function GameBoard() {
   const hand = Array(13).fill('🀫');
   return (
     <div className="board-grid">
       <div className="north seat">
+        <MeldArea melds={[]} />
         <River tiles={[]} />
         <Hand tiles={hand} />
       </div>
       <div className="west seat">
+        <MeldArea melds={[]} />
         <River tiles={[]} />
         <Hand tiles={hand} />
       </div>
       <div className="center">Board</div>
       <div className="east seat">
+        <MeldArea melds={[]} />
         <River tiles={[]} />
         <Hand tiles={hand} />
       </div>
       <div className="south seat">
         <River tiles={[]} />
         <Hand tiles={hand} />
+        <MeldArea melds={[]} />
       </div>
     </div>
   );

--- a/web_gui/MeldArea.jsx
+++ b/web_gui/MeldArea.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function MeldArea({ melds = [] }) {
+  return (
+    <div className="meld-area">
+      {melds.map((meld, mIdx) => (
+        <div key={mIdx} className="meld">
+          {meld.map((t, i) => (
+            <span key={i} className="tile">{t}</span>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -36,6 +36,18 @@
   min-height: 24px;
 }
 
+.meld-area {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  min-height: 24px;
+}
+
+.meld {
+  display: flex;
+  gap: 0.1rem;
+}
+
 .tile {
   display: inline-block;
   width: 24px;
@@ -48,3 +60,7 @@
 .east .river { transform: rotate(90deg); }
 .north .river { transform: rotate(180deg); }
 .west .river { transform: rotate(-90deg); }
+
+.east .meld-area { transform: rotate(90deg); }
+.north .meld-area { transform: rotate(180deg); }
+.west .meld-area { transform: rotate(-90deg); }


### PR DESCRIPTION
## Summary
- extend GameBoard with new MeldArea component
- create `MeldArea.jsx` with basic rendering logic
- rotate and style meld areas via CSS
- update tests for GUI files
- mark feature as implemented in README

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`
- `npm ci` and `npm run build` in `web_gui`

------
https://chatgpt.com/codex/tasks/task_e_6868d6807e54832a8f186e63e684fa58