### PR TITLE
Add scoreboard display component

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Score board showing names, winds & scores
 - [x] Meld display from game state
 - [x] Tile emoji rendering in GUI
 - [x] Adjustable tile font size (default 1.5x)

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -46,6 +46,11 @@ def test_center_display_component_exists() -> None:
     assert center.is_file(), 'CenterDisplay.jsx missing'
 
 
+def test_score_board_component_exists() -> None:
+    score = Path('web_gui/ScoreBoard.js')
+    assert score.is_file(), 'ScoreBoard.js missing'
+
+
 def test_controls_component_exists() -> None:
     controls = Path('web_gui/Controls.jsx')
     assert controls.is_file(), 'Controls.jsx missing'
@@ -54,6 +59,11 @@ def test_controls_component_exists() -> None:
 def test_game_board_references_center_display() -> None:
     board = Path('web_gui/GameBoard.jsx').read_text()
     assert 'CenterDisplay' in board
+
+
+def test_game_board_references_score_board() -> None:
+    board = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'ScoreBoard' in board
 
 
 def test_game_board_references_controls() -> None:

--- a/tests/web_gui/test_scoreboard_render.py
+++ b/tests/web_gui/test_scoreboard_render.py
@@ -1,0 +1,28 @@
+import subprocess
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run(
+        ["node", "-e", code], capture_output=True, text=True, cwd="web_gui"
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_scoreboard_renders() -> None:
+    output = run_node(
+        "import React from 'react';\n"
+        "import { renderToStaticMarkup } from 'react-dom/server';\n"
+        "import ScoreBoard from './ScoreBoard.js';\n"
+        "const players = [\n"
+        "  { name: 'Alice', seat_wind: 'east', score: 25000 },\n"
+        "  { name: 'Bob', seat_wind: 'south', score: 24000 },\n"
+        "];\n"
+        "const html = renderToStaticMarkup(\n"
+        "  React.createElement(ScoreBoard, { players })\n"
+        ");\n"
+        "console.log(html);"
+    )
+    assert 'Alice' in output
+    assert 'east' in output
+    assert '25000' in output

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -3,6 +3,7 @@ import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
+import ScoreBoard from './ScoreBoard.js';
 import Controls from './Controls.jsx';
 import { tileToEmoji } from './tileUtils.js';
 
@@ -63,6 +64,7 @@ export default function GameBoard({ state, server, gameId }) {
 
       <div className="center">
         <CenterDisplay remaining={remaining} dora={dora} />
+        <ScoreBoard players={players} />
       </div>
 
       <div className="east seat">

--- a/web_gui/ScoreBoard.js
+++ b/web_gui/ScoreBoard.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function ScoreBoard({ players = [] }) {
+  return React.createElement(
+    'div',
+    { className: 'score-board' },
+    players.map((p, i) =>
+      React.createElement(
+        'div',
+        { key: i, className: 'score-row' },
+        React.createElement('span', { className: 'player-name' }, p?.name || `Player ${i}`),
+        React.createElement('span', { className: 'player-wind' }, p?.seat_wind),
+        React.createElement('span', { className: 'player-score' }, p?.score)
+      )
+    )
+  );
+}

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -94,3 +94,15 @@
 .east .meld-area { transform: rotate(90deg); }
 .north .meld-area { transform: rotate(180deg); }
 .west .meld-area { transform: rotate(-90deg); }
+
+.score-board {
+  display: flex;
+  justify-content: space-around;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+.score-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- show each player's score and seat wind with new `ScoreBoard` component
- render `ScoreBoard` in the board center
- style scoreboard
- test presence of the new component and verify rendering with Node
- document scoreboard feature in the README

## Testing
- `npm ci` in `web_gui`
- `npx vitest run`
- `npm run build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690a54ab64832aaed4fa93d8e5c55b