### PR TITLE
Refactor GUI event logic into reusable module

### DIFF
--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -1,0 +1,25 @@
+import subprocess
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run([
+        "node",
+        "-e",
+        code,
+    ], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_draw_tile_removes_from_wall() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {players: [{hand: {tiles: []}, river: []}], \
+wall: {tiles: [{suit: 'pin', value: 1}, {suit: 'pin', value: 2}]}};\n"
+        "const evt = {name: 'draw_tile', payload: {player_index: 0, \
+tile: {suit: 'pin', value: 1}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.wall.tiles.length);"
+    )
+    output = run_node(code)
+    assert output == '1'

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -122,8 +122,10 @@ def test_south_hand_displays_emojis() -> None:
 
 
 def test_app_updates_wall_on_draw() -> None:
-    text = Path('web_gui/App.jsx').read_text()
-    assert 'wall.tiles.pop()' in text
+    app = Path('web_gui/App.jsx').read_text()
+    assert 'applyEvent' in app
+    logic = Path('web_gui/applyEvent.js').read_text()
+    assert 'wall.tiles.pop()' in logic
 
 
 def test_style_defines_tile_font_size() -> None:

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import GameBoard from './GameBoard.jsx';
+import { applyEvent } from './applyEvent.js';
 import './style.css';
 
 export default function App() {
@@ -56,35 +57,6 @@ export default function App() {
     }
   }
 
-  function applyEvent(state, event) {
-    if (!state) return state;
-    const newState = JSON.parse(JSON.stringify(state));
-    switch (event.name) {
-      case 'start_game':
-        return event.payload.state;
-      case 'draw_tile': {
-        const p = newState.players[event.payload.player_index];
-        if (p) p.hand.tiles.push(event.payload.tile);
-        if (newState.wall?.tiles?.length) newState.wall.tiles.pop();
-        break;
-      }
-      case 'discard': {
-        const p = newState.players[event.payload.player_index];
-        if (p) {
-          const { tile } = event.payload;
-          const idx = p.hand.tiles.findIndex(
-            (t) => t.suit === tile.suit && t.value === tile.value,
-          );
-          if (idx !== -1) p.hand.tiles.splice(idx, 1);
-          p.river.push(tile);
-        }
-        break;
-      }
-      default:
-        break;
-    }
-    return newState;
-  }
 
   function handleMessage(e) {
     try {

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -1,0 +1,29 @@
+export function applyEvent(state, event) {
+  if (!state) return state;
+  const newState = JSON.parse(JSON.stringify(state));
+  switch (event.name) {
+    case 'start_game':
+      return event.payload.state;
+    case 'draw_tile': {
+      const p = newState.players[event.payload.player_index];
+      if (p) p.hand.tiles.push(event.payload.tile);
+      if (newState.wall?.tiles?.length) newState.wall.tiles.pop();
+      break;
+    }
+    case 'discard': {
+      const p = newState.players[event.payload.player_index];
+      if (p) {
+        const { tile } = event.payload;
+        const idx = p.hand.tiles.findIndex(
+          (t) => t.suit === tile.suit && t.value === tile.value,
+        );
+        if (idx !== -1) p.hand.tiles.splice(idx, 1);
+        p.river.push(tile);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return newState;
+}


### PR DESCRIPTION
## Summary
- move event-handling logic from `App.jsx` into new `applyEvent.js`
- adapt `App.jsx` to use the module
- add tests for event application
- update existing index tests for new module

## Testing
- `flake8`
- `mypy --ignore-missing-imports core web cli`
- `python -m build core`
- `python -m build cli`
- `npm ci`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fc1b9a30832aae2a14130cb41ec0