### PR TITLE
Fix orientation of shimocha in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Future work will expand these components.
 - [x] Continuous integration workflow
 - [x] Core <-> interface API documented
 - [x] GUI design documented
+- [x] Corrected seat orientation (shimocha right side)
 - [ ] 何切る問題 mode
   - [x] CLI practice command
   - [ ] AI recommendation

--- a/tests/web_gui/test_orientation.py
+++ b/tests/web_gui/test_orientation.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_grid_orientation() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert 'east center west' in css
+
+
+def test_dom_order() -> None:
+    jsx = Path('web_gui/GameBoard.jsx').read_text()
+    east_idx = jsx.find('className="east seat"')
+    west_idx = jsx.find('className="west seat"')
+    assert -1 not in (east_idx, west_idx)
+    assert east_idx < west_idx

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -48,20 +48,20 @@ export default function GameBoard({ state, server }) {
         <River tiles={(north?.river ?? []).map(tileLabel)} />
         <Hand tiles={northHand} />
       </div>
-      <div className="west seat">
-        <div>{west?.name ?? 'West'}</div>
-        <MeldArea melds={westMelds} />
-        <River tiles={(west?.river ?? []).map(tileLabel)} />
-        <Hand tiles={westHand} />
-      </div>
-      <div className="center">
-        <CenterDisplay remaining={remaining} dora={dora} />
-      </div>
       <div className="east seat">
         <div>{east?.name ?? 'East'}</div>
         <MeldArea melds={eastMelds} />
         <River tiles={(east?.river ?? []).map(tileLabel)} />
         <Hand tiles={eastHand} />
+      </div>
+      <div className="center">
+        <CenterDisplay remaining={remaining} dora={dora} />
+      </div>
+      <div className="west seat">
+        <div>{west?.name ?? 'West'}</div>
+        <MeldArea melds={westMelds} />
+        <River tiles={(west?.river ?? []).map(tileLabel)} />
+        <Hand tiles={westHand} />
       </div>
       <div className="south seat">
         <div>{south?.name ?? 'South'}</div>

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-areas:
     '. north .'
-    'west center east'
+    'east center west'
     '. south .';
   grid-template-columns: 1fr 2fr 1fr;
   grid-template-rows: auto auto auto;


### PR DESCRIPTION
## Summary
- flip east and west positions so shimocha appears on the right
- update README features list
- add regression tests covering board orientation

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f58720d4832a88fb32eca6a901d3