### PR TITLE
Add server selection and retry in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Future work will expand these components.
 - [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages
 - [x] Basic GUI status display
+- [x] GUI server selection and retry
 - [x] React front-end skeleton
 - [x] Basic board layout
 - [x] Hand & River components

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -54,3 +54,9 @@ def test_game_board_references_center_display() -> None:
 def test_style_css_exists() -> None:
     css = Path('web_gui/style.css')
     assert css.is_file(), 'style.css missing'
+
+
+def test_app_has_server_selection() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert '<input' in text
+    assert 'Retry' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -3,28 +3,43 @@ import GameBoard from './GameBoard.jsx';
 import './style.css';
 
 export default function App() {
+  const [server, setServer] = useState('http://localhost:8000');
   const [status, setStatus] = useState('Contacting server...');
 
-  useEffect(() => {
-    async function fetchStatus() {
-      try {
-        const resp = await fetch('http://localhost:8000/health');
-        if (resp.ok) {
-          const data = await resp.json();
-          setStatus(`Server status: ${data.status}`);
-        } else {
-          setStatus(`Server error: ${resp.status}`);
-        }
-      } catch {
-        setStatus('Failed to contact server');
+  async function fetchStatus() {
+    setStatus('Contacting server...');
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/health`);
+      if (resp.ok) {
+        const data = await resp.json();
+        setStatus(`Server status: ${data.status} (${server})`);
+      } else {
+        setStatus(`Server error: ${resp.status} (${server})`);
       }
+    } catch {
+      setStatus(`Failed to contact server at ${server}`);
     }
+  }
+
+  useEffect(() => {
     fetchStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <>
       <h1>MyMahjong GUI</h1>
+      <div>
+        <label>
+          Server:
+          <input
+            value={server}
+            onChange={(e) => setServer(e.target.value)}
+            style={{ width: '20em' }}
+          />
+        </label>
+        <button onClick={fetchStatus}>Retry</button>
+      </div>
       <GameBoard />
       <p>{status}</p>
     </>


### PR DESCRIPTION
## Summary
- allow server host selection and retry in the GUI
- document new GUI feature in README
- test for server input and retry button in App.jsx

## Testing
- `pip install -e ./core -e ./web -e ./cli`
- `pip install flake8 mypy pytest`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868dd18ee30832abad4d943687d3c6d