### PR TITLE
Switch GUI tiles to images with accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Future work will expand these components.
 - [x] Meld area component
 - [x] Center display (dora & wall count)
 - [x] Meld display from game state
-- [x] Tile emoji rendering in GUI
+- [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option
+- [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
 - [x] Discard tiles via GUI
 - [x] Meld and win actions via GUI

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -101,9 +101,9 @@ def test_hand_supports_discard() -> None:
     assert 'onDiscard' in text
 
 
-def test_hand_uses_tile_to_emoji() -> None:
+def test_hand_uses_tile_to_image() -> None:
     text = Path('web_gui/Hand.jsx').read_text()
-    assert 'tileToEmoji' in text
+    assert 'tileToImage' in text
 
 
 def test_app_handles_websocket_events() -> None:
@@ -123,7 +123,7 @@ def test_game_board_passes_remaining_prop() -> None:
     assert 'remaining={' in board
 
 
-def test_south_hand_displays_emojis() -> None:
+def test_south_hand_displays_images() -> None:
     board = Path('web_gui/GameBoard.jsx').read_text()
     assert 'south?.hand?.tiles.map(tileLabel)' in board
 

--- a/tests/web_gui/test_tile_accessibility.py
+++ b/tests/web_gui/test_tile_accessibility.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+def test_tile_image_asset_exists() -> None:
+    path = Path('web_gui/assets/sou_1.svg')
+    assert path.is_file(), 'sou_1.svg missing'
+
+
+def test_hand_uses_img_tags() -> None:
+    text = Path('web_gui/Hand.jsx').read_text()
+    assert '<img' in text, 'Hand component should use img tags'
+
+
+def test_tile_button_has_aria_label() -> None:
+    text = Path('web_gui/Hand.jsx').read_text()
+    assert 'aria-label={`Discard' in text
+
+
+def test_tile_transition_defined() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert 'transition: transform' in css

--- a/tests/web_gui/test_tile_image.py
+++ b/tests/web_gui/test_tile_image.py
@@ -11,9 +11,9 @@ def run_node(code: str) -> str:
     return result.stdout.strip()
 
 
-def test_tile_to_emoji() -> None:
+def test_tile_to_image() -> None:
     output = run_node(
-        "import { tileToEmoji } from './web_gui/tileUtils.js';\n"
-        "console.log(tileToEmoji({suit: 'sou', value: 8}));"
+        "import { tileToImage } from './web_gui/tileUtils.js';\n"
+        "console.log(tileToImage({suit: 'sou', value: 8}));"
     )
-    assert output == '🀗'
+    assert output.endswith('sou_8.svg')

--- a/web_gui/Button.jsx
+++ b/web_gui/Button.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import './style.css';
 
-export default function Button({ children, ...props }) {
+export default function Button({ children, "aria-label": ariaLabel, ...props }) {
+  const label =
+    ariaLabel || (typeof children === 'string' ? children : undefined);
   return (
-    <button className="flat-btn" {...props}>
+    <button className="flat-btn" aria-label={label} {...props}>
       {children}
     </button>
   );

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
 
-export default function CenterDisplay({ remaining = 0, dora = ['\uD83C\uDE00'] }) {
+export default function CenterDisplay({ remaining = 0, dora = [] }) {
   return (
     <div className="center-display">
       <div className="remaining">Remaining: {remaining}</div>
-      <div className="dora">Dora: {dora.join(' ')}</div>
+      <div className="dora">
+        Dora:{' '}
+        {dora.map((t, i) => (
+          typeof t === 'string' ? (
+            <span key={i}>{t}</span>
+          ) : (
+            <img key={i} src={t.src} alt={t.alt} />
+          )
+        ))}
+      </div>
     </div>
   );
 }

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -4,10 +4,13 @@ import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import CenterDisplay from './CenterDisplay.jsx';
 import Controls from './Controls.jsx';
-import { tileToEmoji } from './tileUtils.js';
+import { tileToImage, tileDescription } from './tileUtils.js';
 
 function tileLabel(tile) {
-  return tileToEmoji(tile);
+  return {
+    src: tileToImage(tile),
+    alt: tileDescription(tile),
+  };
 }
 export default function GameBoard({ state, server, gameId, peek = false }) {
   const players = state?.players ?? [];

--- a/web_gui/Hand.jsx
+++ b/web_gui/Hand.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
-import { tileToEmoji } from './tileUtils.js';
+import { tileToImage, tileDescription } from './tileUtils.js';
 
 export default function Hand({ tiles = [], onDiscard }) {
   return (
     <div className="hand">
       {tiles.map((t, i) => {
-        const label = typeof t === 'string' ? t : tileToEmoji(t);
+        if (typeof t === 'string') {
+          return (
+            <span key={i} className="tile">{t}</span>
+          );
+        }
+        const src = t.src || tileToImage(t);
+        const alt = t.alt || tileDescription(t);
         return onDiscard ? (
           <button
             key={i}
             className="tile"
             onClick={() => onDiscard(t)}
+            aria-label={`Discard ${alt}`}
           >
-            {label}
+            <img src={src} alt={alt} />
           </button>
         ) : (
-          <span key={i} className="tile">{label}</span>
+          <span key={i} className="tile">
+            <img src={src} alt={alt} />
+          </span>
         );
       })}
     </div>

--- a/web_gui/MeldArea.jsx
+++ b/web_gui/MeldArea.jsx
@@ -6,7 +6,13 @@ export default function MeldArea({ melds = [] }) {
       {melds.map((meld, mIdx) => (
         <div key={mIdx} className="meld">
           {meld.map((t, i) => (
-            <span key={i} className="tile">{t}</span>
+            typeof t === 'string' ? (
+              <span key={i} className="tile">{t}</span>
+            ) : (
+              <span key={i} className="tile">
+                <img src={t.src} alt={t.alt} />
+              </span>
+            )
           ))}
         </div>
       ))}

--- a/web_gui/Practice.jsx
+++ b/web_gui/Practice.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Hand from './Hand.jsx';
 import Button from './Button.jsx';
-import { tileToEmoji } from './tileUtils.js';
+import { tileToImage, tileDescription } from './tileUtils.js';
 
 export default function Practice({ server }) {
   const [problem, setProblem] = useState(null);
@@ -48,13 +48,25 @@ export default function Practice({ server }) {
   return (
     <div className="practice">
       <div>Seat wind: {problem.seat_wind}</div>
-      <div>Dora indicator: {tileToEmoji(problem.dora_indicator)}</div>
+      <div>
+        Dora indicator:{' '}
+        <img
+          src={tileToImage(problem.dora_indicator)}
+          alt={tileDescription(problem.dora_indicator)}
+        />
+      </div>
       <Hand tiles={problem.hand} onDiscard={choose} />
       {chosen && (
-        <div>You discarded {tileToEmoji(chosen)}</div>
+        <div>
+          You discarded{' '}
+          <img src={tileToImage(chosen)} alt={tileDescription(chosen)} />
+        </div>
       )}
       {suggestion && (
-        <div>AI suggests discarding {tileToEmoji(suggestion)}</div>
+        <div>
+          AI suggests discarding{' '}
+          <img src={tileToImage(suggestion)} alt={tileDescription(suggestion)} />
+        </div>
       )}
       <Button onClick={loadProblem}>Next Problem</Button>
     </div>

--- a/web_gui/River.jsx
+++ b/web_gui/River.jsx
@@ -4,7 +4,13 @@ export default function River({ tiles = [] }) {
   return (
     <div className="river">
       {tiles.map((t, i) => (
-        <span key={i} className="tile">{t}</span>
+        typeof t === 'string' ? (
+          <span key={i} className="tile">{t}</span>
+        ) : (
+          <span key={i} className="tile">
+            <img src={t.src} alt={t.alt} />
+          </span>
+        )
       ))}
     </div>
   );

--- a/web_gui/assets/dragon_1.svg
+++ b/web_gui/assets/dragon_1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>W</text>
+</svg>

--- a/web_gui/assets/dragon_2.svg
+++ b/web_gui/assets/dragon_2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>G</text>
+</svg>

--- a/web_gui/assets/dragon_3.svg
+++ b/web_gui/assets/dragon_3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>R</text>
+</svg>

--- a/web_gui/assets/man_1.svg
+++ b/web_gui/assets/man_1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>1m</text>
+</svg>

--- a/web_gui/assets/man_2.svg
+++ b/web_gui/assets/man_2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>2m</text>
+</svg>

--- a/web_gui/assets/man_3.svg
+++ b/web_gui/assets/man_3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>3m</text>
+</svg>

--- a/web_gui/assets/man_4.svg
+++ b/web_gui/assets/man_4.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>4m</text>
+</svg>

--- a/web_gui/assets/man_5.svg
+++ b/web_gui/assets/man_5.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>5m</text>
+</svg>

--- a/web_gui/assets/man_6.svg
+++ b/web_gui/assets/man_6.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>6m</text>
+</svg>

--- a/web_gui/assets/man_7.svg
+++ b/web_gui/assets/man_7.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>7m</text>
+</svg>

--- a/web_gui/assets/man_8.svg
+++ b/web_gui/assets/man_8.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>8m</text>
+</svg>

--- a/web_gui/assets/man_9.svg
+++ b/web_gui/assets/man_9.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>9m</text>
+</svg>

--- a/web_gui/assets/pin_1.svg
+++ b/web_gui/assets/pin_1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>1p</text>
+</svg>

--- a/web_gui/assets/pin_2.svg
+++ b/web_gui/assets/pin_2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>2p</text>
+</svg>

--- a/web_gui/assets/pin_3.svg
+++ b/web_gui/assets/pin_3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>3p</text>
+</svg>

--- a/web_gui/assets/pin_4.svg
+++ b/web_gui/assets/pin_4.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>4p</text>
+</svg>

--- a/web_gui/assets/pin_5.svg
+++ b/web_gui/assets/pin_5.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>5p</text>
+</svg>

--- a/web_gui/assets/pin_6.svg
+++ b/web_gui/assets/pin_6.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>6p</text>
+</svg>

--- a/web_gui/assets/pin_7.svg
+++ b/web_gui/assets/pin_7.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>7p</text>
+</svg>

--- a/web_gui/assets/pin_8.svg
+++ b/web_gui/assets/pin_8.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>8p</text>
+</svg>

--- a/web_gui/assets/pin_9.svg
+++ b/web_gui/assets/pin_9.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>9p</text>
+</svg>

--- a/web_gui/assets/sou_1.svg
+++ b/web_gui/assets/sou_1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>1s</text>
+</svg>

--- a/web_gui/assets/sou_2.svg
+++ b/web_gui/assets/sou_2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>2s</text>
+</svg>

--- a/web_gui/assets/sou_3.svg
+++ b/web_gui/assets/sou_3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>3s</text>
+</svg>

--- a/web_gui/assets/sou_4.svg
+++ b/web_gui/assets/sou_4.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>4s</text>
+</svg>

--- a/web_gui/assets/sou_5.svg
+++ b/web_gui/assets/sou_5.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>5s</text>
+</svg>

--- a/web_gui/assets/sou_6.svg
+++ b/web_gui/assets/sou_6.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>6s</text>
+</svg>

--- a/web_gui/assets/sou_7.svg
+++ b/web_gui/assets/sou_7.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>7s</text>
+</svg>

--- a/web_gui/assets/sou_8.svg
+++ b/web_gui/assets/sou_8.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>8s</text>
+</svg>

--- a/web_gui/assets/sou_9.svg
+++ b/web_gui/assets/sou_9.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>9s</text>
+</svg>

--- a/web_gui/assets/wind_1.svg
+++ b/web_gui/assets/wind_1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>E</text>
+</svg>

--- a/web_gui/assets/wind_2.svg
+++ b/web_gui/assets/wind_2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>S</text>
+</svg>

--- a/web_gui/assets/wind_3.svg
+++ b/web_gui/assets/wind_3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>W</text>
+</svg>

--- a/web_gui/assets/wind_4.svg
+++ b/web_gui/assets/wind_4.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 60'>
+<rect x='0' y='0' width='40' height='60' fill='white' stroke='black'/>
+<text x='20' y='35' font-size='20' text-anchor='middle'>N</text>
+</svg>

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -85,6 +85,16 @@
   background-color: white;
   border: 1px solid #333;
   border-radius: 2px;
+  transition: transform 0.2s;
+}
+
+.tile:hover {
+  transform: translateY(-2px);
+}
+
+.tile img {
+  width: 100%;
+  height: 100%;
 }
 
 .east .river { transform: rotate(90deg); }

--- a/web_gui/tileUtils.js
+++ b/web_gui/tileUtils.js
@@ -1,19 +1,17 @@
-export function tileToEmoji(tile) {
+export function tileToImage(tile) {
   const { suit, value } = tile;
-  if (suit === 'man') {
-    return String.fromCodePoint(0x1f007 + (value - 1));
-  }
-  if (suit === 'sou') {
-    return String.fromCodePoint(0x1f010 + (value - 1));
-  }
-  if (suit === 'pin') {
-    return String.fromCodePoint(0x1f019 + (value - 1));
-  }
+  return `./assets/${suit}_${value}.svg`;
+}
+
+export function tileDescription(tile) {
+  const { suit, value } = tile;
   if (suit === 'wind') {
-    return String.fromCodePoint(0x1f000 + (value - 1));
+    const names = ['east', 'south', 'west', 'north'];
+    return `${names[value - 1]} wind`;
   }
   if (suit === 'dragon') {
-    return String.fromCodePoint(0x1f004 + (value - 1));
+    const names = ['white', 'green', 'red'];
+    return `${names[value - 1]} dragon`;
   }
-  return `${suit[0]}${value}`;
+  return `${value} ${suit}`;
 }


### PR DESCRIPTION
## Summary
- replace tile emoji with generated SVG assets
- update tile utils to return image paths and descriptions
- show tile images in board, hand, river, melds and practice modes
- add hover transitions in CSS and aria-labels on buttons
- document accessibility support in README
- add tests for new image assets and accessibility

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686928688994832a956abc021a5dfe60