### PR TITLE
Add initial 何切る問題 practice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Future work will expand these components.
 - [x] Core <-> interface API documented
 - [x] GUI design documented
 - [ ] 何切る問題 mode
+  - [x] CLI practice command
+  - [ ] AI recommendation
+  - [ ] Web UI support
 
 ### Core engine capabilities
 
@@ -121,6 +124,12 @@ See `docs/detailed-design.md` for an overview of the planned architecture.
 ## 何切る問題 mode (planned)
 
 This practice mode will present a what-to-discard problem to the player.
+
+An initial version is available via the CLI:
+
+```bash
+python -m cli.main practice
+```
 
 ### Planned workflow
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2,6 +2,7 @@ import click
 
 from . import remote_game
 from .local_game import run_game
+from core import practice, models
 
 
 @click.group()
@@ -87,6 +88,28 @@ def health(server: str) -> None:
     data = remote_game.check_health(server)
     status = data.get("status", "unknown")
     click.echo(f"Server status: {status}")
+
+
+@cli.command(name="practice")
+def practice_cmd() -> None:
+    """Run a simple '何切る' practice problem."""
+
+    problem = practice.generate_problem()
+
+    def fmt(tile: models.Tile) -> str:
+        return f"{tile.suit[0]}{tile.value}"
+
+    click.echo(f"Seat wind: {problem.seat_wind}")
+    click.echo(f"Dora indicator: {fmt(problem.dora_indicator)}")
+    hand_str = " ".join(
+        f"{i+1}:{fmt(t)}" for i, t in enumerate(problem.hand)
+    )
+    click.echo(f"Hand: {hand_str}")
+    index = click.prompt("Discard which tile number?", type=int)
+    chosen = problem.hand[index - 1]
+    click.echo(f"You discarded {fmt(chosen)}")
+    ai_suggestion = practice.suggest_discard(problem.hand)
+    click.echo(f"AI suggests discarding {fmt(ai_suggestion)}")
 
 
 if __name__ == "__main__":

--- a/core/practice.py
+++ b/core/practice.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Helpers for '何切る問題' practice mode."""
+
+from dataclasses import dataclass
+import random
+
+from .mahjong_engine import MahjongEngine
+from .models import Tile
+
+
+@dataclass
+class PracticeProblem:
+    """Scenario presented to the player."""
+
+    hand: list[Tile]
+    dora_indicator: Tile
+    seat_wind: str
+
+
+def generate_problem() -> PracticeProblem:
+    """Return a practice scenario with a random hand, seat wind and dora."""
+
+    engine = MahjongEngine()
+    engine.pop_events()  # discard start event
+    engine.draw_tile(0)
+    hand = engine.state.players[0].hand.tiles.copy()
+    if engine.state.wall:
+        dora = random.choice(engine.state.wall.tiles)
+    else:
+        dora = Tile("man", 1)
+    seat_wind = random.choice(["east", "south", "west", "north"])
+    return PracticeProblem(hand=hand, dora_indicator=dora, seat_wind=seat_wind)
+
+
+def suggest_discard(hand: list[Tile]) -> Tile:
+    """Return the AI suggested discard. Placeholder implementation."""
+
+    return random.choice(hand)

--- a/tests/cli/test_practice_command.py
+++ b/tests/cli/test_practice_command.py
@@ -1,0 +1,22 @@
+from click.testing import CliRunner
+
+from cli.main import cli
+from core import practice, models
+
+
+def test_practice_command(monkeypatch):
+    hand = [models.Tile("man", 1) for _ in range(14)]
+    problem = practice.PracticeProblem(
+        hand=hand,
+        dora_indicator=models.Tile("pin", 9),
+        seat_wind="east",
+    )
+    monkeypatch.setattr(practice, "generate_problem", lambda: problem)
+    monkeypatch.setattr(practice, "suggest_discard", lambda h: h[0])
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["practice"], input="1\n")
+
+    assert result.exit_code == 0
+    assert "Seat wind: east" in result.output
+    assert "AI suggests discarding m1" in result.output

--- a/tests/core/test_practice.py
+++ b/tests/core/test_practice.py
@@ -1,0 +1,18 @@
+from core import practice
+from core.models import Tile
+
+
+def test_generate_problem(monkeypatch):
+    # make random.choice deterministic
+    monkeypatch.setattr(practice.random, "choice", lambda seq: seq[0])
+    prob = practice.generate_problem()
+    assert len(prob.hand) == 14
+    assert isinstance(prob.dora_indicator, Tile)
+    assert prob.seat_wind == "east"
+
+
+def test_suggest_discard(monkeypatch):
+    tiles = [Tile("man", 1), Tile("pin", 2)]
+    monkeypatch.setattr(practice.random, "choice", lambda seq: seq[-1])
+    tile = practice.suggest_discard(tiles)
+    assert tile == tiles[-1]


### PR DESCRIPTION
## Summary
- add `core.practice` module for generating practice problems
- implement `practice` CLI command
- document the new command and update feature checklist
- test practice module and CLI command

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `python -m build core`
- `python -m build cli`


------
https://chatgpt.com/codex/tasks/task_e_6868f215b9b8832a89ebf6b256b47b0c