### PR TITLE
Implement automatic tile draw on turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Future work will expand these components.
 - [x] Peek at opponents' hands option
 - [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
+- [x] Automatic draw on turn start
 - [x] Discard tiles via GUI
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI

--- a/docs/web-gui-architecture.md
+++ b/docs/web-gui-architecture.md
@@ -13,7 +13,7 @@ The web client will be implemented as a small React application bundled with Vit
 - **Hand** – displays the tiles in a player's hand and action buttons.
 - **River** – shows each player's discard pile with orientation classes.
 - **MeldArea** – lists called sets (chi/pon/kan) for a seat.
-- **Controls** – minimal buttons for drawing, discarding and declaring wins.
+- **Controls** – buttons for calling melds, declaring wins and skipping turns.
 
 Each component receives only the data it needs so the interface remains simple and testable. Styling is handled by a single `style.css` file using CSS grid and flexbox.
 
@@ -22,7 +22,8 @@ Each component receives only the data it needs so the interface remains simple a
 1. After the page loads, `App` fetches the current game state via `GET /games/{id}`.
 2. `App` opens a WebSocket to `/ws/{id}` and listens for events.
 3. Incoming events update the React state, which re-renders the `GameBoard`.
-4. User actions send POST requests back to the server using the REST API.
+4. When `current_player` changes, `GameBoard` posts `{action: 'draw'}` for that player so drawing occurs automatically.
+5. User actions send POST requests back to the server using the REST API.
 
 ## Future Enhancements
 

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -4,34 +4,10 @@ import Button from './Button.jsx';
 export default function Controls({ server, gameId }) {
   const [message, setMessage] = useState('');
 
-  async function draw() {
-    try {
-      if (!gameId) return;
-      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ player_index: 0, action: 'draw' }),
-      });
-      if (resp.ok) {
-        const tile = await resp.json();
-        setMessage(`Drew ${tile.suit} ${tile.value}`);
-      } else {
-        let data = null;
-        try {
-          data = await resp.json();
-        } catch {
-          // ignore
-        }
-        setMessage(data?.detail || 'Error drawing tile');
-      }
-    } catch {
-      setMessage('Server unreachable');
-    }
-  }
 
   async function simple(action, payload = {}) {
     try {
-      await fetch(`${server.replace(/\/$/, '')}/games/1/action`, {
+      await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ player_index: 0, action, ...payload }),
@@ -72,7 +48,6 @@ export default function Controls({ server, gameId }) {
 
   return (
     <div className="controls">
-      <Button onClick={draw}>Draw</Button>
       <Button onClick={chi}>Chi</Button>
       <Button onClick={pon}>Pon</Button>
       <Button onClick={kan}>Kan</Button>

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState(playerIndex = 0) {
+  return {
+    current_player: playerIndex,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+  };
+}
+
+describe('GameBoard auto draw', () => {
+  it('requests draw when current_player changes', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = fetchMock;
+    const state = mockState(0);
+    const { rerender } = render(<GameBoard state={state} server="http://s" gameId="1" />);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ player_index: 0, action: 'draw' });
+    state.current_player = 1;
+    rerender(<GameBoard state={state} server="http://s" gameId="1" />);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ player_index: 1, action: 'draw' });
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
@@ -15,6 +15,22 @@ export default function GameBoard({ state, server, gameId, peek = false }) {
   const west = players[1];
   const north = players[2];
   const east = players[3];
+
+  const prevPlayer = useRef(null);
+
+  useEffect(() => {
+    const current = state?.current_player;
+    if (!gameId || current == null || current === prevPlayer.current) return;
+    prevPlayer.current = current;
+    const tiles = state?.players?.[current]?.hand?.tiles ?? [];
+    if (tiles.length === 13) {
+      fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player_index: current, action: 'draw' }),
+      }).catch(() => {});
+    }
+  }, [state?.current_player, gameId, server, state?.players]);
 
   const nameWithRiichi = (p) => (p?.riichi ? `${p.name} (Riichi)` : p?.name);
   const defaultHand = Array(13).fill('🀫');


### PR DESCRIPTION
## Summary
- auto-draw a tile when `current_player` changes
- remove manual Draw button
- document automatic draws
- add React test for new behaviour
- mark feature complete in README

## Testing
- `npm install`
- `npx vitest run`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ae220d50832a880bb3c8bf3282e1