### PR TITLE
Handle start_kyoku event in GUI

### DIFF
--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -1,0 +1,23 @@
+import subprocess
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run(
+        ["node", "-e", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_start_kyoku_resets_state() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/eventHandlers.js';\n"
+        "const prev = {wall:{tiles:[1,2,3]}, players:[{hand:{tiles:[{suit:'man',value:1}]}, river:[]} ]};\n"
+        "const newState = {wall:{tiles:[0,0]}, players:[{hand:{tiles:[]}, river:[]} ]};\n"
+        "const evt = {name:'start_kyoku', payload:{state:newState}};\n"
+        "const result = applyEvent(prev, evt);\n"
+        "console.log(result.wall.tiles.length + ':' + result.players[0].hand.tiles.length);"
+    )
+    output = run_node(code)
+    assert output == '2:0'
+

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -122,7 +122,7 @@ def test_south_hand_displays_emojis() -> None:
 
 
 def test_app_updates_wall_on_draw() -> None:
-    text = Path('web_gui/App.jsx').read_text()
+    text = Path('web_gui/eventHandlers.js').read_text()
     assert 'wall.tiles.pop()' in text
 
 

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import GameBoard from './GameBoard.jsx';
+import { applyEvent } from "./eventHandlers.js";
 import './style.css';
 
 export default function App() {
@@ -55,37 +56,6 @@ export default function App() {
       // ignore
     }
   }
-
-  function applyEvent(state, event) {
-    if (!state) return state;
-    const newState = JSON.parse(JSON.stringify(state));
-    switch (event.name) {
-      case 'start_game':
-        return event.payload.state;
-      case 'draw_tile': {
-        const p = newState.players[event.payload.player_index];
-        if (p) p.hand.tiles.push(event.payload.tile);
-        if (newState.wall?.tiles?.length) newState.wall.tiles.pop();
-        break;
-      }
-      case 'discard': {
-        const p = newState.players[event.payload.player_index];
-        if (p) {
-          const { tile } = event.payload;
-          const idx = p.hand.tiles.findIndex(
-            (t) => t.suit === tile.suit && t.value === tile.value,
-          );
-          if (idx !== -1) p.hand.tiles.splice(idx, 1);
-          p.river.push(tile);
-        }
-        break;
-      }
-      default:
-        break;
-    }
-    return newState;
-  }
-
   function handleMessage(e) {
     try {
       const evt = JSON.parse(e.data);

--- a/web_gui/eventHandlers.js
+++ b/web_gui/eventHandlers.js
@@ -1,0 +1,30 @@
+export function applyEvent(state, event) {
+  if (!state) return state;
+  const newState = JSON.parse(JSON.stringify(state));
+  switch (event.name) {
+    case 'start_game':
+    case 'start_kyoku':
+      return event.payload.state;
+    case 'draw_tile': {
+      const p = newState.players[event.payload.player_index];
+      if (p) p.hand.tiles.push(event.payload.tile);
+      if (newState.wall?.tiles?.length) newState.wall.tiles.pop();
+      break;
+    }
+    case 'discard': {
+      const p = newState.players[event.payload.player_index];
+      if (p) {
+        const { tile } = event.payload;
+        const idx = p.hand.tiles.findIndex(
+          (t) => t.suit === tile.suit && t.value === tile.value,
+        );
+        if (idx !== -1) p.hand.tiles.splice(idx, 1);
+        p.river.push(tile);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return newState;
+}


### PR DESCRIPTION
## Summary
- factor `applyEvent` into new `eventHandlers.js`
- handle `start_kyoku` event like `start_game`
- update `App.jsx` to use external handler
- add regression test for `start_kyoku`
- fix string check in existing tests

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fc23c5a0832abe4190bb5eb6005b