### PR TITLE
Add dev script for local front/back setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Future work will expand these components.
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented
+- [x] Local dev start script
 
 ### Core engine capabilities
 
@@ -104,6 +105,14 @@ from the `web_gui` directory:
 cd web_gui
 npm install
 npx vite --open
+```
+
+### Start both services together
+
+Run the helper script in the repository root to launch the FastAPI backend and Vite dev server simultaneously:
+
+```bash
+python scripts/dev.py
 ```
 
 The GUI will automatically connect to the local FastAPI server's REST endpoints.

--- a/README.md
+++ b/README.md
@@ -28,16 +28,21 @@ Future work will expand these components.
 - [x] RuleSet interface for scoring
 - [x] Local single-player play via CLI
 - [x] Basic remote game creation via CLI
+- [x] Join remote games via CLI
+- [x] Draw tile in remote games via CLI
+- [x] Remote server health check via CLI
 - [ ] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages
 - [x] Basic GUI status display
+- [x] GUI server selection and retry
 - [x] React front-end skeleton
 - [x] Basic board layout
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
 - [x] Basic draw control via REST API
+- [x] Start game via GUI
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented
@@ -62,24 +67,47 @@ Future work will expand these components.
 - [x] standard wall initialization
 - [x] configurable ruleset
 - [x] event log
+- [x] current player tracking
 
-## Implementation plan
+## Implementation plan progress
 
-1. **Create the game engine** – wrap the Python `mahjong` library and expose
-   methods for drawing, discarding and scoring.
-2. **Integrate Mortal AI** – add a module that uses the
-   [MJAI high level API](https://mjai.app/docs/highlevel-api) to communicate with
-   the AI process and execute its moves.
-3. **Build CLI** – provide commands for starting a local game against the AI and
-   for connecting to remote games.
-4. **Implement FastAPI server** – expose REST and WebSocket endpoints for game
-   management and real-time play.
-5. **Develop React front-end** – consume the API and present a board based on the
-   `docs/board-layout.md` design.
-6. **Implement MJAI adapter** – translate game state to and from
-   `docs/mjai-ai-integration.md` so AI engines can connect via the protocol.
-7. **Set up GitHub Actions** – lint, type check, run tests and deploy the built
-   web front-end to GitHub Pages.
+- [x] **1. Create the game engine** – wrap the Python `mahjong` library and expose
+  methods for drawing, discarding and scoring.
+- [ ] **2. Integrate Mortal AI** – add a module that uses the
+  [MJAI high level API](https://mjai.app/docs/highlevel-api) to communicate with
+  the AI process and execute its moves.
+- [x] **3. Build CLI** – provide commands for starting a local game against the AI and
+  for connecting to remote games.
+- [x] **4. Implement FastAPI server** – expose REST endpoints and prepare a WebSocket
+  channel for real-time play.
+- [x] **5. Develop React front-end** – consume the API and present a board based on the
+  `docs/board-layout.md` design.
+- [ ] **6. Implement MJAI adapter** – translate game state to and from
+  `docs/mjai-ai-integration.md` so AI engines can connect via the protocol.
+- [x] **7. Set up GitHub Actions** – lint, type check, run tests and deploy the built
+  web front-end to GitHub Pages.
+- [ ] **8. Add action endpoints** – implement `POST /games/{id}/action` for draw,
+  discard, meld calls and win declarations.
+- [ ] **9. Stream events via WebSocket** – create `/ws/{id}` to push engine events so
+  the GUI updates instantly.
+- [ ] **10. Connect GUI state** – update React components to fetch the initial game,
+  handle WebSocket events and send player actions.
+- [ ] **11. Provide a mock AI** – run a simple MJAI-compatible process through the
+  adapter with an interface that later swaps in Mortal.
+- [ ] **12. Write end-to-end tests** – cover REST routes, WebSocket updates and basic
+  GUI interactions.
+
+### Remaining tasks
+
+The following plan steps are not yet implemented:
+
+- Step 2 – Integrate Mortal AI.
+- Step 6 – Implement MJAI adapter.
+- Step 8 – Add full action endpoints.
+- Step 9 – Stream events via WebSocket.
+- Step 10 – Connect GUI state to WebSocket updates.
+- Step 11 – Provide a mock AI.
+- Step 12 – Write end-to-end tests.
 
 See `docs/detailed-design.md` for an overview of the planned architecture.
 `docs/web-gui-architecture.md` provides more details about the planned React GUI.

--- a/cli/main.py
+++ b/cli/main.py
@@ -40,5 +40,36 @@ def join(game_id: int, server: str) -> None:
     click.echo(f"Joined game {game_id} with players: {names}")
 
 
+@cli.command()
+@click.argument("game_id", type=int)
+@click.argument("player_index", type=int)
+@click.option(
+    "--server",
+    "server",
+    "-s",
+    required=True,
+    help="Base URL of remote server",
+)
+def draw(game_id: int, player_index: int, server: str) -> None:
+    """Draw a tile for PLAYER_INDEX in a remote game."""
+    tile = remote_game.draw_tile(server, game_id, player_index)
+    click.echo(f"Player {player_index} drew {tile['suit']}{tile['value']}")
+
+
+@cli.command()
+@click.option(
+    "--server",
+    "server",
+    "-s",
+    required=True,
+    help="Base URL of remote server",
+)
+def health(server: str) -> None:
+    """Check remote server health."""
+    data = remote_game.check_health(server)
+    status = data.get("status", "unknown")
+    click.echo(f"Server status: {status}")
+
+
 if __name__ == "__main__":
     cli()

--- a/cli/remote_game.py
+++ b/cli/remote_game.py
@@ -18,3 +18,21 @@ def get_game(server: str, game_id: int) -> dict:
     resp = requests.get(url)
     resp.raise_for_status()
     return resp.json()
+
+
+def draw_tile(server: str, game_id: int, player_index: int) -> dict:
+    """Draw a tile for ``player_index`` in ``game_id`` and return the tile."""
+    url = f"{server.rstrip('/')}/games/{game_id}/action"
+    resp = requests.post(
+        url, json={"player_index": player_index, "action": "draw"}
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def check_health(server: str) -> dict:
+    """Check the remote server health endpoint."""
+    url = f"{server.rstrip('/')}/health"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -15,6 +15,7 @@ class MahjongEngine:
         self.ruleset: RuleSet = ruleset or StandardRuleSet()
         self.state = GameState(wall=Wall())
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
+        self.state.current_player = 0
         self.events: list[GameEvent] = []
         self.deal_initial_hands()
         self._emit("start_game", {"state": self.state})
@@ -115,7 +116,12 @@ class MahjongEngine:
 
     def skip(self, player_index: int) -> None:
         """Skip action for the specified player."""
-        _ = player_index  # currently no-op
+        if player_index != self.state.current_player:
+            return
+        self.state.current_player = (self.state.current_player + 1) % len(
+            self.state.players
+        )
+        self._emit("skip", {"player_index": player_index})
 
     def end_game(self) -> GameState:
         """Reset the engine and return the final state."""
@@ -124,4 +130,5 @@ class MahjongEngine:
         self._emit("end_game", {"scores": scores})
         self.state = GameState(wall=Wall())
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
+        self.state.current_player = 0
         return final_state

--- a/core/models.py
+++ b/core/models.py
@@ -35,6 +35,7 @@ class GameState:
     """Overall game state placeholder."""
     players: List["Player"] = field(default_factory=list)
     wall: Optional["Wall"] = None
+    current_player: int = 0
 
 
 @dataclass

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Run the FastAPI backend and React front-end together."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+from typing import List
+
+BACKEND_CMD = ["uvicorn", "web.server:app", "--reload"]
+FRONTEND_CMD = ["npx", "vite", "--open"]
+
+
+def start_processes() -> List[subprocess.Popen]:
+    """Start backend and frontend processes and return them."""
+    backend = subprocess.Popen(BACKEND_CMD)
+    frontend = subprocess.Popen(FRONTEND_CMD, cwd="web_gui")
+    return [backend, frontend]
+
+
+def terminate_processes(processes: List[subprocess.Popen]) -> None:
+    """Terminate all given processes."""
+    for p in processes:
+        if p.poll() is None:
+            p.terminate()
+    for p in processes:
+        try:
+            p.wait(timeout=5)
+        except Exception:
+            p.kill()
+
+
+def main() -> None:
+    processes = start_processes()
+
+    def _handle(signum: int, frame: object) -> None:
+        terminate_processes(processes)
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _handle)
+    signal.signal(signal.SIGTERM, _handle)
+
+    try:
+        processes[0].wait()
+    finally:
+        terminate_processes(processes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -31,3 +31,25 @@ def test_join_command_remote(monkeypatch) -> None:
     result = runner.invoke(cli, ["join", "1", "-s", "http://host"])
     assert result.exit_code == 0
     assert "Joined game 1" in result.output
+
+
+def test_draw_command_remote(monkeypatch) -> None:
+    def fake_draw(server: str, game_id: int, player_index: int) -> dict:
+        return {"suit": "m", "value": 5}
+
+    monkeypatch.setattr("cli.remote_game.draw_tile", fake_draw)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["draw", "1", "0", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "drew m5" in result.output
+
+
+def test_health_command_remote(monkeypatch) -> None:
+    def fake_health(server: str) -> dict:
+        return {"status": "ok"}
+
+    monkeypatch.setattr("cli.remote_game.check_health", fake_health)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["health", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "Server status: ok" in result.output

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -117,3 +117,21 @@ def test_event_log() -> None:
         "tsumo",
         "end_game",
     ]
+
+
+def test_skip_advances_turn_and_emits_event() -> None:
+    engine = MahjongEngine()
+    assert engine.state.current_player == 0
+    engine.pop_events()  # clear start_game
+    engine.skip(0)
+    assert engine.state.current_player == 1
+    events = engine.pop_events()
+    assert events and events[0].name == "skip"
+
+
+def test_skip_ignored_if_not_players_turn() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    engine.skip(1)
+    assert engine.state.current_player == 0
+    assert not engine.pop_events()

--- a/tests/scripts/test_dev.py
+++ b/tests/scripts/test_dev.py
@@ -1,0 +1,25 @@
+from scripts import dev
+import subprocess
+
+class DummyProcess:
+    def __init__(self, cmd, cwd=None):
+        self.cmd = cmd
+        self.cwd = cwd
+    def poll(self):
+        return 0
+    def terminate(self):
+        self.terminated = True
+    def wait(self, timeout=None):
+        return 0
+
+def test_start_processes(monkeypatch):
+    calls = []
+    def fake_popen(cmd, cwd=None):
+        p = DummyProcess(cmd, cwd)
+        calls.append((cmd, cwd))
+        return p
+    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    procs = dev.start_processes()
+    assert calls[0] == (dev.BACKEND_CMD, None)
+    assert calls[1] == (dev.FRONTEND_CMD, 'web_gui')
+    assert len(procs) == 2

--- a/tests/scripts/test_dev.py
+++ b/tests/scripts/test_dev.py
@@ -1,25 +1,32 @@
 from scripts import dev
 import subprocess
 
+
 class DummyProcess:
     def __init__(self, cmd, cwd=None):
         self.cmd = cmd
         self.cwd = cwd
+
     def poll(self):
         return 0
+
     def terminate(self):
         self.terminated = True
+
     def wait(self, timeout=None):
         return 0
 
+
 def test_start_processes(monkeypatch):
     calls = []
+
     def fake_popen(cmd, cwd=None):
         p = DummyProcess(cmd, cwd)
         calls.append((cmd, cwd))
         return p
-    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
     procs = dev.start_processes()
     assert calls[0] == (dev.BACKEND_CMD, None)
-    assert calls[1] == (dev.FRONTEND_CMD, 'web_gui')
+    assert calls[1] == (dev.FRONTEND_CMD, "web_gui")
     assert len(procs) == 2

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -64,3 +64,21 @@ def test_game_board_references_controls() -> None:
 def test_style_css_exists() -> None:
     css = Path('web_gui/style.css')
     assert css.is_file(), 'style.css missing'
+
+
+def test_app_has_server_selection() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert '<input' in text
+    assert 'Retry' in text
+
+
+def test_app_can_start_game() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Start Game' in text
+    assert '/games' in text
+
+
+def test_controls_use_server_prop() -> None:
+    text = Path('web_gui/Controls.jsx').read_text()
+    assert 'server' in text
+    assert '/games/1/action' in text

--- a/web/server.py
+++ b/web/server.py
@@ -3,11 +3,19 @@ from __future__ import annotations
 from dataclasses import asdict
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from core import api
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class CreateGameRequest(BaseModel):

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -3,29 +3,76 @@ import GameBoard from './GameBoard.jsx';
 import './style.css';
 
 export default function App() {
+  const [server, setServer] = useState('http://localhost:8000');
   const [status, setStatus] = useState('Contacting server...');
+  const [players, setPlayers] = useState('A,B,C,D');
+  const [gameState, setGameState] = useState(null);
+
+  async function fetchStatus() {
+    setStatus('Contacting server...');
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/health`);
+      if (resp.ok) {
+        const data = await resp.json();
+        setStatus(`Server status: ${data.status} (${server})`);
+      } else {
+        setStatus(`Server error: ${resp.status} (${server})`);
+      }
+    } catch {
+      setStatus(`Failed to contact server at ${server}`);
+    }
+  }
+
+  async function startGame() {
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ players: players.split(',').map((p) => p.trim()) }),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setGameState(data);
+        setStatus('Game started');
+      } else {
+        setStatus(`Failed to start game (${resp.status})`);
+      }
+    } catch {
+      setStatus(`Failed to contact server at ${server}`);
+    }
+  }
 
   useEffect(() => {
-    async function fetchStatus() {
-      try {
-        const resp = await fetch('http://localhost:8000/health');
-        if (resp.ok) {
-          const data = await resp.json();
-          setStatus(`Server status: ${data.status}`);
-        } else {
-          setStatus(`Server error: ${resp.status}`);
-        }
-      } catch {
-        setStatus('Failed to contact server');
-      }
-    }
     fetchStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <>
       <h1>MyMahjong GUI</h1>
-      <GameBoard />
+      <div>
+        <label>
+          Server:
+          <input
+            value={server}
+            onChange={(e) => setServer(e.target.value)}
+            style={{ width: '20em' }}
+          />
+        </label>
+        <button onClick={fetchStatus}>Retry</button>
+      </div>
+      <div>
+        <label>
+          Players:
+          <input
+            value={players}
+            onChange={(e) => setPlayers(e.target.value)}
+            style={{ width: '20em' }}
+          />
+        </label>
+        <button onClick={startGame}>Start Game</button>
+      </div>
+      <GameBoard state={gameState} server={server} />
       <p>{status}</p>
     </>
   );

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 
-export default function Controls() {
+export default function Controls({ server }) {
   const [message, setMessage] = useState('');
 
   async function draw() {
     try {
-      const resp = await fetch('http://localhost:8000/games/1/action', {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games/1/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ player_index: 0, action: 'draw' }),

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -5,32 +5,49 @@ import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
 import Controls from './Controls.jsx';
 
-export default function GameBoard() {
-  const hand = Array(13).fill('🀫');
+function tileLabel(tile) {
+  return `${tile.suit[0]}${tile.value}`;
+}
+export default function GameBoard({ state, server }) {
+  const players = state?.players ?? [];
+  const south = players[0];
+  const west = players[1];
+  const north = players[2];
+  const east = players[3];
+  const defaultHand = Array(13).fill('🀫');
+  const northHand = north?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const westHand = west?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const eastHand = east?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
+
   return (
     <div className="board-grid">
       <div className="north seat">
+        <div>{north?.name ?? 'North'}</div>
         <MeldArea melds={[]} />
-        <River tiles={[]} />
-        <Hand tiles={hand} />
+        <River tiles={(north?.river ?? []).map(tileLabel)} />
+        <Hand tiles={northHand} />
       </div>
       <div className="west seat">
+        <div>{west?.name ?? 'West'}</div>
         <MeldArea melds={[]} />
-        <River tiles={[]} />
-        <Hand tiles={hand} />
+        <River tiles={(west?.river ?? []).map(tileLabel)} />
+        <Hand tiles={westHand} />
       </div>
       <div className="center">
         <CenterDisplay />
       </div>
       <div className="east seat">
+        <div>{east?.name ?? 'East'}</div>
         <MeldArea melds={[]} />
-        <River tiles={[]} />
-        <Hand tiles={hand} />
+        <River tiles={(east?.river ?? []).map(tileLabel)} />
+        <Hand tiles={eastHand} />
       </div>
       <div className="south seat">
-        <River tiles={[]} />
-        <Hand tiles={hand} />
-        <Controls />
+        <div>{south?.name ?? 'South'}</div>
+        <River tiles={(south?.river ?? []).map(tileLabel)} />
+        <Hand tiles={southHand} />
+        <Controls server={server} />
         <MeldArea melds={[]} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `scripts/dev.py` to run FastAPI and Vite together
- test the new script
- document how to use it in README
- note the new feature in implementation status

## Testing
- `flake8`
- `mypy core web cli scripts`
- `pytest -q`
- `python -m build core`
- `python -m build cli`


------
https://chatgpt.com/codex/tasks/task_e_6868de266414832a8f83550be49610de