### PR TITLE
Fix dealer hand size

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -46,11 +46,16 @@ class MahjongEngine:
         )
 
     def deal_initial_hands(self) -> None:
-        """Deal 13 tiles to each player at the start of the game."""
+        """Deal initial tiles: 14 for the dealer and 13 for others."""
         assert self.state.wall is not None
+        # everyone starts with 13 tiles
         for _ in range(13):
             for player in self.state.players:
                 player.draw(self.state.wall.draw_tile())
+
+        # dealer gets one extra tile to begin their first turn
+        dealer_index = self.state.dealer
+        self.state.players[dealer_index].draw(self.state.wall.draw_tile())
 
     @property
     def remaining_tiles(self) -> int:

--- a/core/practice.py
+++ b/core/practice.py
@@ -27,7 +27,7 @@ def generate_problem() -> PracticeProblem:
 
     engine = MahjongEngine()
     engine.pop_events()  # discard start event
-    engine.draw_tile(0)
+    # The dealer begins with 14 tiles so no initial draw is needed
     hand = engine.state.players[0].hand.tiles.copy()
     if engine.state.wall:
         dora = random.choice(engine.state.wall.tiles)

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -9,8 +9,10 @@ def test_start_game() -> None:
 
 def test_start_game_deals_hands() -> None:
     state = api.start_game(["A", "B", "C", "D"])
+    dealer = state.dealer
     counts = [len(p.hand.tiles) for p in state.players]
-    assert all(c == 13 for c in counts)
+    assert counts[dealer] == 14
+    assert all(counts[i] == 13 for i in range(4) if i != dealer)
 
 
 def test_draw_and_discard() -> None:

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -12,9 +12,11 @@ def test_engine_initialization() -> None:
 
 def test_initial_hands_dealt() -> None:
     engine = MahjongEngine()
+    dealer = engine.state.dealer
     counts = [len(p.hand.tiles) for p in engine.state.players]
-    assert all(c == 13 for c in counts)
-    assert engine.remaining_tiles == 136 - 13 * 4
+    assert counts[dealer] == 14
+    assert all(counts[i] == 13 for i in range(4) if i != dealer)
+    assert engine.remaining_tiles == 136 - (14 + 13 * 3)
 
 
 def test_draw_tile_updates_state() -> None:


### PR DESCRIPTION
## Summary
- dealer gets 14 tiles when starting a hand
- update practice problem generation for new dealer draw
- adjust tests for the extra dealer tile

## Testing
- `python -m build core`
- `python -m build cli`
- `/root/.pyenv/versions/3.12.10/bin/flake8`
- `/root/.pyenv/versions/3.12.10/bin/mypy core web cli`
- `/root/.pyenv/versions/3.12.10/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f99f6868832a93769a1a1a86fc09