### PR TITLE
Add tile emoji display to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Tile emoji rendering in GUI
 - [x] Basic draw control via REST API
 - [x] Start game via GUI
 - [x] Continuous integration workflow

--- a/tests/web_gui/test_tile_emoji.py
+++ b/tests/web_gui/test_tile_emoji.py
@@ -1,0 +1,19 @@
+import subprocess
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run([
+        "node",
+        "-e",
+        code,
+    ], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_tile_to_emoji() -> None:
+    output = run_node(
+        "import { tileToEmoji } from './web_gui/tileUtils.js';\n"
+        "console.log(tileToEmoji({suit: 'sou', value: 8}));"
+    )
+    assert output == '🀗'

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -4,9 +4,10 @@ import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
 import Controls from './Controls.jsx';
+import { tileToEmoji } from './tileUtils.js';
 
 function tileLabel(tile) {
-  return `${tile.suit[0]}${tile.value}`;
+  return tileToEmoji(tile);
 }
 export default function GameBoard({ state, server }) {
   const players = state?.players ?? [];

--- a/web_gui/tileUtils.js
+++ b/web_gui/tileUtils.js
@@ -1,0 +1,19 @@
+export function tileToEmoji(tile) {
+  const { suit, value } = tile;
+  if (suit === 'man') {
+    return String.fromCodePoint(0x1f007 + (value - 1));
+  }
+  if (suit === 'sou') {
+    return String.fromCodePoint(0x1f010 + (value - 1));
+  }
+  if (suit === 'pin') {
+    return String.fromCodePoint(0x1f019 + (value - 1));
+  }
+  if (suit === 'wind') {
+    return String.fromCodePoint(0x1f000 + (value - 1));
+  }
+  if (suit === 'dragon') {
+    return String.fromCodePoint(0x1f004 + (value - 1));
+  }
+  return `${suit[0]}${value}`;
+}


### PR DESCRIPTION
## Summary
- show emoji for tiles on the game board
- note emoji feature in the README
- test tile-to-emoji helper

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e6e0d4a8832ab4e58cc2a9305182