### PR TITLE
Implement score updates on win events

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -145,13 +145,31 @@ class MahjongEngine:
     def declare_tsumo(self, player_index: int, win_tile: Tile) -> HandResponse:
         """Declare a self-drawn win and return scoring info."""
         result = self.calculate_score(player_index, win_tile)
-        self._emit("tsumo", {"player_index": player_index, "result": result})
+        player = self.state.players[player_index]
+        if result.cost and "total" in result.cost:
+            player.score += int(result.cost["total"])
+        scores = [p.score for p in self.state.players]
+        self._emit(
+            "tsumo",
+            {
+                "player_index": player_index,
+                "result": result,
+                "scores": scores,
+            },
+        )
         return result
 
     def declare_ron(self, player_index: int, win_tile: Tile) -> HandResponse:
         """Declare a win on another player's discard."""
         result = self.calculate_score(player_index, win_tile)
-        self._emit("ron", {"player_index": player_index, "result": result})
+        player = self.state.players[player_index]
+        if result.cost and "total" in result.cost:
+            player.score += int(result.cost["total"])
+        scores = [p.score for p in self.state.players]
+        self._emit(
+            "ron",
+            {"player_index": player_index, "result": result, "scores": scores},
+        )
         return result
 
     def skip(self, player_index: int) -> None:

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -51,8 +51,8 @@ translate them directly.
 | `discard`          | `player_index`, `Tile`                  | Tile placed into the river. |
 | `meld`             | `player_index`, `Meld`                  | Meld call (chi/pon/kan). |
 | `riichi`           | `player_index`                          | Player declares riichi. |
-| `tsumo`            | `player_index`, `HandResponse`          | Self-drawn win. |
-| `ron`              | `player_index`, `HandResponse`          | Win on discard. |
+| `tsumo`            | `player_index`, `HandResponse`, scores  | Self-drawn win. |
+| `ron`              | `player_index`, `HandResponse`, scores  | Win on discard. |
 | `ryukyoku`         | reason                                  | Hand ends in draw. |
 | `end_game`         | final scores                            | Sent after the last hand. |
 

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -105,9 +105,40 @@ def test_declare_riichi() -> None:
     assert player.score == start_score - 1000
 
 
+def test_tsumo_updates_scores_and_emits_event() -> None:
+    engine = MahjongEngine(ruleset=ScoringRuleSet())
+    engine.pop_events()
+    tile = Tile("man", 1)
+    engine.state.players[0].hand.tiles.append(tile)
+    start_score = engine.state.players[0].score
+    engine.declare_tsumo(0, tile)
+    assert engine.state.players[0].score == start_score + 8000
+    evt = engine.pop_events()[-1]
+    assert evt.name == "tsumo"
+    assert evt.payload["scores"][0] == start_score + 8000
+
+
+def test_ron_updates_scores_and_emits_event() -> None:
+    engine = MahjongEngine(ruleset=ScoringRuleSet())
+    engine.pop_events()
+    tile = Tile("man", 2)
+    engine.state.players[0].hand.tiles.append(tile)
+    start_score = engine.state.players[0].score
+    engine.declare_ron(0, tile)
+    assert engine.state.players[0].score == start_score + 8000
+    evt = engine.pop_events()[-1]
+    assert evt.name == "ron"
+    assert evt.payload["scores"][0] == start_score + 8000
+
+
 class DummyRuleSet(RuleSet):
     def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
         return HandResponse(han=1)
+
+
+class ScoringRuleSet(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=1, cost={"total": 8000})
 
 
 def test_event_log() -> None:


### PR DESCRIPTION
## Summary
- update player scores in `declare_tsumo` and `declare_ron`
- include updated scores in `tsumo`/`ron` events
- document new event payload fields
- test score updates and event payloads

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli --ignore-missing-imports`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686913ab652c832a83721652ecd1aea7