### PR TITLE
Improve web UI display

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Meld display from game state
 - [x] Tile emoji rendering in GUI
 - [x] Basic draw control via REST API
 - [x] Discard tiles via GUI

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -94,7 +94,18 @@ def test_hand_supports_discard() -> None:
     assert 'onDiscard' in text
 
 
+def test_hand_uses_tile_to_emoji() -> None:
+    text = Path('web_gui/Hand.jsx').read_text()
+    assert 'tileToEmoji' in text
+
+
 def test_app_handles_websocket_events() -> None:
     text = Path('web_gui/App.jsx').read_text()
     assert 'handleMessage' in text
     assert 'event-log' in text
+
+
+def test_game_board_displays_melds_and_remaining() -> None:
+    text = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'northMelds' in text
+    assert 'remaining={remaining}' in text

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function CenterDisplay({ remaining = 70, dora = ['\uD83C\uDE00'] }) {
+export default function CenterDisplay({ remaining = 0, dora = [] }) {
   return (
     <div className="center-display">
       <div className="remaining">Remaining: {remaining}</div>

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -19,7 +19,13 @@ export default function GameBoard({ state, server }) {
   const northHand = north?.hand?.tiles.map(tileLabel) ?? defaultHand;
   const westHand = west?.hand?.tiles.map(tileLabel) ?? defaultHand;
   const eastHand = east?.hand?.tiles.map(tileLabel) ?? defaultHand;
-  const southHand = south?.hand?.tiles ?? defaultHand;
+  const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
+  const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
+  const eastMelds = east?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
+  const southMelds = south?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
+  const remaining = state?.wall?.tiles?.length ?? 0;
+  const dora = state?.wall?.tiles?.[0] ? [tileLabel(state.wall.tiles[0])] : [];
 
   async function discard(tile) {
     try {
@@ -37,22 +43,22 @@ export default function GameBoard({ state, server }) {
     <div className="board-grid">
       <div className="north seat">
         <div>{north?.name ?? 'North'}</div>
-        <MeldArea melds={[]} />
+        <MeldArea melds={northMelds} />
         <River tiles={(north?.river ?? []).map(tileLabel)} />
         <Hand tiles={northHand} />
       </div>
       <div className="west seat">
         <div>{west?.name ?? 'West'}</div>
-        <MeldArea melds={[]} />
+        <MeldArea melds={westMelds} />
         <River tiles={(west?.river ?? []).map(tileLabel)} />
         <Hand tiles={westHand} />
       </div>
       <div className="center">
-        <CenterDisplay />
+        <CenterDisplay remaining={remaining} dora={dora} />
       </div>
       <div className="east seat">
         <div>{east?.name ?? 'East'}</div>
-        <MeldArea melds={[]} />
+        <MeldArea melds={eastMelds} />
         <River tiles={(east?.river ?? []).map(tileLabel)} />
         <Hand tiles={eastHand} />
       </div>
@@ -61,7 +67,7 @@ export default function GameBoard({ state, server }) {
         <River tiles={(south?.river ?? []).map(tileLabel)} />
         <Hand tiles={southHand} onDiscard={discard} />
         <Controls server={server} />
-        <MeldArea melds={[]} />
+        <MeldArea melds={southMelds} />
       </div>
     </div>
   );

--- a/web_gui/Hand.jsx
+++ b/web_gui/Hand.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { tileToEmoji } from './tileUtils.js';
 
 export default function Hand({ tiles = [], onDiscard }) {
   return (
     <div className="hand">
       {tiles.map((t, i) => {
-        const label = typeof t === 'string' ? t : `${t.suit[0]}${t.value}`;
+        const label = typeof t === 'string' ? t : tileToEmoji(t);
         return onDiscard ? (
           <button
             key={i}


### PR DESCRIPTION
## Summary
- show meld tiles and remaining wall tiles in the React board
- render player's own tiles with emoji helper
- expose remaining/dora info via `CenterDisplay`
- add tests for new React code
- note meld display in README

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868f01b5ca4832a92e79ebd326f5f7f