### PR TITLE
Add ScoreBoard UI with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Score board with seat winds and scores
 - [x] Meld display from game state
 - [x] Tile emoji rendering in GUI
 - [x] Adjustable tile font size (default 1.5x)

--- a/tests/web_gui/test_score_board.py
+++ b/tests/web_gui/test_score_board.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run(
+        ["node", "-e", code], capture_output=True, text=True, cwd="web_gui"
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def ensure_node_modules() -> None:
+    if not Path('web_gui/node_modules').exists():
+        subprocess.run(['npm', 'ci'], cwd='web_gui', check=True)
+
+
+def test_score_board_renders() -> None:
+    ensure_node_modules()
+    output = run_node(
+        "import React from 'react';\n"
+        "import ReactDOMServer from 'react-dom/server';\n"
+        "import ScoreBoard from './ScoreBoard.js';\n"
+        "const players = [\n"
+        "  {name: 'Alice', score: 32000, hand: {tiles: [], melds: []}, river: []},\n"
+        "  {name: 'Bob', score: 28000, hand: {tiles: [], melds: []}, river: []},\n"
+        "  {name: 'Carol', score: 26000, hand: {tiles: [], melds: []}, river: []},\n"
+        "  {name: 'Dave', score: 24000, hand: {tiles: [], melds: []}, river: []}\n"
+        "];\n"
+        "const html = ReactDOMServer.renderToStaticMarkup(\n"
+        "  React.createElement(ScoreBoard, { players })\n"
+        ");\n"
+        "console.log(html);"
+    )
+    assert 'Alice' in output
+    assert 'South' in output
+    assert '32000' in output

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -3,6 +3,7 @@ import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
+import ScoreBoard from './ScoreBoard.js';
 import Controls from './Controls.jsx';
 import { tileToEmoji } from './tileUtils.js';
 
@@ -56,6 +57,7 @@ export default function GameBoard({ state, server }) {
       </div>
       <div className="center">
         <CenterDisplay remaining={remaining} dora={dora} />
+        <ScoreBoard players={players} />
       </div>
       <div className="east seat">
         <div>{east?.name ?? 'East'}</div>

--- a/web_gui/ScoreBoard.js
+++ b/web_gui/ScoreBoard.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function ScoreBoard({ players = [] }) {
+  const winds = ['South', 'West', 'North', 'East'];
+  return React.createElement(
+    'div',
+    { className: 'score-board' },
+    winds.map((wind, i) => {
+      const p = players[i];
+      return React.createElement(
+        'div',
+        { key: wind, className: 'score-entry' },
+        React.createElement('span', { className: 'seat-wind' }, wind),
+        React.createElement('span', { className: 'player-name' }, p?.name ?? wind),
+        React.createElement('span', { className: 'player-score' }, p?.score ?? 0),
+      );
+    }),
+  );
+}

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -94,3 +94,20 @@
 .east .meld-area { transform: rotate(90deg); }
 .north .meld-area { transform: rotate(180deg); }
 .west .meld-area { transform: rotate(-90deg); }
+
+.score-board {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.score-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.seat-wind {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add `ScoreBoard` React component showing winds, players and scores
- show `ScoreBoard` in `GameBoard`
- style the scoreboard via CSS
- record new feature in README
- add tests ensuring ScoreBoard renders with sample players

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868f9a56070832ab1b83aebd22d3fcb