### PR TITLE
Add peek option to reveal opponent hands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Future work will expand these components.
 - [x] Meld display from game state
 - [x] Tile emoji rendering in GUI
 - [x] Adjustable tile font size (default 1.5x)
+- [x] Optional peek to reveal opponent hands
 - [x] Basic draw control via REST API
 - [x] Discard tiles via GUI
 - [x] Start game via GUI

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -89,6 +89,12 @@ def test_controls_use_server_prop() -> None:
     assert '/games/1/action' in text
 
 
+def test_controls_has_peek_checkbox() -> None:
+    text = Path('web_gui/Controls.jsx').read_text()
+    assert 'Peek' in text
+    assert 'onTogglePeek' in text
+
+
 def test_hand_supports_discard() -> None:
     text = Path('web_gui/Hand.jsx').read_text()
     assert 'onDiscard' in text
@@ -114,6 +120,11 @@ def test_game_board_displays_melds_and_remaining() -> None:
 def test_game_board_passes_remaining_prop() -> None:
     board = Path('web_gui/GameBoard.jsx').read_text()
     assert 'remaining={' in board
+
+
+def test_game_board_accepts_peek_prop() -> None:
+    board = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'peek = false' in board
 
 
 def test_south_hand_displays_emojis() -> None:

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -8,6 +8,7 @@ export default function App() {
   const [players, setPlayers] = useState('A,B,C,D');
   const [gameState, setGameState] = useState(null);
   const [events, setEvents] = useState([]);
+  const [peek, setPeek] = useState(false);
   const wsRef = useRef(null);
 
   async function fetchStatus() {
@@ -137,7 +138,7 @@ export default function App() {
         </label>
         <button onClick={startGame}>Start Game</button>
       </div>
-      <GameBoard state={gameState} server={server} />
+      <GameBoard state={gameState} server={server} peek={peek} onTogglePeek={setPeek} />
       <div className="event-log">
         <h2>Events</h2>
         <ul>

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-export default function Controls({ server }) {
+export default function Controls({ server, peek = false, onTogglePeek }) {
   const [message, setMessage] = useState('');
 
   async function draw() {
@@ -30,6 +30,14 @@ export default function Controls({ server }) {
   return (
     <div className="controls">
       <button onClick={draw}>Draw</button>
+      <label>
+        <input
+          type="checkbox"
+          checked={peek}
+          onChange={(e) => onTogglePeek?.(e.target.checked)}
+        />
+        Peek
+      </label>
       {message && <div className="message">{message}</div>}
     </div>
   );

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -9,16 +9,22 @@ import { tileToEmoji } from './tileUtils.js';
 function tileLabel(tile) {
   return tileToEmoji(tile);
 }
-export default function GameBoard({ state, server }) {
+export default function GameBoard({ state, server, peek = false, onTogglePeek }) {
   const players = state?.players ?? [];
   const south = players[0];
   const west = players[1];
   const north = players[2];
   const east = players[3];
   const defaultHand = Array(13).fill('🀫');
-  const northHand = north?.hand?.tiles.map(tileLabel) ?? defaultHand;
-  const westHand = west?.hand?.tiles.map(tileLabel) ?? defaultHand;
-  const eastHand = east?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const northHand = peek
+    ? north?.hand?.tiles.map(tileLabel) ?? defaultHand
+    : defaultHand;
+  const westHand = peek
+    ? west?.hand?.tiles.map(tileLabel) ?? defaultHand
+    : defaultHand;
+  const eastHand = peek
+    ? east?.hand?.tiles.map(tileLabel) ?? defaultHand
+    : defaultHand;
   const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
   const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
   const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
@@ -67,7 +73,7 @@ export default function GameBoard({ state, server }) {
         <div>{south?.name ?? 'South'}</div>
         <River tiles={(south?.river ?? []).map(tileLabel)} />
         <Hand tiles={southHand} onDiscard={discard} />
-        <Controls server={server} />
+        <Controls server={server} peek={peek} onTogglePeek={onTogglePeek} />
         <MeldArea melds={southMelds} />
       </div>
     </div>

--- a/web_gui/GameBoard.test.jsx
+++ b/web_gui/GameBoard.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+const sampleState = {
+  players: [
+    { name: 'South', hand: { tiles: [{ suit: 'man', value: 1 }], melds: [] }, river: [] },
+    { name: 'West', hand: { tiles: [{ suit: 'man', value: 2 }], melds: [] }, river: [] },
+    { name: 'North', hand: { tiles: [{ suit: 'man', value: 3 }], melds: [] }, river: [] },
+    { name: 'East', hand: { tiles: [{ suit: 'man', value: 4 }], melds: [] }, river: [] },
+  ],
+  wall: { tiles: [] },
+};
+
+describe('GameBoard peek option', () => {
+  it('hides opponent hands by default', () => {
+    render(<GameBoard state={sampleState} server="" />);
+    expect(screen.getAllByText('🀫').length).toBeGreaterThan(0);
+    expect(screen.queryByText('🀈')).toBeNull();
+  });
+
+  it('shows opponent hands when peek is enabled', () => {
+    render(<GameBoard state={sampleState} server="" peek={true} />);
+    expect(screen.getByText('🀈')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add optional peek checkbox to see opponent hands
- show opponent hands when peek enabled
- support peek via App state and GameBoard prop
- document peek feature in README
- test new component logic

## Testing
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm install`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6868fcd0c824832a80af500cb523b4e5