### PR TITLE
Implement turn rotation on actions

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -87,12 +87,15 @@ class MahjongEngine:
         self._emit("draw_tile", {"player_index": player_index, "tile": tile})
         if self.state.wall.remaining_tiles == 0:
             self._emit("ryukyoku", {"reason": "wall_empty"})
+        else:
+            self.state.current_player = (player_index + 1) % len(self.state.players)
         return tile
 
     def discard_tile(self, player_index: int, tile: Tile) -> None:
         """Discard a tile from the specified player's hand."""
         self.state.players[player_index].discard(tile)
         self._emit("discard", {"player_index": player_index, "tile": tile})
+        self.state.current_player = (player_index + 1) % len(self.state.players)
 
     def declare_riichi(self, player_index: int) -> None:
         """Declare riichi for the given player."""

--- a/tests/core/test_turn_rotation.py
+++ b/tests/core/test_turn_rotation.py
@@ -1,0 +1,16 @@
+from core.mahjong_engine import MahjongEngine
+
+
+def test_draw_advances_turn() -> None:
+    engine = MahjongEngine()
+    current = engine.state.current_player
+    engine.draw_tile(current)
+    assert engine.state.current_player == (current + 1) % len(engine.state.players)
+
+
+def test_discard_advances_turn() -> None:
+    engine = MahjongEngine()
+    current = engine.state.current_player
+    tile = engine.state.players[current].hand.tiles[0]
+    engine.discard_tile(current, tile)
+    assert engine.state.current_player == (current + 1) % len(engine.state.players)


### PR DESCRIPTION
## Summary
- rotate `current_player` after drawing or discarding tiles
- keep `skip` as a no-op when called out of turn
- add tests to ensure turn rotation works

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6869167edbdc832a88f6913aa5d608ab