### PR TITLE
Implement meld validation and discard consumption

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -42,6 +42,8 @@ class GameState:
     dealer: int = 0
     round_number: int = 1
     seat_winds: list[str] = field(default_factory=list)
+    last_discard: Tile | None = None
+    last_discard_player: int | None = None
 
 
 @dataclass

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -33,12 +33,15 @@ def test_get_state() -> None:
 
 def test_call_pon() -> None:
     state = api.start_game(["A", "B", "C", "D"])
-    tiles = [models.Tile("pin", 1) for _ in range(3)]
-    player = state.players[0]
-    player.hand.tiles.extend(tiles[:2])
-    api.call_pon(0, tiles)
-    assert len(player.hand.melds) == 1
-    assert player.hand.melds[0].type == "pon"
+    tile = models.Tile("pin", 1)
+    discarder = state.players[1]
+    caller = state.players[0]
+    discarder.hand.tiles.append(tile)
+    api.discard_tile(1, tile)
+    caller.hand.tiles.extend([models.Tile("pin", 1), models.Tile("pin", 1)])
+    api.call_pon(0, [models.Tile("pin", 1), models.Tile("pin", 1), tile])
+    assert len(caller.hand.melds) == 1
+    assert caller.hand.melds[0].type == "pon"
 
 
 def test_end_game_creates_new_state() -> None:

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -66,12 +66,16 @@ def test_calculate_score_returns_value() -> None:
 
 def test_call_pon_adds_meld() -> None:
     engine = MahjongEngine()
-    tiles = [Tile("man", 1) for _ in range(3)]
-    player = engine.state.players[0]
-    player.hand.tiles.extend(tiles[:2])
-    engine.call_pon(0, tiles)
-    assert len(player.hand.melds) == 1
-    assert player.hand.melds[0].type == "pon"
+    tile = Tile("man", 1)
+    discarder = engine.state.players[0]
+    caller = engine.state.players[1]
+    discarder.hand.tiles.append(tile)
+    engine.discard_tile(0, tile)
+    caller.hand.tiles.extend([Tile("man", 1), Tile("man", 1)])
+    engine.call_pon(1, [Tile("man", 1), Tile("man", 1), tile])
+    assert len(caller.hand.melds) == 1
+    assert caller.hand.melds[0].type == "pon"
+    assert tile not in discarder.river
 
 
 def test_end_game_resets_state() -> None:

--- a/tests/core/test_meld_validation.py
+++ b/tests/core/test_meld_validation.py
@@ -1,0 +1,57 @@
+import pytest
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile
+
+
+def test_call_chi_consumes_discard() -> None:
+    engine = MahjongEngine()
+    discarder = engine.state.players[0]
+    caller = engine.state.players[1]
+    tile = Tile("man", 3)
+    discarder.hand.tiles = [tile]
+    caller.hand.tiles = []
+    engine.discard_tile(0, tile)
+    caller.hand.tiles.extend([Tile("man", 1), Tile("man", 2)])
+    engine.call_chi(1, [Tile("man", 1), Tile("man", 2), tile])
+    assert len(caller.hand.melds) == 1
+    assert caller.hand.melds[0].type == "chi"
+    assert tile not in discarder.river
+
+
+def test_call_chi_invalid_missing_tile() -> None:
+    engine = MahjongEngine()
+    discarder = engine.state.players[0]
+    caller = engine.state.players[1]
+    tile = Tile("man", 3)
+    discarder.hand.tiles = [tile]
+    caller.hand.tiles = []
+    engine.discard_tile(0, tile)
+    caller.hand.tiles.append(Tile("man", 1))
+    with pytest.raises(ValueError):
+        engine.call_chi(1, [Tile("man", 1), Tile("man", 2), tile])
+
+
+def test_call_pon_invalid_structure() -> None:
+    engine = MahjongEngine()
+    discarder = engine.state.players[0]
+    caller = engine.state.players[2]
+    tile = Tile("sou", 7)
+    discarder.hand.tiles = [tile]
+    caller.hand.tiles = []
+    engine.discard_tile(0, tile)
+    caller.hand.tiles.extend([Tile("sou", 7), Tile("sou", 8)])
+    with pytest.raises(ValueError):
+        engine.call_pon(2, [Tile("sou", 7), Tile("sou", 7), Tile("sou", 8)])
+
+
+def test_call_kan_insufficient_tiles() -> None:
+    engine = MahjongEngine()
+    discarder = engine.state.players[0]
+    caller = engine.state.players[1]
+    tile = Tile("pin", 5)
+    discarder.hand.tiles = [tile]
+    caller.hand.tiles = []
+    engine.discard_tile(0, tile)
+    caller.hand.tiles.extend([Tile("pin", 5), Tile("pin", 5)])
+    with pytest.raises(ValueError):
+        engine.call_kan(1, [Tile("pin", 5), Tile("pin", 5), Tile("pin", 5), tile])


### PR DESCRIPTION
## Summary
- track the last discarded tile in `GameState`
- validate `chi`, `pon` and `kan` meld requests
- consume discards when melds are called
- adjust API and server tests for new behaviour
- cover illegal meld cases with new tests

## Testing
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691e9046b8832aaa238f15af03d887