### PR TITLE
Add remaining yama tile count

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Future work will expand these components.
 - [x] start_kyoku
 - [x] ryukyoku detection
 - [x] standard wall initialization
+- [x] wanpai separation and yama remaining count
 - [x] configurable ruleset
 - [x] event log
 - [x] current player tracking

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -63,6 +63,12 @@ class MahjongEngine:
         assert self.state.wall is not None
         return self.state.wall.remaining_tiles
 
+    @property
+    def remaining_yama_tiles(self) -> int:
+        """Number of drawable tiles left this hand."""
+        assert self.state.wall is not None
+        return self.state.wall.remaining_yama_tiles
+
     def draw_tile(self, player_index: int) -> Tile:
         """Draw a tile for the specified player."""
         assert self.state.wall is not None

--- a/core/wall.py
+++ b/core/wall.py
@@ -24,9 +24,10 @@ def create_standard_wall() -> list[Tile]:
 
 @dataclass
 class Wall:
-    """Represents the tile wall and dora indicators."""
+    """Represents the tile wall and dead wall (wanpai)."""
 
     tiles: List[Tile] = field(default_factory=list)
+    wanpai_size: int = 14
 
     def __post_init__(self) -> None:
         if not self.tiles:
@@ -35,6 +36,11 @@ class Wall:
     def reset(self) -> None:
         """Fill the wall with a freshly shuffled standard tile set."""
         self.tiles = create_standard_wall()
+
+    @property
+    def remaining_yama_tiles(self) -> int:
+        """Tiles left that can still be drawn this hand."""
+        return max(len(self.tiles) - self.wanpai_size, 0)
 
     @property
     def remaining_tiles(self) -> int:

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -87,6 +87,13 @@ def test_remaining_tiles_property() -> None:
     assert engine.remaining_tiles == remaining - 1
 
 
+def test_remaining_yama_tiles_property() -> None:
+    engine = MahjongEngine()
+    yama_remaining = engine.remaining_yama_tiles
+    engine.draw_tile(0)
+    assert engine.remaining_yama_tiles == yama_remaining - 1
+
+
 def test_declare_riichi() -> None:
     engine = MahjongEngine()
     player = engine.state.players[0]

--- a/tests/core/test_wall.py
+++ b/tests/core/test_wall.py
@@ -26,3 +26,13 @@ def test_wall_remaining_decreases() -> None:
     before = wall.remaining_tiles
     wall.draw_tile()
     assert wall.remaining_tiles == before - 1
+
+
+def test_remaining_yama_tiles_excludes_wanpai() -> None:
+    wall = Wall()
+    assert wall.remaining_yama_tiles == 136 - wall.wanpai_size
+    wall.draw_tile()
+    assert wall.remaining_yama_tiles == 136 - wall.wanpai_size - 1
+    # Remove all drawable tiles
+    wall.tiles = wall.tiles[-wall.wanpai_size:]
+    assert wall.remaining_yama_tiles == 0


### PR DESCRIPTION
## Summary
- track wanpai separately from the drawable wall
- expose `remaining_yama_tiles` on `Wall` and `MahjongEngine`
- document feature in README
- test yama tile counts

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fd9b7778832a9c65c3a0cbf5b092