### PR TITLE
Use uv for local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ See `docs/detailed-design.md` for an overview of the planned architecture.
 
 ### Start the FastAPI server
 
-The API server depends on the **core** package. Install the editable packages
-and run `uvicorn`:
+The API server depends on the **core** package. Install the [**uv**](https://github.com/astral-sh/uv) tool and use it to install the editable packages before running `uvicorn`:
 
 ```bash
-pip install -e ./core -e ./web
+curl -Ls https://astral.sh/uv/install.sh | sh
+uv pip install -e ./core -e ./web
 uvicorn web.server:app --reload
 ```
 


### PR DESCRIPTION
## Summary
- update local development guide to install and use `uv` when starting the FastAPI server

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868da655880832a86703be3a8aa8910