### PR TITLE
Add responsive mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Future work will expand these components.
 - [x] Core <-> interface API documented
 - [x] GUI design documented
 - [x] Corrected seat orientation (shimocha right side)
+- [x] Responsive layout for narrow screens
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -17,7 +17,7 @@ For a detailed overview of how each player area and discard river is arranged, i
 
 1. Provide visual assets for tiles and update the React components to render images instead of text.
 2. Update `web/src/style.css` to define fixed or minimum heights for board rows and make player areas scroll if content overflows.
-3. Add media queries that reorganize the grid on small screens (e.g. stacking side players above the center).
+3. Add media queries that reorganize the grid on small screens (e.g. stacking side players above the center). **Done.**
 4. Replace textual control labels with icons and add appropriate `aria-label` attributes. **Done.**
 5. Ensure the layout uses flexible units so it remains usable on both desktops and phones.
 6. Show dora indicators and remaining wall tiles in the center display. **Done.**

--- a/tests/web_gui/test_responsive.py
+++ b/tests/web_gui/test_responsive.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_style_contains_media_query() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert '@media (max-width' in css

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -120,3 +120,16 @@
 .flat-btn:active {
   background-color: #004a99;
 }
+
+@media (max-width: 600px) {
+  .board-grid {
+    grid-template-areas:
+      'north'
+      'west'
+      'center'
+      'east'
+      'south';
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(5, auto);
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple mobile layout media query
- document responsive layout feature in README
- note completion of media query task in gui-design
- test CSS media query

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686933ffc5bc832ab01442246005f7f2