### PR TITLE
Add RuleSet abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Future work will expand these components.
 - [x] Mortal backend integration design
 - [ ] MJAI protocol support
 - [x] GameState JSON serialization
+- [x] RuleSet interface for scoring
 - [x] Local single-player play via CLI
 - [x] Basic remote game creation via CLI
 - [ ] REST + WebSocket API
@@ -55,6 +56,7 @@ Future work will expand these components.
 - [x] skip
 - [x] end_game
 - [x] standard wall initialization
+- [x] configurable ruleset
 
 ## Implementation plan
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -11,4 +11,5 @@ __all__ = [
     "mortal_runner",
     "api",
     "models",
+    "rules",
 ]

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 from .models import GameState, Tile, Meld
 from .player import Player
 from .wall import Wall
+from .rules import RuleSet, StandardRuleSet
 from mahjong.hand_calculating.hand_response import HandResponse
 
 
 class MahjongEngine:
     """Simplified engine that wraps the `mahjong` library."""
 
-    def __init__(self) -> None:
+    def __init__(self, ruleset: RuleSet | None = None) -> None:
+        self.ruleset: RuleSet = ruleset or StandardRuleSet()
         self.state = GameState(wall=Wall())
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
         self.deal_initial_hands()
@@ -48,37 +50,9 @@ class MahjongEngine:
         self, player_index: int, win_tile: Tile
     ) -> HandResponse:
         """Return scoring information for the winning hand."""
-        from mahjong.tile import TilesConverter
-        from mahjong.hand_calculating.hand import HandCalculator
-        from mahjong.hand_calculating.hand_config import HandConfig
-
-        def tile_to_index(tile: Tile) -> int:
-            if tile.suit == "man":
-                return tile.value - 1
-            if tile.suit == "pin":
-                return 9 + tile.value - 1
-            if tile.suit == "sou":
-                return 18 + tile.value - 1
-            if tile.suit == "wind":
-                return 27 + tile.value - 1
-            if tile.suit == "dragon":
-                return 31 + tile.value - 1
-            raise ValueError(f"Unknown suit: {tile.suit}")
-
-        hand_tiles = self.state.players[player_index].hand.tiles
-        counts = [0] * 34
-        for t in hand_tiles:
-            counts[tile_to_index(t)] += 1
-
-        tiles_136 = TilesConverter.to_136_array(counts)
-        win_tile_136 = TilesConverter.find_34_tile_in_136_array(
-            tile_to_index(win_tile), tiles_136
-        )
-        assert win_tile_136 is not None, "Winning tile not found in hand"
-
-        calculator = HandCalculator()
-        return calculator.estimate_hand_value(
-            tiles_136, win_tile_136, config=HandConfig(is_tsumo=True)
+        player = self.state.players[player_index]
+        return self.ruleset.calculate_score(
+            player.hand.tiles, player.hand.melds, win_tile, is_tsumo=True
         )
 
     def call_chi(self, player_index: int, tiles: list[Tile]) -> None:

--- a/core/rules.py
+++ b/core/rules.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Rule set abstractions for scoring and validation."""
+
+from dataclasses import dataclass
+
+from mahjong.hand_calculating.hand import HandCalculator
+from mahjong.hand_calculating.hand_config import HandConfig
+from mahjong.hand_calculating.hand_response import HandResponse
+from mahjong.tile import TilesConverter
+
+from .models import Tile, Meld
+
+
+def _tile_to_index(tile: Tile) -> int:
+    if tile.suit == "man":
+        return tile.value - 1
+    if tile.suit == "pin":
+        return 9 + tile.value - 1
+    if tile.suit == "sou":
+        return 18 + tile.value - 1
+    if tile.suit == "wind":
+        return 27 + tile.value - 1
+    if tile.suit == "dragon":
+        return 31 + tile.value - 1
+    raise ValueError(f"Unknown suit: {tile.suit}")
+
+
+class RuleSet:
+    """Base interface for Mahjong rule sets."""
+
+    def calculate_score(
+        self,
+        hand_tiles: list[Tile],
+        melds: list[Meld],
+        win_tile: Tile,
+        *,
+        is_tsumo: bool = True,
+    ) -> HandResponse:
+        """Return scoring for the given hand."""
+        raise NotImplementedError
+
+
+@dataclass
+class StandardRuleSet(RuleSet):
+    """Default rules using the `mahjong` library's hand calculator."""
+
+    calculator: HandCalculator = HandCalculator()
+
+    def calculate_score(
+        self,
+        hand_tiles: list[Tile],
+        melds: list[Meld],
+        win_tile: Tile,
+        *,
+        is_tsumo: bool = True,
+    ) -> HandResponse:
+        counts = [0] * 34
+        for t in hand_tiles:
+            counts[_tile_to_index(t)] += 1
+        for meld in melds:
+            for t in meld.tiles:
+                counts[_tile_to_index(t)] += 0  # meld tiles already removed
+        tiles_136 = TilesConverter.to_136_array(counts)
+        win_tile_136 = TilesConverter.find_34_tile_in_136_array(
+            _tile_to_index(win_tile), tiles_136
+        )
+        assert win_tile_136 is not None, "Winning tile not found in hand"
+        config = HandConfig(is_tsumo=is_tsumo)
+        return self.calculator.estimate_hand_value(
+            tiles_136, win_tile_136, config=config
+        )

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -1,0 +1,44 @@
+from core.rules import RuleSet, StandardRuleSet
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile, Meld
+from mahjong.hand_calculating.hand_response import HandResponse
+
+
+class DummyRuleSet(RuleSet):
+    def __init__(self) -> None:
+        self.called_with: tuple | None = None
+
+    def calculate_score(
+        self,
+        hand_tiles: list[Tile],
+        melds: list[Meld],
+        win_tile: Tile,
+        *,
+        is_tsumo: bool = True,
+    ) -> HandResponse:
+        self.called_with = (hand_tiles[:], melds[:], win_tile, is_tsumo)
+        return HandResponse(han=0)
+
+
+def test_engine_delegates_to_ruleset() -> None:
+    ruleset = DummyRuleSet()
+    engine = MahjongEngine(ruleset=ruleset)
+    player = engine.state.players[0]
+    tile = Tile("man", 1)
+    player.hand.tiles.append(tile)
+    engine.calculate_score(0, tile)
+    assert ruleset.called_with is not None
+    hand_tiles, melds, win_tile, is_tsumo = ruleset.called_with
+    assert win_tile == tile
+    assert hand_tiles[-1] == tile
+    assert is_tsumo
+
+
+def test_standard_ruleset_scoring() -> None:
+    ruleset = StandardRuleSet()
+    engine = MahjongEngine(ruleset=ruleset)
+    player = engine.state.players[0]
+    tiles = [Tile("man", v) for v in range(1, 10)] + [Tile("pin", 1)]
+    player.hand.tiles = tiles
+    result = engine.calculate_score(0, tiles[-1])
+    assert isinstance(result, HandResponse)


### PR DESCRIPTION
## Summary
- introduce `RuleSet` and `StandardRuleSet` for scoring logic
- update `MahjongEngine` to use `RuleSet`
- export new module through `core.__init__`
- document RuleSet feature in README
- add unit tests for the new abstraction

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`
- `python -m build web`


------
https://chatgpt.com/codex/tasks/task_e_6868d7558808832a879f0f7e15453aaa