### PR TITLE
Improve web GUI with game creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Future work will expand these components.
 - [x] Meld area component
 - [x] Center display (dora & wall count)
 - [x] Basic draw control via REST API
+- [x] Start game via GUI
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -70,3 +70,15 @@ def test_app_has_server_selection() -> None:
     text = Path('web_gui/App.jsx').read_text()
     assert '<input' in text
     assert 'Retry' in text
+
+
+def test_app_can_start_game() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Start Game' in text
+    assert '/games' in text
+
+
+def test_controls_use_server_prop() -> None:
+    text = Path('web_gui/Controls.jsx').read_text()
+    assert 'server' in text
+    assert '/games/1/action' in text

--- a/web/server.py
+++ b/web/server.py
@@ -3,11 +3,19 @@ from __future__ import annotations
 from dataclasses import asdict
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from core import api
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class CreateGameRequest(BaseModel):

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -5,6 +5,8 @@ import './style.css';
 export default function App() {
   const [server, setServer] = useState('http://localhost:8000');
   const [status, setStatus] = useState('Contacting server...');
+  const [players, setPlayers] = useState('A,B,C,D');
+  const [gameState, setGameState] = useState(null);
 
   async function fetchStatus() {
     setStatus('Contacting server...');
@@ -15,6 +17,25 @@ export default function App() {
         setStatus(`Server status: ${data.status} (${server})`);
       } else {
         setStatus(`Server error: ${resp.status} (${server})`);
+      }
+    } catch {
+      setStatus(`Failed to contact server at ${server}`);
+    }
+  }
+
+  async function startGame() {
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ players: players.split(',').map((p) => p.trim()) }),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setGameState(data);
+        setStatus('Game started');
+      } else {
+        setStatus(`Failed to start game (${resp.status})`);
       }
     } catch {
       setStatus(`Failed to contact server at ${server}`);
@@ -40,7 +61,18 @@ export default function App() {
         </label>
         <button onClick={fetchStatus}>Retry</button>
       </div>
-      <GameBoard />
+      <div>
+        <label>
+          Players:
+          <input
+            value={players}
+            onChange={(e) => setPlayers(e.target.value)}
+            style={{ width: '20em' }}
+          />
+        </label>
+        <button onClick={startGame}>Start Game</button>
+      </div>
+      <GameBoard state={gameState} server={server} />
       <p>{status}</p>
     </>
   );

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 
-export default function Controls() {
+export default function Controls({ server }) {
   const [message, setMessage] = useState('');
 
   async function draw() {
     try {
-      const resp = await fetch('http://localhost:8000/games/1/action', {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games/1/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ player_index: 0, action: 'draw' }),

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -5,32 +5,49 @@ import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
 import Controls from './Controls.jsx';
 
-export default function GameBoard() {
-  const hand = Array(13).fill('🀫');
+function tileLabel(tile) {
+  return `${tile.suit[0]}${tile.value}`;
+}
+export default function GameBoard({ state, server }) {
+  const players = state?.players ?? [];
+  const south = players[0];
+  const west = players[1];
+  const north = players[2];
+  const east = players[3];
+  const defaultHand = Array(13).fill('🀫');
+  const northHand = north?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const westHand = west?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const eastHand = east?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
+
   return (
     <div className="board-grid">
       <div className="north seat">
+        <div>{north?.name ?? 'North'}</div>
         <MeldArea melds={[]} />
-        <River tiles={[]} />
-        <Hand tiles={hand} />
+        <River tiles={(north?.river ?? []).map(tileLabel)} />
+        <Hand tiles={northHand} />
       </div>
       <div className="west seat">
+        <div>{west?.name ?? 'West'}</div>
         <MeldArea melds={[]} />
-        <River tiles={[]} />
-        <Hand tiles={hand} />
+        <River tiles={(west?.river ?? []).map(tileLabel)} />
+        <Hand tiles={westHand} />
       </div>
       <div className="center">
         <CenterDisplay />
       </div>
       <div className="east seat">
+        <div>{east?.name ?? 'East'}</div>
         <MeldArea melds={[]} />
-        <River tiles={[]} />
-        <Hand tiles={hand} />
+        <River tiles={(east?.river ?? []).map(tileLabel)} />
+        <Hand tiles={eastHand} />
       </div>
       <div className="south seat">
-        <River tiles={[]} />
-        <Hand tiles={hand} />
-        <Controls />
+        <div>{south?.name ?? 'South'}</div>
+        <River tiles={(south?.river ?? []).map(tileLabel)} />
+        <Hand tiles={southHand} />
+        <Controls server={server} />
         <MeldArea melds={[]} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow cross-origin requests in FastAPI server
- add game creation controls to React front-end
- pass server address down to Controls component
- show player names and hands on the board
- document new feature in README
- test presence of new GUI elements

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`


------
https://chatgpt.com/codex/tasks/task_e_6868e1a87898832a8e6e283c44af5fe7