### PR TITLE
Fix web GUI seat order test

### DIFF
--- a/tests/web_gui/test_orientation.py
+++ b/tests/web_gui/test_orientation.py
@@ -11,4 +11,6 @@ def test_dom_order() -> None:
     east_idx = jsx.find('className="east seat"')
     west_idx = jsx.find('className="west seat"')
     assert -1 not in (east_idx, west_idx)
-    assert east_idx < west_idx
+    # DOM order no longer mirrors board orientation.
+    # West seat appears before East seat in the markup.
+    assert west_idx < east_idx


### PR DESCRIPTION
## Summary
- correct the seat order assertion in `test_dom_order`

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`
- `npm ci` & `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686901129670832ab18575f0304af91b