### PR TITLE
Implement round start and draw-ending events

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Future work will expand these components.
 - [x] declare_riichi
 - [x] skip
 - [x] end_game
+- [x] start_kyoku
+- [x] ryukyoku detection
 - [x] standard wall initialization
 - [x] configurable ruleset
 - [x] event log

--- a/core/api.py
+++ b/core/api.py
@@ -19,6 +19,13 @@ def start_game(player_names: list[str]) -> GameState:
     return _engine.state
 
 
+def start_kyoku(dealer: int, round_number: int) -> GameState:
+    """Begin a new hand and return the updated state."""
+    assert _engine is not None, "Game not started"
+    _engine.start_kyoku(dealer, round_number)
+    return _engine.state
+
+
 def draw_tile(player_index: int) -> Tile:
     """Draw a tile for the given player."""
     assert _engine is not None, "Game not started"
@@ -128,6 +135,10 @@ def apply_action(action: GameAction) -> object | None:
     if action.type == "skip":
         assert action.player_index is not None
         _engine.skip(action.player_index)
+        return None
+    if action.type == "start_kyoku":
+        assert action.dealer is not None and action.round_number is not None
+        _engine.start_kyoku(action.dealer, action.round_number)
         return None
     if action.type == "end_game":
         return _engine.end_game()

--- a/core/models.py
+++ b/core/models.py
@@ -36,6 +36,8 @@ class GameState:
     players: List["Player"] = field(default_factory=list)
     wall: Optional["Wall"] = None
     current_player: int = 0
+    dealer: int = 0
+    round_number: int = 1
 
 
 @dataclass
@@ -54,3 +56,5 @@ class GameAction:
     player_index: int | None = None
     tile: Tile | None = None
     tiles: list[Tile] | None = None
+    dealer: int | None = None
+    round_number: int | None = None

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -54,3 +54,10 @@ def test_declare_riichi_api() -> None:
     api.declare_riichi(0)
     assert player.riichi
     assert player.score == score - 1000
+
+
+def test_start_kyoku_api() -> None:
+    api.start_game(["A", "B", "C", "D"])
+    state = api.start_kyoku(2, 3)
+    assert state.dealer == 2
+    assert state.round_number == 3

--- a/tests/core/test_apply_action.py
+++ b/tests/core/test_apply_action.py
@@ -20,3 +20,12 @@ def test_apply_action_unknown() -> None:
     action = models.GameAction(type="foo", player_index=0)
     with pytest.raises(ValueError):
         api.apply_action(action)
+
+
+def test_apply_action_start_kyoku() -> None:
+    api.start_game(["A", "B", "C", "D"])
+    action = models.GameAction(type="start_kyoku", dealer=1, round_number=2)
+    api.apply_action(action)
+    state = api.get_state()
+    assert state.dealer == 1
+    assert state.round_number == 2

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -135,3 +135,24 @@ def test_skip_ignored_if_not_players_turn() -> None:
     engine.skip(1)
     assert engine.state.current_player == 0
     assert not engine.pop_events()
+
+
+def test_start_kyoku_resets_state_and_emits_event() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()  # clear start_game and start_kyoku
+    engine.start_kyoku(dealer=1, round_number=2)
+    assert engine.state.dealer == 1
+    assert engine.state.round_number == 2
+    events = engine.pop_events()
+    assert events and events[0].name == "start_kyoku"
+
+
+def test_ryukyoku_event_on_wall_empty() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()  # clear initial events
+    assert engine.state.wall is not None
+    engine.state.wall.tiles = [Tile("man", 1)]
+    engine.draw_tile(0)
+    events = engine.pop_events()
+    names = [e.name for e in events]
+    assert "ryukyoku" in names

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -67,6 +67,8 @@ def test_websocket_streams_events() -> None:
     with client.websocket_connect("/ws/1") as ws:
         data = ws.receive_json()
         assert data["name"] == "start_game"
+        data = ws.receive_json()
+        assert data["name"] == "start_kyoku"
         client.post(
             "/games/1/action",
             json={"player_index": 0, "action": "draw"},


### PR DESCRIPTION
## Summary
- support tracking dealer and round in `GameState`
- add `start_kyoku` method and emit events for new rounds
- emit `ryukyoku` when the wall is exhausted
- expose `start_kyoku` through the core API and action helper
- extend tests for the new functionality
- document start_kyoku and ryukyoku detection in README

## Testing
- `pip install -e ./core -e ./web -e ./cli`
- `pip install flake8 mypy`
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f253b2bc832a9f1f63eca8c29ca8