### PR TITLE
Add doc for missing core features

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ The following plan steps are not yet implemented:
 - Step 11 – Provide a mock AI.
 - Step 12 – Write end-to-end tests.
 
+### Core engine missing features
+
+The core package covers the basic turn flow but several important capabilities
+remain to be built:
+
+- [ ] Closed and added kan support with replacement draws and new dora
+  indicators.
+- [ ] Tracking honba and riichi sticks in `GameState`.
+- [ ] Automatic round progression with dealer repeats and hanchan end
+  detection.
+- [ ] Exhaustive draw conditions such as four kans and nine terminals.
+- [ ] Complete MJAI protocol adapter for external AIs.
+- [ ] Mortal AI integration using the adapter.
+
+See `docs/core-tasks.md` for detailed task descriptions.
+
 See `docs/detailed-design.md` for an overview of the planned architecture.
 `docs/web-gui-architecture.md` provides more details about the planned React GUI.
 

--- a/docs/core-tasks.md
+++ b/docs/core-tasks.md
@@ -1,0 +1,31 @@
+# Remaining Core Tasks
+
+The following features are still missing from the `core` package to allow a full Mahjong game. Each item should be implemented incrementally.
+
+## Closed and added kans
+- Allow players to declare a closed kan using four tiles from their hand.
+- Support added kan (shouminkan) when a player upgrades a pon meld.
+- Draw a replacement tile from the dead wall and reveal a new dora indicator.
+- Emit chankan opportunities for other players.
+
+## Honba and riichi stick tracking
+- Track the number of bonus points on the table for consecutive draws/wins.
+- Deduct and pay out riichi sticks when wins are resolved.
+
+## Round progression and renchan
+- Advance the round and dealer position automatically after each hand.
+- Handle dealer repeats when the dealer wins or the hand ends in draw.
+- Detect the end of a hanchan.
+
+## Exhaustive draw conditions
+- Detect rare draw scenarios such as four kans, four riichi, and nine terminals.
+- Emit a `ryukyoku` event with the specific reason.
+
+## MJAI protocol adapter
+- Expand `ai_adapter.py` to handle all MJAI messages.
+- Validate actions received from external AIs before applying them.
+
+## Mortal AI integration
+- Use `mortal_runner.py` to launch the AI and connect through the adapter.
+- Provide helpers so the CLI and web server can run Mortal as an opponent.
+


### PR DESCRIPTION
## Summary
- document missing core engine features
- list tasks in README and new `core-tasks.md`

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli` *(fails: missing `mahjong` stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692852920c832a968f67c666104d53