### PR TITLE
Enhance turn tracking in engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Future work will expand these components.
 - [x] standard wall initialization
 - [x] configurable ruleset
 - [x] event log
+- [x] current player tracking
 
 ## Implementation plan progress
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -15,6 +15,7 @@ class MahjongEngine:
         self.ruleset: RuleSet = ruleset or StandardRuleSet()
         self.state = GameState(wall=Wall())
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
+        self.state.current_player = 0
         self.events: list[GameEvent] = []
         self.deal_initial_hands()
         self._emit("start_game", {"state": self.state})
@@ -115,7 +116,12 @@ class MahjongEngine:
 
     def skip(self, player_index: int) -> None:
         """Skip action for the specified player."""
-        _ = player_index  # currently no-op
+        if player_index != self.state.current_player:
+            return
+        self.state.current_player = (self.state.current_player + 1) % len(
+            self.state.players
+        )
+        self._emit("skip", {"player_index": player_index})
 
     def end_game(self) -> GameState:
         """Reset the engine and return the final state."""
@@ -124,4 +130,5 @@ class MahjongEngine:
         self._emit("end_game", {"scores": scores})
         self.state = GameState(wall=Wall())
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
+        self.state.current_player = 0
         return final_state

--- a/core/models.py
+++ b/core/models.py
@@ -35,6 +35,7 @@ class GameState:
     """Overall game state placeholder."""
     players: List["Player"] = field(default_factory=list)
     wall: Optional["Wall"] = None
+    current_player: int = 0
 
 
 @dataclass

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -117,3 +117,21 @@ def test_event_log() -> None:
         "tsumo",
         "end_game",
     ]
+
+
+def test_skip_advances_turn_and_emits_event() -> None:
+    engine = MahjongEngine()
+    assert engine.state.current_player == 0
+    engine.pop_events()  # clear start_game
+    engine.skip(0)
+    assert engine.state.current_player == 1
+    events = engine.pop_events()
+    assert events and events[0].name == "skip"
+
+
+def test_skip_ignored_if_not_players_turn() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    engine.skip(1)
+    assert engine.state.current_player == 0
+    assert not engine.pop_events()


### PR DESCRIPTION
## Summary
- track current player in `GameState`
- implement skip action to advance turn
- update engine reset logic
- document new feature in README
- test turn rotation

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`

------
https://chatgpt.com/codex/tasks/task_e_6868e1a1fdf8832ab977a0d7c9904dc1