### PR TITLE
Implement practice mode API and AI heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Future work will expand these components.
 - [x] GUI design documented
 - [ ] 何切る問題 mode
   - [x] CLI practice command
-  - [ ] AI recommendation
+  - [x] AI recommendation
   - [ ] Web UI support
 
 ### Core engine capabilities
@@ -124,23 +124,29 @@ The following plan steps are not yet implemented:
 See `docs/detailed-design.md` for an overview of the planned architecture.
 `docs/web-gui-architecture.md` provides more details about the planned React GUI.
 
-## 何切る問題 mode (planned)
+## 何切る問題 mode
 
-This practice mode will present a what-to-discard problem to the player.
+This practice mode presents a what-to-discard problem to the player.
+It is available via the CLI and the API.
 
-An initial version is available via the CLI:
+Run the CLI version with:
 
 ```bash
 python -m cli.main practice
 ```
 
-### Planned workflow
+### Current workflow
 
 1. Randomly choose the seat wind and dora indicator.
 2. Assume it is the dealer's first turn with no prior actions.
 3. Display the hand and let the user select a discard.
-4. Ask the AI to compute its recommended discard.
+4. The AI computes its recommended discard using a basic shanten heuristic.
 5. Show the AI suggestion to the user for comparison.
+
+Two API endpoints are provided:
+
+- `GET /practice` returns a new problem.
+- `POST /practice/suggest` returns the AI's suggested discard.
 
 ## Running locally
 

--- a/core/api.py
+++ b/core/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile, GameEvent, GameAction
+from . import practice
 from mahjong.hand_calculating.hand_response import HandResponse
 
 # Singleton engine instance used by interfaces
@@ -96,6 +97,18 @@ def pop_events() -> list[GameEvent]:
     """Retrieve and clear pending engine events."""
     assert _engine is not None, "Game not started"
     return _engine.pop_events()
+
+
+def generate_practice_problem() -> practice.PracticeProblem:
+    """Return a new practice problem."""
+
+    return practice.generate_problem()
+
+
+def suggest_practice_discard(hand: list[Tile]) -> Tile:
+    """Return AI suggested discard for ``hand``."""
+
+    return practice.suggest_discard(hand)
 
 
 def apply_action(action: GameAction) -> object | None:

--- a/core/practice.py
+++ b/core/practice.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 import random
 
+from mahjong.shanten import Shanten
+
+from .rules import _tile_to_index
+
 from .mahjong_engine import MahjongEngine
 from .models import Tile
 
@@ -33,7 +37,32 @@ def generate_problem() -> PracticeProblem:
     return PracticeProblem(hand=hand, dora_indicator=dora, seat_wind=seat_wind)
 
 
-def suggest_discard(hand: list[Tile]) -> Tile:
-    """Return the AI suggested discard. Placeholder implementation."""
+def _hand_counts(hand: list[Tile]) -> list[int]:
+    """Return 34-tile count representation of ``hand``."""
 
-    return random.choice(hand)
+    counts = [0] * 34
+    for tile in hand:
+        counts[_tile_to_index(tile)] += 1
+    return counts
+
+
+def suggest_discard(hand: list[Tile]) -> Tile:
+    """Return the AI suggested discard using a basic shanten heuristic."""
+
+    counts = _hand_counts(hand)
+    shanten = Shanten()
+    best_tiles: list[Tile] = []
+    best_value = 8  # higher than any real shanten number
+
+    for tile in hand:
+        idx = _tile_to_index(tile)
+        counts[idx] -= 1
+        value = shanten.calculate_shanten(counts)
+        counts[idx] += 1
+        if value < best_value:
+            best_value = value
+            best_tiles = [tile]
+        elif value == best_value:
+            best_tiles.append(tile)
+
+    return random.choice(best_tiles) if best_tiles else random.choice(hand)

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -1,4 +1,4 @@
-from core import api, models
+from core import api, models, practice
 
 
 def test_start_game() -> None:
@@ -61,3 +61,11 @@ def test_start_kyoku_api() -> None:
     state = api.start_kyoku(2, 3)
     assert state.dealer == 2
     assert state.round_number == 3
+
+
+def test_practice_api_functions(monkeypatch) -> None:
+    monkeypatch.setattr(practice.random, "choice", lambda seq: seq[0])
+    prob = api.generate_practice_problem()
+    assert len(prob.hand) == 14
+    tile = api.suggest_practice_discard(prob.hand)
+    assert isinstance(tile, models.Tile)

--- a/tests/core/test_practice.py
+++ b/tests/core/test_practice.py
@@ -12,7 +12,8 @@ def test_generate_problem(monkeypatch):
 
 
 def test_suggest_discard(monkeypatch):
-    tiles = [Tile("man", 1), Tile("pin", 2)]
+    # all tiles equal so algorithm relies on random.choice
+    tiles = [Tile("man", 1) for _ in range(14)]
     monkeypatch.setattr(practice.random, "choice", lambda seq: seq[-1])
     tile = practice.suggest_discard(tiles)
     assert tile == tiles[-1]

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -75,3 +75,15 @@ def test_websocket_streams_events() -> None:
         )
         data = ws.receive_json()
         assert data["name"] == "draw_tile"
+
+
+def test_practice_endpoints() -> None:
+    prob = client.get("/practice")
+    assert prob.status_code == 200
+    data = prob.json()
+    assert "hand" in data and "dora_indicator" in data
+
+    resp = client.post("/practice/suggest", json={"hand": data["hand"]})
+    assert resp.status_code == 200
+    tile = resp.json()
+    assert "suit" in tile and "value" in tile

--- a/web/server.py
+++ b/web/server.py
@@ -25,6 +25,12 @@ class CreateGameRequest(BaseModel):
     players: list[str]
 
 
+class SuggestRequest(BaseModel):
+    """Request body for AI discard suggestion."""
+
+    hand: list[dict]
+
+
 @app.get("/health")
 def health() -> dict[str, str]:
     """Simple health check endpoint."""
@@ -43,6 +49,23 @@ def get_game(game_id: int) -> dict:
     """Return basic game state for the given game id."""
     # For now we ignore game_id and return the singleton engine state
     return asdict(api.get_state())
+
+
+@app.get("/practice")
+def practice_problem() -> dict:
+    """Return a random practice problem."""
+
+    problem = api.generate_practice_problem()
+    return asdict(problem)
+
+
+@app.post("/practice/suggest")
+def practice_suggest(req: SuggestRequest) -> dict:
+    """Return AI discard suggestion for the provided hand."""
+
+    hand = [models.Tile(**t) for t in req.hand]
+    tile = api.suggest_practice_discard(hand)
+    return asdict(tile)
 
 
 class ActionRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add AI-based discard suggestion using shanten heuristic
- expose practice problem & suggestion endpoints
- update CLI practice tests and add server tests for new endpoints
- document practice mode API and feature status

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f47a1a80832a8189196380892b12