### PR TITLE
Add health command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Future work will expand these components.
 - [x] Basic remote game creation via CLI
 - [x] Join remote games via CLI
 - [x] Draw tile in remote games via CLI
+- [x] Remote server health check via CLI
 - [ ] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages

--- a/cli/main.py
+++ b/cli/main.py
@@ -56,5 +56,20 @@ def draw(game_id: int, player_index: int, server: str) -> None:
     click.echo(f"Player {player_index} drew {tile['suit']}{tile['value']}")
 
 
+@cli.command()
+@click.option(
+    "--server",
+    "server",
+    "-s",
+    required=True,
+    help="Base URL of remote server",
+)
+def health(server: str) -> None:
+    """Check remote server health."""
+    data = remote_game.check_health(server)
+    status = data.get("status", "unknown")
+    click.echo(f"Server status: {status}")
+
+
 if __name__ == "__main__":
     cli()

--- a/cli/remote_game.py
+++ b/cli/remote_game.py
@@ -28,3 +28,11 @@ def draw_tile(server: str, game_id: int, player_index: int) -> dict:
     )
     resp.raise_for_status()
     return resp.json()
+
+
+def check_health(server: str) -> dict:
+    """Check the remote server health endpoint."""
+    url = f"{server.rstrip('/')}/health"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -42,3 +42,14 @@ def test_draw_command_remote(monkeypatch) -> None:
     result = runner.invoke(cli, ["draw", "1", "0", "-s", "http://host"])
     assert result.exit_code == 0
     assert "drew m5" in result.output
+
+
+def test_health_command_remote(monkeypatch) -> None:
+    def fake_health(server: str) -> dict:
+        return {"status": "ok"}
+
+    monkeypatch.setattr("cli.remote_game.check_health", fake_health)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["health", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "Server status: ok" in result.output


### PR DESCRIPTION
## Summary
- extend `cli.main` with `health` command to check server status
- add `remote_game.check_health` helper
- document new CLI feature in README
- test the new command

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868e19bb3e4832a96b85bb7e8f1d60d