### PR TITLE
Fix GitHub Pages stylesheet loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ The static web GUI in the `web_gui` directory is built and deployed via GitHub P
 
 https://kotarotanabe.github.io/MyMahjong/
 
+The Vite configuration sets `base: '/MyMahjong/'` so asset URLs resolve correctly when
+served from this subpath.
+
 ## Continuous Integration
 
 GitHub Actions run linting, type checking, build and tests for every pull request.

--- a/tests/web_gui/test_vite_config.py
+++ b/tests/web_gui/test_vite_config.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_vite_base_path() -> None:
+    config = Path('web_gui/vite.config.js').read_text()
+    assert "base: '/MyMahjong/'" in config, 'Vite base path not set'

--- a/web_gui/vite.config.js
+++ b/web_gui/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   root: '.',
+  base: '/MyMahjong/',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- set Vite `base` path so the GUI assets load correctly from GitHub Pages
- document the base path in the README
- add a test for the Vite configuration

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `npm run build --prefix web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6868f4615570832ab0c152efbcd60929