### PR TITLE
Add dora indicator tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Future work will expand these components.
 - [x] start_kyoku
 - [x] ryukyoku detection
 - [x] standard wall initialization
+- [x] dead wall & dora indicator tracking
 - [x] configurable ruleset
 - [x] event log
 - [x] current player tracking

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -31,6 +31,10 @@ class MahjongEngine:
     def start_kyoku(self, dealer: int, round_number: int) -> None:
         """Begin a new hand with fresh tiles."""
         self.state.wall = Wall()
+        wall = self.state.wall
+        assert wall is not None
+        self.state.dora_indicators = wall.dora_indicators.copy()
+        self.state.dead_wall = wall.dead_wall.copy()
         for p in self.state.players:
             p.hand.tiles.clear()
             p.hand.melds.clear()
@@ -153,6 +157,10 @@ class MahjongEngine:
         scores = [p.score for p in final_state.players]
         self._emit("end_game", {"scores": scores})
         self.state = GameState(wall=Wall())
+        wall = self.state.wall
+        assert wall is not None
+        self.state.dora_indicators = wall.dora_indicators.copy()
+        self.state.dead_wall = wall.dead_wall.copy()
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
         self.state.current_player = 0
         return final_state

--- a/core/models.py
+++ b/core/models.py
@@ -33,8 +33,11 @@ class Hand:
 @dataclass
 class GameState:
     """Overall game state placeholder."""
+
     players: List["Player"] = field(default_factory=list)
     wall: Optional["Wall"] = None
+    dora_indicators: List[Tile] = field(default_factory=list)
+    dead_wall: List[Tile] = field(default_factory=list)
     current_player: int = 0
     dealer: int = 0
     round_number: int = 1

--- a/core/wall.py
+++ b/core/wall.py
@@ -24,9 +24,11 @@ def create_standard_wall() -> list[Tile]:
 
 @dataclass
 class Wall:
-    """Represents the tile wall and dora indicators."""
+    """Represents the live wall plus dead wall and dora indicators."""
 
     tiles: List[Tile] = field(default_factory=list)
+    dead_wall: List[Tile] = field(default_factory=list)
+    dora_indicators: List[Tile] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if not self.tiles:
@@ -35,6 +37,14 @@ class Wall:
     def reset(self) -> None:
         """Fill the wall with a freshly shuffled standard tile set."""
         self.tiles = create_standard_wall()
+        # Reserve the last 14 tiles as the dead wall
+        self.dead_wall = [self.tiles.pop() for _ in range(14)]
+        # Reveal the 5th tile from the end of the dead wall as the
+        # dora indicator
+        if len(self.dead_wall) >= 5:
+            self.dora_indicators = [self.dead_wall[-5]]
+        else:
+            self.dora_indicators = []
 
     @property
     def remaining_tiles(self) -> int:

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -16,7 +16,8 @@ def test_initial_hands_dealt() -> None:
     counts = [len(p.hand.tiles) for p in engine.state.players]
     assert counts[dealer] == 14
     assert all(counts[i] == 13 for i in range(4) if i != dealer)
-    assert engine.remaining_tiles == 136 - (14 + 13 * 3)
+    # Only 122 tiles are available for play after reserving the dead wall
+    assert engine.remaining_tiles == 122 - (14 + 13 * 3)
 
 
 def test_draw_tile_updates_state() -> None:
@@ -145,6 +146,8 @@ def test_start_kyoku_resets_state_and_emits_event() -> None:
     engine.start_kyoku(dealer=1, round_number=2)
     assert engine.state.dealer == 1
     assert engine.state.round_number == 2
+    assert len(engine.state.dora_indicators) == 1
+    assert engine.state.dora_indicators[0] in engine.state.dead_wall
     events = engine.pop_events()
     assert events and events[0].name == "start_kyoku"
 

--- a/tests/core/test_wall.py
+++ b/tests/core/test_wall.py
@@ -13,9 +13,10 @@ def test_wall_draw_tile() -> None:
 
 def test_wall_initializes_standard_set() -> None:
     wall = Wall()
-    assert wall.remaining_tiles == 136
+    # 14 tiles are reserved for the dead wall
+    assert wall.remaining_tiles == 122
     counts: dict[tuple[str, int], int] = {}
-    for t in wall.tiles:
+    for t in wall.tiles + wall.dead_wall:
         key = (t.suit, t.value)
         counts[key] = counts.get(key, 0) + 1
     assert all(c == 4 for c in counts.values())
@@ -26,3 +27,10 @@ def test_wall_remaining_decreases() -> None:
     before = wall.remaining_tiles
     wall.draw_tile()
     assert wall.remaining_tiles == before - 1
+
+
+def test_wall_sets_dead_wall_and_dora() -> None:
+    wall = Wall()
+    assert len(wall.dead_wall) == 14
+    assert len(wall.dora_indicators) == 1
+    assert wall.dora_indicators[0] in wall.dead_wall


### PR DESCRIPTION
## Summary
- extend `Wall` with `dead_wall` and `dora_indicators`
- include those fields in `GameState`
- populate them from `start_kyoku`
- expose dead wall and dora indicator tests
- document the new capability in the README

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fc36c1b8832a8afe06476d7ad298