### PR TITLE
Add basic MJAI adapter utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Future work will expand these components.
 - [ ] Mortal AI integration
 - [x] Mortal backend integration design
 - [ ] MJAI protocol support
+- [x] Basic MJAI event serialization
 - [x] GameState JSON serialization
 - [x] RuleSet interface for scoring
 - [x] Local single-player play via CLI

--- a/core/ai_adapter.py
+++ b/core/ai_adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 
-from .models import GameState
+from .models import GameEvent, GameState
 from .mortal_runner import MortalAI
 
 
@@ -25,3 +25,29 @@ def send_state_to_ai(state: GameState, ai: MortalAI) -> None:
 
     message = game_state_to_json(state)
     ai.send(message)
+
+
+def event_to_json(event: GameEvent) -> str:
+    """Return a JSON message describing ``event``."""
+
+    payload = {"type": event.name}
+    payload.update(event.payload)
+    return json.dumps(payload)
+
+
+def send_event_to_ai(event: GameEvent, ai: MortalAI) -> None:
+    """Serialize ``event`` and send it to ``ai``."""
+
+    ai.send(event_to_json(event))
+
+
+def json_to_action(message: str) -> dict:
+    """Parse a JSON-encoded AI action message."""
+
+    return json.loads(message)
+
+
+def receive_action(ai: MortalAI) -> dict:
+    """Receive a JSON action from ``ai`` and return it as a dict."""
+
+    return json_to_action(ai.receive())

--- a/tests/core/test_ai_adapter.py
+++ b/tests/core/test_ai_adapter.py
@@ -1,5 +1,12 @@
-from core.ai_adapter import game_state_to_json, send_state_to_ai
-from core.models import GameState, Tile
+from core.ai_adapter import (
+    game_state_to_json,
+    send_state_to_ai,
+    event_to_json,
+    send_event_to_ai,
+    json_to_action,
+    receive_action,
+)
+from core.models import GameState, Tile, GameEvent
 from core.mortal_runner import MortalAI
 from core.player import Player
 from core.wall import Wall
@@ -12,6 +19,9 @@ class DummyAI(MortalAI):
 
     def send(self, message: str) -> None:  # type: ignore[override]
         self.sent_messages.append(message)
+
+    def receive(self) -> str:  # type: ignore[override]
+        return self.sent_messages.pop(0)
 
 
 def test_game_state_to_json() -> None:
@@ -30,3 +40,32 @@ def test_send_state_to_ai() -> None:
     send_state_to_ai(state, ai)
     assert len(ai.sent_messages) == 1
     assert json.loads(ai.sent_messages[0])["players"][0]["name"] == "A"
+
+
+def test_event_conversion_roundtrip() -> None:
+    event = GameEvent(
+        name="draw_tile",
+        payload={"player_index": 0, "tile": {"suit": "man", "value": 1}},
+    )
+    data = json.loads(event_to_json(event))
+    assert data["type"] == "draw_tile"
+    assert data["tile"]["value"] == 1
+
+
+def test_json_to_action() -> None:
+    msg = '{"type": "discard", "tile": {"suit": "pin", "value": 3}}'
+    action = json_to_action(msg)
+    assert action["type"] == "discard"
+    assert action["tile"]["value"] == 3
+
+
+def test_send_and_receive_event() -> None:
+    ai = DummyAI()
+    event = GameEvent(
+        name="end_game",
+        payload={"scores": [25000, 24000, 23000, 26000]},
+    )
+    send_event_to_ai(event, ai)
+    received = receive_action(ai)
+    assert received["type"] == "end_game"
+    assert received["scores"] == [25000, 24000, 23000, 26000]


### PR DESCRIPTION
## Summary
- implement JSON conversion helpers for AI events
- add tests for AI adapter
- document feature progress in README

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e33dd934832a81b78fc667f8a3ab