### PR TITLE
Fix tile emoji and wall count in GUI

### DIFF
--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -98,3 +98,18 @@ def test_app_handles_websocket_events() -> None:
     text = Path('web_gui/App.jsx').read_text()
     assert 'handleMessage' in text
     assert 'event-log' in text
+
+
+def test_game_board_passes_remaining_prop() -> None:
+    board = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'remaining={' in board
+
+
+def test_south_hand_displays_emojis() -> None:
+    board = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'south?.hand?.tiles.map(tileLabel)' in board
+
+
+def test_app_updates_wall_on_draw() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'wall.tiles.pop()' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -65,6 +65,7 @@ export default function App() {
       case 'draw_tile': {
         const p = newState.players[event.payload.player_index];
         if (p) p.hand.tiles.push(event.payload.tile);
+        if (newState.wall?.tiles?.length) newState.wall.tiles.pop();
         break;
       }
       case 'discard': {

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function CenterDisplay({ remaining = 70, dora = ['\uD83C\uDE00'] }) {
+export default function CenterDisplay({ remaining = 0, dora = ['\uD83C\uDE00'] }) {
   return (
     <div className="center-display">
       <div className="remaining">Remaining: {remaining}</div>

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -19,7 +19,9 @@ export default function GameBoard({ state, server }) {
   const northHand = north?.hand?.tiles.map(tileLabel) ?? defaultHand;
   const westHand = west?.hand?.tiles.map(tileLabel) ?? defaultHand;
   const eastHand = east?.hand?.tiles.map(tileLabel) ?? defaultHand;
-  const southHand = south?.hand?.tiles ?? defaultHand;
+  const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
+
+  const remaining = state?.wall?.tiles?.length ?? 0;
 
   async function discard(tile) {
     try {
@@ -48,7 +50,7 @@ export default function GameBoard({ state, server }) {
         <Hand tiles={westHand} />
       </div>
       <div className="center">
-        <CenterDisplay />
+        <CenterDisplay remaining={remaining} />
       </div>
       <div className="east seat">
         <div>{east?.name ?? 'East'}</div>


### PR DESCRIPTION
## Summary
- update south hand rendering to use emoji tiles
- show remaining wall tiles in the center display
- track wall tile count in GUI state updates
- adjust CenterDisplay defaults
- test that GameBoard passes remaining prop and uses emoji

## Testing
- `python -m pip install -e ./core -e ./web -e ./cli`
- `python -m pip install flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `/root/.pyenv/versions/3.12.10/bin/flake8`
- `/root/.pyenv/versions/3.12.10/bin/mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f09fd250832a923f1c2e2cea851e