### PR TITLE
Improve GUI toggle icons

### DIFF
--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -70,7 +70,7 @@ def test_style_css_exists() -> None:
 def test_app_has_server_selection() -> None:
     text = Path('web_gui/App.jsx').read_text()
     assert '<input' in text
-    assert 'Retry' in text
+    assert 'aria-label="Retry"' in text
 
 
 def test_app_can_start_game() -> None:

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -180,7 +180,7 @@ export default function App() {
           />
         </label>
         <div className="control">
-          <Button onClick={fetchStatus}>Retry</Button>
+          <Button aria-label="Retry" onClick={fetchStatus}>🔄</Button>
         </div>
       </div>
       <div className="field">
@@ -194,16 +194,16 @@ export default function App() {
           </span>
         </label>
       </div>
-      <div className="field">
-        <label className="checkbox">
-          <input
-            type="checkbox"
-            className="mr-1"
-            checked={peek}
-            onChange={(e) => setPeek(e.target.checked)}
-          />
-          Peek
-        </label>
+      <div className="field is-grouped is-align-items-flex-end">
+        <label className="label mr-2">Peek:</label>
+        <div className="control">
+          <Button
+            aria-label="Toggle peek"
+            onClick={() => setPeek(!peek)}
+          >
+            {peek ? '🙈' : '👁️'}
+          </Button>
+        </div>
       </div>
       <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">


### PR DESCRIPTION
## Summary
- switch Retry button to refresh icon
- toggle peek visibility with icon instead of checkbox
- update unit test to search for `aria-label="Retry"`

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm install`
- `npm test` (vitest)

------
https://chatgpt.com/codex/tasks/task_e_6869de9c0530832a8b4aabf11155b558