### PR TITLE
Fix empty wall error handling

### DIFF
--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -49,6 +49,19 @@ def test_discard_action_endpoint() -> None:
     assert resp.json() == {"status": "ok"}
 
 
+def test_draw_from_empty_wall_returns_error() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    from core import api
+    assert api._engine is not None
+    api._engine.state.wall.tiles = []  # type: ignore[list]
+    resp = client.post(
+        "/games/1/action",
+        json={"player_index": 0, "action": "draw"},
+    )
+    assert resp.status_code == 409
+    assert resp.json() == {"detail": "Wall is empty"}
+
+
 def test_websocket_streams_events() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     with client.websocket_connect("/ws/1") as ws:

--- a/web/server.py
+++ b/web/server.py
@@ -58,7 +58,10 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
     """Perform a simple game action and return its result."""
     _ = game_id  # placeholder for future multi-game support
     if req.action == "draw":
-        tile = api.draw_tile(req.player_index)
+        try:
+            tile = api.draw_tile(req.player_index)
+        except IndexError:
+            raise HTTPException(status_code=409, detail="Wall is empty")
         return asdict(tile)
     if req.action == "discard" and req.tile:
         tile = models.Tile(**req.tile)

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -14,7 +14,13 @@ export default function Controls({ server }) {
         const tile = await resp.json();
         setMessage(`Drew ${tile.suit} ${tile.value}`);
       } else {
-        setMessage('Error drawing tile');
+        let data = null;
+        try {
+          data = await resp.json();
+        } catch {
+          // ignore
+        }
+        setMessage(data?.detail || 'Error drawing tile');
       }
     } catch {
       setMessage('Server unreachable');


### PR DESCRIPTION
## Summary
- handle empty wall draw request in backend
- surface backend error message in GUI
- test that API reports error when wall is empty

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e7608d70832abb66fcf2bcae8f90