### PR TITLE
Add join-by-ID support to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Future work will expand these components.
 - [x] Basic draw control via REST API
 - [x] Discard tiles via GUI
 - [x] Start game via GUI
+- [x] Join game by ID via GUI
+- [x] Reconnect to running game after reload
 - [x] Continuous integration workflow
 - [x] Web GUI unit tests
 - [x] Core <-> interface API documented

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -16,6 +16,7 @@ def test_create_and_get_game() -> None:
     assert create.status_code == 200
     data = create.json()
     assert len(data["players"]) == 4
+    assert data["id"] == 1
 
     response = client.get("/games/1")
     assert response.status_code == 200

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -78,15 +78,22 @@ def test_app_can_start_game() -> None:
     assert '/games' in text
 
 
+def test_app_has_game_id_input() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Game ID:' in text
+    assert 'Join Game' in text
+    assert 'localStorage' in text
+
+
 def test_app_opens_websocket() -> None:
     text = Path('web_gui/App.jsx').read_text()
-    assert '/ws/1' in text
+    assert '/ws/${' in text
 
 
 def test_controls_use_server_prop() -> None:
     text = Path('web_gui/Controls.jsx').read_text()
     assert 'server' in text
-    assert '/games/1/action' in text
+    assert '/games/${' in text
 
 
 def test_hand_supports_discard() -> None:

--- a/web/server.py
+++ b/web/server.py
@@ -10,6 +10,8 @@ from pydantic import BaseModel
 from core import api, models
 
 app = FastAPI()
+# very small in-memory id tracker until multi-game support exists
+_next_game_id = 1
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -39,9 +41,12 @@ def health() -> dict[str, str]:
 
 @app.post("/games")
 def create_game(req: CreateGameRequest) -> dict:
-    """Create a new game and return its state."""
+    """Create a new game and return its id and state."""
+    global _next_game_id
     state = api.start_game(req.players)
-    return asdict(state)
+    game_id = _next_game_id
+    _next_game_id += 1
+    return {"id": game_id, **asdict(state)}
 
 
 @app.get("/games/{game_id}")

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -6,6 +6,7 @@ export default function App() {
   const [server, setServer] = useState('http://localhost:8000');
   const [status, setStatus] = useState('Contacting server...');
   const [players, setPlayers] = useState('A,B,C,D');
+  const [gameId, setGameId] = useState(() => localStorage.getItem('gameId') || '');
   const [gameState, setGameState] = useState(null);
   const [events, setEvents] = useState([]);
   const wsRef = useRef(null);
@@ -35,8 +36,10 @@ export default function App() {
       if (resp.ok) {
         const data = await resp.json();
         setGameState(data);
+        setGameId(String(data.id));
+        localStorage.setItem('gameId', String(data.id));
         setStatus('Game started');
-        openWebSocket();
+        openWebSocket(data.id);
       } else {
         setStatus(`Failed to start game (${resp.status})`);
       }
@@ -45,9 +48,10 @@ export default function App() {
     }
   }
 
-  async function fetchGameState() {
+  async function fetchGameState(id = gameId) {
     try {
-      const resp = await fetch(`${server.replace(/\/$/, '')}/games/1`);
+      if (!id) return;
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${id}`);
       if (resp.ok) {
         setGameState(await resp.json());
       }
@@ -96,8 +100,9 @@ export default function App() {
     }
   }
 
-  function openWebSocket() {
-    const url = `${server.replace(/\/$/, '').replace('http', 'ws')}/ws/1`;
+  function openWebSocket(id = gameId) {
+    if (!id) return;
+    const url = `${server.replace(/\/$/, '').replace('http', 'ws')}/ws/${id}`;
     const ws = new WebSocket(url);
     ws.onopen = () => setStatus('WebSocket connected');
     ws.onmessage = handleMessage;
@@ -106,6 +111,10 @@ export default function App() {
 
   useEffect(() => {
     fetchStatus();
+    if (gameId) {
+      fetchGameState(gameId);
+      openWebSocket(gameId);
+    }
     return () => {
       wsRef.current?.close();
     };
@@ -137,7 +146,20 @@ export default function App() {
         </label>
         <button onClick={startGame}>Start Game</button>
       </div>
-      <GameBoard state={gameState} server={server} />
+      <div>
+        <label>
+          Game ID:
+          <input
+            value={gameId}
+            onChange={(e) => setGameId(e.target.value)}
+            style={{ width: '5em' }}
+          />
+        </label>
+        <button onClick={() => { fetchGameState(); openWebSocket(); }}>
+          Join Game
+        </button>
+      </div>
+      <GameBoard state={gameState} server={server} gameId={gameId} />
       <div className="event-log">
         <h2>Events</h2>
         <ul>

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 
-export default function Controls({ server }) {
+export default function Controls({ server, gameId }) {
   const [message, setMessage] = useState('');
 
   async function draw() {
     try {
-      const resp = await fetch(`${server.replace(/\/$/, '')}/games/1/action`, {
+      if (!gameId) return;
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ player_index: 0, action: 'draw' }),

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -9,7 +9,7 @@ import { tileToEmoji } from './tileUtils.js';
 function tileLabel(tile) {
   return tileToEmoji(tile);
 }
-export default function GameBoard({ state, server }) {
+export default function GameBoard({ state, server, gameId }) {
   const players = state?.players ?? [];
   const south = players[0];
   const west = players[1];
@@ -30,7 +30,8 @@ export default function GameBoard({ state, server }) {
   
   async function discard(tile) {
     try {
-      await fetch(`${server.replace(/\/$/, '')}/games/1/action`, {
+      if (!gameId) return;
+      await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ player_index: 0, action: 'discard', tile }),
@@ -67,7 +68,7 @@ export default function GameBoard({ state, server }) {
         <div>{south?.name ?? 'South'}</div>
         <River tiles={(south?.river ?? []).map(tileLabel)} />
         <Hand tiles={southHand} onDiscard={discard} />
-        <Controls server={server} />
+        <Controls server={server} gameId={gameId} />
         <MeldArea melds={southMelds} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow server to return game id
- let App.jsx track `gameId` and reconnect automatically
- wire GameBoard/Controls to selected id
- expose join button and persist id in localStorage
- update README features
- add unit tests for join flow and updated server response

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fc2d7010832abb20af2f3e31d648