### PR TITLE
Add center display to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Future work will expand these components.
 - [x] Basic board layout
 - [x] Hand & River components
 - [x] Meld area component
+- [x] Center display (dora & wall count)
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -41,6 +41,16 @@ def test_meld_area_component_exists() -> None:
     assert meld.is_file(), 'MeldArea.jsx missing'
 
 
+def test_center_display_component_exists() -> None:
+    center = Path('web_gui/CenterDisplay.jsx')
+    assert center.is_file(), 'CenterDisplay.jsx missing'
+
+
+def test_game_board_references_center_display() -> None:
+    board = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'CenterDisplay' in board
+
+
 def test_style_css_exists() -> None:
     css = Path('web_gui/style.css')
     assert css.is_file(), 'style.css missing'

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function CenterDisplay({ remaining = 70, dora = ['\uD83C\uDE00'] }) {
+  return (
+    <div className="center-display">
+      <div className="remaining">Remaining: {remaining}</div>
+      <div className="dora">Dora: {dora.join(' ')}</div>
+    </div>
+  );
+}

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
+import CenterDisplay from './CenterDisplay.jsx';
 
 export default function GameBoard() {
   const hand = Array(13).fill('🀫');
@@ -17,7 +18,9 @@ export default function GameBoard() {
         <River tiles={[]} />
         <Hand tiles={hand} />
       </div>
-      <div className="center">Board</div>
+      <div className="center">
+        <CenterDisplay />
+      </div>
       <div className="east seat">
         <MeldArea melds={[]} />
         <River tiles={[]} />

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -19,6 +19,12 @@
 .north { grid-area: north; }
 .west { grid-area: west; }
 .center { grid-area: center; }
+.center-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
 .east { grid-area: east; }
 .south { grid-area: south; }
 


### PR DESCRIPTION
## Summary
- show remaining tiles and dora indicators with new CenterDisplay component
- wire CenterDisplay into GameBoard and style it
- document the new feature in README
- test that the new component exists and is referenced

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868d9c5769c832a88b640e83c972efc