### PR TITLE
Add remote draw command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Future work will expand these components.
 - [x] RuleSet interface for scoring
 - [x] Local single-player play via CLI
 - [x] Basic remote game creation via CLI
+- [x] Join remote games via CLI
+- [x] Draw tile in remote games via CLI
 - [ ] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages

--- a/cli/main.py
+++ b/cli/main.py
@@ -40,5 +40,21 @@ def join(game_id: int, server: str) -> None:
     click.echo(f"Joined game {game_id} with players: {names}")
 
 
+@cli.command()
+@click.argument("game_id", type=int)
+@click.argument("player_index", type=int)
+@click.option(
+    "--server",
+    "server",
+    "-s",
+    required=True,
+    help="Base URL of remote server",
+)
+def draw(game_id: int, player_index: int, server: str) -> None:
+    """Draw a tile for PLAYER_INDEX in a remote game."""
+    tile = remote_game.draw_tile(server, game_id, player_index)
+    click.echo(f"Player {player_index} drew {tile['suit']}{tile['value']}")
+
+
 if __name__ == "__main__":
     cli()

--- a/cli/remote_game.py
+++ b/cli/remote_game.py
@@ -18,3 +18,13 @@ def get_game(server: str, game_id: int) -> dict:
     resp = requests.get(url)
     resp.raise_for_status()
     return resp.json()
+
+
+def draw_tile(server: str, game_id: int, player_index: int) -> dict:
+    """Draw a tile for ``player_index`` in ``game_id`` and return the tile."""
+    url = f"{server.rstrip('/')}/games/{game_id}/action"
+    resp = requests.post(
+        url, json={"player_index": player_index, "action": "draw"}
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -31,3 +31,14 @@ def test_join_command_remote(monkeypatch) -> None:
     result = runner.invoke(cli, ["join", "1", "-s", "http://host"])
     assert result.exit_code == 0
     assert "Joined game 1" in result.output
+
+
+def test_draw_command_remote(monkeypatch) -> None:
+    def fake_draw(server: str, game_id: int, player_index: int) -> dict:
+        return {"suit": "m", "value": 5}
+
+    monkeypatch.setattr("cli.remote_game.draw_tile", fake_draw)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["draw", "1", "0", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "drew m5" in result.output


### PR DESCRIPTION
## Summary
- implement `draw` command in CLI to trigger server action
- update remote helpers
- cover new command with tests
- update README feature checklist

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868de08ad6c832ab6d6aeab663d8eb5