### PR TITLE
Ensure websockets enabled

### DIFF
--- a/tests/web/test_dependencies.py
+++ b/tests/web/test_dependencies.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_uvicorn_standard_dependency() -> None:
+    text = Path('web/pyproject.toml').read_text()
+    assert 'uvicorn[standard]' in text

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastapi",
-    "uvicorn",
+    "uvicorn[standard]",
     "mymahjong-core",
     "httpx",
 ]


### PR DESCRIPTION
## Summary
- add uvicorn[standard] dependency so WebSocket endpoints work
- test for uvicorn[standard] requirement

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f62985ec832a9be586ab98ff36d3