### PR TITLE
Add core action dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Future work will expand these components.
 - [x] configurable ruleset
 - [x] event log
 - [x] current player tracking
+- [x] action dispatch helper
 
 ## Implementation plan progress
 

--- a/core/api.py
+++ b/core/api.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
-from .models import GameState, Tile, GameEvent
+from .models import GameState, Tile, GameEvent, GameAction
 from mahjong.hand_calculating.hand_response import HandResponse
 
 # Singleton engine instance used by interfaces
@@ -89,3 +89,47 @@ def pop_events() -> list[GameEvent]:
     """Retrieve and clear pending engine events."""
     assert _engine is not None, "Game not started"
     return _engine.pop_events()
+
+
+def apply_action(action: GameAction) -> object | None:
+    """Apply ``action`` to the running engine and return any result."""
+
+    assert _engine is not None, "Game not started"
+
+    if action.type == "draw":
+        assert action.player_index is not None
+        return _engine.draw_tile(action.player_index)
+    if action.type == "discard" and action.tile is not None:
+        assert action.player_index is not None
+        _engine.discard_tile(action.player_index, action.tile)
+        return None
+    if action.type == "chi" and action.tiles is not None:
+        assert action.player_index is not None
+        _engine.call_chi(action.player_index, action.tiles)
+        return None
+    if action.type == "pon" and action.tiles is not None:
+        assert action.player_index is not None
+        _engine.call_pon(action.player_index, action.tiles)
+        return None
+    if action.type == "kan" and action.tiles is not None:
+        assert action.player_index is not None
+        _engine.call_kan(action.player_index, action.tiles)
+        return None
+    if action.type == "riichi":
+        assert action.player_index is not None
+        _engine.declare_riichi(action.player_index)
+        return None
+    if action.type == "tsumo" and action.tile is not None:
+        assert action.player_index is not None
+        return _engine.declare_tsumo(action.player_index, action.tile)
+    if action.type == "ron" and action.tile is not None:
+        assert action.player_index is not None
+        return _engine.declare_ron(action.player_index, action.tile)
+    if action.type == "skip":
+        assert action.player_index is not None
+        _engine.skip(action.player_index)
+        return None
+    if action.type == "end_game":
+        return _engine.end_game()
+
+    raise ValueError(f"Unknown action: {action.type}")

--- a/core/models.py
+++ b/core/models.py
@@ -44,3 +44,13 @@ class GameEvent:
 
     name: str
     payload: dict[str, Any]
+
+
+@dataclass
+class GameAction:
+    """Action issued by a player or AI."""
+
+    type: str
+    player_index: int | None = None
+    tile: Tile | None = None
+    tiles: list[Tile] | None = None

--- a/tests/core/test_apply_action.py
+++ b/tests/core/test_apply_action.py
@@ -1,0 +1,22 @@
+import pytest
+from core import api, models
+
+
+def test_apply_action_draw_discard() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    assert state.wall is not None
+    tile = models.Tile(suit="sou", value=9)
+    state.wall.tiles.append(tile)
+    draw = models.GameAction(type="draw", player_index=0)
+    result = api.apply_action(draw)
+    assert result == tile
+    discard = models.GameAction(type="discard", player_index=0, tile=tile)
+    api.apply_action(discard)
+    assert tile in state.players[0].river
+
+
+def test_apply_action_unknown() -> None:
+    api.start_game(["A", "B", "C", "D"])
+    action = models.GameAction(type="foo", player_index=0)
+    with pytest.raises(ValueError):
+        api.apply_action(action)


### PR DESCRIPTION
## Summary
- extend core data models with GameAction dataclass
- implement `apply_action` function in core API
- export new capability in README checklists
- add tests for action dispatching

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`


------
https://chatgpt.com/codex/tasks/task_e_6868f012f2f8832ab5c513f15567bc42