### PR TITLE
Add CLI state command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Future work will expand these components.
 - [x] Basic remote game creation via CLI
 - [x] Join remote games via CLI
 - [x] Draw tile in remote games via CLI
+- [x] View remote game state via CLI
 - [x] Remote server health check via CLI
 - [ ] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)

--- a/cli/main.py
+++ b/cli/main.py
@@ -57,6 +57,24 @@ def draw(game_id: int, player_index: int, server: str) -> None:
 
 
 @cli.command()
+@click.argument("game_id", type=int)
+@click.option(
+    "--server",
+    "server",
+    "-s",
+    required=True,
+    help="Base URL of remote server",
+)
+def state(game_id: int, server: str) -> None:
+    """Display the current state of a remote game."""
+    data = remote_game.get_game(server, game_id)
+    names = ", ".join(p["name"] for p in data.get("players", []))
+    remaining = data.get("wall", {}).get("remaining_tiles")
+    msg = f"Game {game_id}: {remaining} tiles remaining; players: {names}"
+    click.echo(msg)
+
+
+@cli.command()
 @click.option(
     "--server",
     "server",

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -53,3 +53,18 @@ def test_health_command_remote(monkeypatch) -> None:
     result = runner.invoke(cli, ["health", "-s", "http://host"])
     assert result.exit_code == 0
     assert "Server status: ok" in result.output
+
+
+def test_state_command_remote(monkeypatch) -> None:
+    def fake_get(server: str, game_id: int) -> dict:
+        return {
+            "players": [{"name": "A"}, {"name": "B"}],
+            "wall": {"remaining_tiles": 10},
+        }
+
+    monkeypatch.setattr("cli.remote_game.get_game", fake_get)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["state", "1", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "10 tiles remaining" in result.output
+    assert "A, B" in result.output


### PR DESCRIPTION
## Summary
- add `state` command in CLI to display remote game status
- document CLI feature in README
- test new CLI command

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`
- `python -m build web`


------
https://chatgpt.com/codex/tasks/task_e_6868e3b3f5c4832aa5b49dbb57c06bb6