### PR TITLE
Add basic draw controls to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Basic draw control via REST API
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -21,3 +21,14 @@ def test_create_and_get_game() -> None:
     assert response.status_code == 200
     data = response.json()
     assert "players" in data
+
+
+def test_draw_action_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    resp = client.post(
+        "/games/1/action",
+        json={"player_index": 0, "action": "draw"},
+    )
+    assert resp.status_code == 200
+    tile = resp.json()
+    assert "suit" in tile and "value" in tile

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -46,9 +46,19 @@ def test_center_display_component_exists() -> None:
     assert center.is_file(), 'CenterDisplay.jsx missing'
 
 
+def test_controls_component_exists() -> None:
+    controls = Path('web_gui/Controls.jsx')
+    assert controls.is_file(), 'Controls.jsx missing'
+
+
 def test_game_board_references_center_display() -> None:
     board = Path('web_gui/GameBoard.jsx').read_text()
     assert 'CenterDisplay' in board
+
+
+def test_game_board_references_controls() -> None:
+    board = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'Controls' in board
 
 
 def test_style_css_exists() -> None:

--- a/web/server.py
+++ b/web/server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from core import api
@@ -34,3 +34,20 @@ def get_game(game_id: int) -> dict:
     """Return basic game state for the given game id."""
     # For now we ignore game_id and return the singleton engine state
     return asdict(api.get_state())
+
+
+class ActionRequest(BaseModel):
+    """Request body for game actions."""
+
+    player_index: int
+    action: str
+
+
+@app.post("/games/{game_id}/action")
+def game_action(game_id: int, req: ActionRequest) -> dict:
+    """Perform a simple game action and return its result."""
+    _ = game_id  # placeholder for future multi-game support
+    if req.action == "draw":
+        tile = api.draw_tile(req.player_index)
+        return asdict(tile)
+    raise HTTPException(status_code=400, detail="Unknown action")

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+export default function Controls() {
+  const [message, setMessage] = useState('');
+
+  async function draw() {
+    try {
+      const resp = await fetch('http://localhost:8000/games/1/action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player_index: 0, action: 'draw' }),
+      });
+      if (resp.ok) {
+        const tile = await resp.json();
+        setMessage(`Drew ${tile.suit} ${tile.value}`);
+      } else {
+        setMessage('Error drawing tile');
+      }
+    } catch {
+      setMessage('Server unreachable');
+    }
+  }
+
+  return (
+    <div className="controls">
+      <button onClick={draw}>Draw</button>
+      {message && <div className="message">{message}</div>}
+    </div>
+  );
+}

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -3,6 +3,7 @@ import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
+import Controls from './Controls.jsx';
 
 export default function GameBoard() {
   const hand = Array(13).fill('🀫');
@@ -29,6 +30,7 @@ export default function GameBoard() {
       <div className="south seat">
         <River tiles={[]} />
         <Hand tiles={hand} />
+        <Controls />
         <MeldArea melds={[]} />
       </div>
     </div>

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -49,6 +49,17 @@
   min-height: 24px;
 }
 
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.message {
+  margin-top: 0.25rem;
+}
+
 .meld {
   display: flex;
   gap: 0.1rem;


### PR DESCRIPTION
## Summary
- implement `/games/{id}/action` endpoint for drawing tiles
- add `Controls` React component
- show controls in the south seat
- style controls and message display
- test new endpoint and component
- document draw control in README

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`
- `npm install --prefix web_gui`
- `npm run build --prefix web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6868dc5758b0832a99b1400f1f7fab24