### PR TITLE
Add GUI practice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Future work will expand these components.
 - [x] Core <-> interface API documented
 - [x] GUI design documented
 - [x] Corrected seat orientation (shimocha right side)
-- [ ] 何切る問題 mode
+- [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation
-  - [ ] Web UI support
+  - [x] Web UI support
 
 ### Core engine capabilities
 
@@ -116,7 +116,7 @@ Future work will expand these components.
   adapter with an interface that later swaps in Mortal.
 - [ ] **12. Write end-to-end tests** – cover REST routes, WebSocket updates and basic
   GUI interactions.
-- [ ] **13. Add `何切る問題` mode** – offer a practice scenario with a random seat wind
+ - [x] **13. Add `何切る問題` mode** – offer a practice scenario with a random seat wind
   and dora where the user picks a discard and the AI suggests a move.
 
 ### Remaining tasks
@@ -128,7 +128,6 @@ The following plan steps are not yet implemented:
 - Step 8 – Add full action endpoints.
 - Step 11 – Provide a mock AI.
 - Step 12 – Write end-to-end tests.
-- Step 13 – Add `何切る問題` mode.
 
 See `docs/detailed-design.md` for an overview of the planned architecture.
 `docs/web-gui-architecture.md` provides more details about the planned React GUI.

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -153,3 +153,14 @@ def test_game_board_marks_riichi() -> None:
 def test_style_defines_tile_font_size() -> None:
     css = Path('web_gui/style.css').read_text()
     assert '--tile-font-size' in css
+
+
+def test_practice_component_exists() -> None:
+    practice = Path('web_gui/Practice.jsx')
+    assert practice.is_file(), 'Practice.jsx missing'
+
+
+def test_app_has_mode_select() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Mode:' in text
+    assert 'Practice' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import GameBoard from './GameBoard.jsx';
+import Practice from './Practice.jsx';
 import './style.css';
 
 export default function App() {
@@ -9,6 +10,7 @@ export default function App() {
   const [gameId, setGameId] = useState(() => localStorage.getItem('gameId') || '');
   const [gameState, setGameState] = useState(null);
   const [events, setEvents] = useState([]);
+  const [mode, setMode] = useState('game');
   const wsRef = useRef(null);
 
   async function fetchStatus() {
@@ -165,6 +167,15 @@ export default function App() {
       </div>
       <div>
         <label>
+          Mode:
+          <select value={mode} onChange={(e) => setMode(e.target.value)}>
+            <option value="game">Game</option>
+            <option value="practice">Practice</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
           Players:
           <input
             value={players}
@@ -187,15 +198,21 @@ export default function App() {
           Join Game
         </button>
       </div>
-      <GameBoard state={gameState} server={server} gameId={gameId} />
-      <div className="event-log">
-        <h2>Events</h2>
-        <ul>
-          {events.map((e, i) => (
-            <li key={i}>{e}</li>
-          ))}
-        </ul>
-      </div>
+      {mode === 'game' ? (
+        <GameBoard state={gameState} server={server} gameId={gameId} />
+      ) : (
+        <Practice server={server} />
+      )}
+      {mode === 'game' && (
+        <div className="event-log">
+          <h2>Events</h2>
+          <ul>
+            {events.map((e, i) => (
+              <li key={i}>{e}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <p>{status}</p>
     </>
   );

--- a/web_gui/Practice.jsx
+++ b/web_gui/Practice.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import Hand from './Hand.jsx';
+import { tileToEmoji } from './tileUtils.js';
+
+export default function Practice({ server }) {
+  const [problem, setProblem] = useState(null);
+  const [suggestion, setSuggestion] = useState(null);
+  const [chosen, setChosen] = useState(null);
+
+  async function loadProblem() {
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/practice`);
+      if (resp.ok) {
+        setProblem(await resp.json());
+        setSuggestion(null);
+        setChosen(null);
+      }
+    } catch {
+      setProblem(null);
+    }
+  }
+
+  async function choose(tile) {
+    setChosen(tile);
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/practice/suggest`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hand: problem.hand }),
+      });
+      if (resp.ok) {
+        setSuggestion(await resp.json());
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  useEffect(() => {
+    loadProblem();
+  }, []);
+
+  if (!problem) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="practice">
+      <div>Seat wind: {problem.seat_wind}</div>
+      <div>Dora indicator: {tileToEmoji(problem.dora_indicator)}</div>
+      <Hand tiles={problem.hand} onDiscard={choose} />
+      {chosen && (
+        <div>You discarded {tileToEmoji(chosen)}</div>
+      )}
+      {suggestion && (
+        <div>AI suggests discarding {tileToEmoji(suggestion)}</div>
+      )}
+      <button onClick={loadProblem}>Next Problem</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Practice.jsx` component for 何切る problems
- allow switching between game and practice modes in `App.jsx`
- update README to mark practice mode supported
- cover new UI in unit tests

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68690a449d78832a9f0f5212a64117ec