### PR TITLE
Implement websocket event streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Future work will expand these components.
 - [x] Join remote games via CLI
 - [x] Draw tile in remote games via CLI
 - [x] Remote server health check via CLI
-- [ ] REST + WebSocket API
+- [x] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)
 - [x] Web GUI served through GitHub Pages
 - [x] Basic GUI status display
@@ -87,7 +87,7 @@ Future work will expand these components.
   web front-end to GitHub Pages.
 - [ ] **8. Add action endpoints** – implement `POST /games/{id}/action` for draw,
   discard, meld calls and win declarations.
-- [ ] **9. Stream events via WebSocket** – create `/ws/{id}` to push engine events so
+- [x] **9. Stream events via WebSocket** – create `/ws/{id}` to push engine events so
   the GUI updates instantly.
 - [ ] **10. Connect GUI state** – update React components to fetch the initial game,
   handle WebSocket events and send player actions.
@@ -103,7 +103,6 @@ The following plan steps are not yet implemented:
 - Step 2 – Integrate Mortal AI.
 - Step 6 – Implement MJAI adapter.
 - Step 8 – Add full action endpoints.
-- Step 9 – Stream events via WebSocket.
 - Step 10 – Connect GUI state to WebSocket updates.
 - Step 11 – Provide a mock AI.
 - Step 12 – Write end-to-end tests.

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -32,3 +32,31 @@ def test_draw_action_endpoint() -> None:
     assert resp.status_code == 200
     tile = resp.json()
     assert "suit" in tile and "value" in tile
+
+
+def test_discard_action_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    draw = client.post(
+        "/games/1/action",
+        json={"player_index": 0, "action": "draw"},
+    )
+    tile = draw.json()
+    resp = client.post(
+        "/games/1/action",
+        json={"player_index": 0, "action": "discard", "tile": tile},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_websocket_streams_events() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    with client.websocket_connect("/ws/1") as ws:
+        data = ws.receive_json()
+        assert data["name"] == "start_game"
+        client.post(
+            "/games/1/action",
+            json={"player_index": 0, "action": "draw"},
+        )
+        data = ws.receive_json()
+        assert data["name"] == "draw_tile"

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -78,6 +78,11 @@ def test_app_can_start_game() -> None:
     assert '/games' in text
 
 
+def test_app_opens_websocket() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert '/ws/1' in text
+
+
 def test_controls_use_server_prop() -> None:
     text = Path('web_gui/Controls.jsx').read_text()
     assert 'server' in text


### PR DESCRIPTION
## Summary
- implement server-side websocket endpoint to stream events
- support discard via action API
- auto-connect React app to the new WebSocket
- add tests for new endpoints and front-end references
- document WebSocket feature as complete

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e3add354832a811526e0fb3b83a8