### PR TITLE
Add peek option to reveal opponents' hands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Future work will expand these components.
 - [x] Meld display from game state
 - [x] Tile emoji rendering in GUI
 - [x] Adjustable tile font size (default 1.5x)
+- [x] Peek at opponents' hands option
 - [x] Basic draw control via REST API
 - [x] Discard tiles via GUI
 - [x] Meld and win actions via GUI

--- a/tests/web_gui/test_peek_option.py
+++ b/tests/web_gui/test_peek_option.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_app_has_peek_toggle() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Peek' in text
+    assert 'setPeek' in text
+
+
+def test_game_board_accepts_peek_prop() -> None:
+    text = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'peek =' in text or 'peek=' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -12,6 +12,7 @@ export default function App() {
   const [gameState, setGameState] = useState(null);
   const [events, setEvents] = useState([]);
   const [mode, setMode] = useState('game');
+  const [peek, setPeek] = useState(false);
   const wsRef = useRef(null);
 
   async function fetchStatus() {
@@ -179,6 +180,16 @@ export default function App() {
       </div>
       <div>
         <label>
+          <input
+            type="checkbox"
+            checked={peek}
+            onChange={(e) => setPeek(e.target.checked)}
+          />
+          Peek
+        </label>
+      </div>
+      <div>
+        <label>
           Players:
           <input
             value={players}
@@ -202,7 +213,7 @@ export default function App() {
         </button>
       </div>
       {mode === 'game' ? (
-        <GameBoard state={gameState} server={server} gameId={gameId} />
+        <GameBoard state={gameState} server={server} gameId={gameId} peek={peek} />
       ) : (
         <Practice server={server} />
       )}

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -9,7 +9,7 @@ import { tileToEmoji } from './tileUtils.js';
 function tileLabel(tile) {
   return tileToEmoji(tile);
 }
-export default function GameBoard({ state, server, gameId }) {
+export default function GameBoard({ state, server, gameId, peek = false }) {
   const players = state?.players ?? [];
   const south = players[0];
   const west = players[1];
@@ -19,9 +19,17 @@ export default function GameBoard({ state, server, gameId }) {
   const nameWithRiichi = (p) => (p?.riichi ? `${p.name} (Riichi)` : p?.name);
   const defaultHand = Array(13).fill('🀫');
 
-  const northHand = north?.hand?.tiles.map(tileLabel) ?? defaultHand;
-  const westHand = west?.hand?.tiles.map(tileLabel) ?? defaultHand;
-  const eastHand = east?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  function concealedHand(p) {
+    const count = p?.hand?.tiles?.length ?? 13;
+    return Array(count).fill('🀫');
+  }
+
+  const northHand =
+    peek ? north?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(north);
+  const westHand =
+    peek ? west?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(west);
+  const eastHand =
+    peek ? east?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(east);
   const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
 
   const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];


### PR DESCRIPTION
## Summary
- add `peek` toggle to App and GameBoard
- hide opponents' tiles unless `peek` is enabled
- document new feature in README
- add tests for the new option

## Testing
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --silent --prefix web_gui` *(no output)*
- `npx --yes vitest run --coverage --no-color --root web_gui` *(failed: MISSING DEPENDENCY)*

------
https://chatgpt.com/codex/tasks/task_e_686914f066a8832a945de2384f78d6f8