### PR TITLE
Add alternate player panel layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Future work will expand these components.
 - [x] GUI server selection and retry
 - [x] React front-end skeleton
 - [x] Basic board layout
+- [x] Alternate player panel layout option
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)

--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -31,6 +31,23 @@ Each seat has one meld zone. The North player's hand is drawn just above the riv
   +---------------+----------------------+---------------+
 ```
 
+### Player Panel Layout
+
+An alternative layout treats each player area as a self-contained panel:
+
+```
++---------------+---------------------+
+| Toimen panel  | Shimocha panel      |
++---------------+---------------------+
+| Kamicha panel | Jicha panel (self)  |
++---------------+---------------------+
+```
+
+Each panel stacks a thin riichi stick area with the seat name and score, a river
+display that grows up to four rows of six tiles, then a combined hand and meld
+section. The panels themselves are arranged in a 2x2 grid. A setting in the GUI
+allows switching between this design and the classic layout above.
+
 Discard piles surround the center while each player's opened sets cluster in the
 corners. The central area holds the remaining wall tiles and dora indicator display.
 

--- a/tests/web_gui/test_new_layout.py
+++ b/tests/web_gui/test_new_layout.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_alt_layout_class_in_css() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert '.board-grid-alt' in css
+
+
+def test_game_board_supports_layout_prop() -> None:
+    jsx = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'layout ===' in jsx and 'board-grid-alt' in jsx

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -16,6 +16,7 @@ export default function App() {
   const [events, setEvents] = useState([]);
   const [mode, setMode] = useState('game');
   const [peek, setPeek] = useState(false);
+  const [layout, setLayout] = useState('classic');
   const wsRef = useRef(null);
 
   useEffect(() => {
@@ -205,6 +206,17 @@ export default function App() {
           Peek
         </label>
       </div>
+      <div className="field">
+        <label className="label">
+          Layout:
+          <span className="select ml-2">
+            <select value={layout} onChange={(e) => setLayout(e.target.value)}>
+              <option value="classic">Classic</option>
+              <option value="panels">Player Panels</option>
+            </select>
+          </span>
+        </label>
+      </div>
       <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">
           Players:
@@ -236,7 +248,13 @@ export default function App() {
         </div>
       </div>
       {mode === 'game' ? (
-        <GameBoard state={gameState} server={server} gameId={gameId} peek={peek} />
+        <GameBoard
+          state={gameState}
+          server={server}
+          gameId={gameId}
+          peek={peek}
+          layout={layout}
+        />
       ) : (
         <Practice server={server} />
       )}

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -9,7 +9,13 @@ import { tileToEmoji, tileDescription } from './tileUtils.js';
 function tileLabel(tile) {
   return tileToEmoji(tile);
 }
-export default function GameBoard({ state, server, gameId, peek = false }) {
+export default function GameBoard({
+  state,
+  server,
+  gameId,
+  peek = false,
+  layout = 'classic',
+}) {
   const players = state?.players ?? [];
   const south = players[0];
   const west = players[1];
@@ -69,8 +75,35 @@ export default function GameBoard({ state, server, gameId, peek = false }) {
     }
   }
 
+  const boardClass = layout === 'classic' ? 'board-grid' : 'board-grid-alt';
+
+  if (layout !== 'classic') {
+    const panel = (p, hand, melds, riverTiles, seat, onDiscard) => (
+      <div className={`${seat} seat player-panel`}>
+        <div className="player-header">
+          <span className="riichi-stick">{p?.riichi ? '|' : '\u00a0'}</span>
+          <span>{(p ? p.name : seat) + (p ? ` ${p.score}` : '')}</span>
+        </div>
+        <River tiles={riverTiles} />
+        <div className="hand-with-melds">
+          <Hand tiles={hand} onDiscard={onDiscard} />
+          <MeldArea melds={melds} />
+        </div>
+      </div>
+    );
+
+    return (
+      <div className={boardClass}>
+        {panel(north, northHand, northMelds, (north?.river ?? []).map(tileLabel), 'north')}
+        {panel(east, eastHand, eastMelds, (east?.river ?? []).map(tileLabel), 'east')}
+        {panel(west, westHand, westMelds, (west?.river ?? []).map(tileLabel), 'west')}
+        {panel(south, southHand, southMelds, (south?.river ?? []).map(tileLabel), 'south', discard)}
+      </div>
+    );
+  }
+
   return (
-    <div className="board-grid">
+    <div className={boardClass}>
       <div className="north seat">
         <div>{nameWithRiichi(north) || 'North'}</div>
         <MeldArea melds={northMelds} />

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -14,10 +14,42 @@
   text-align: center;
 }
 
+.board-grid-alt {
+  display: grid;
+  grid-template-areas:
+    'north east'
+    'west south';
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  gap: 0.5rem;
+  text-align: center;
+}
+
 .seat {
   padding: 0.5rem;
   background-color: #f2f2f2;
   border: 1px solid #ccc;
+}
+
+.player-panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.player-header {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.riichi-stick {
+  width: 20px;
+}
+
+.hand-with-melds {
+  display: flex;
+  flex-direction: column;
 }
 
 .north { grid-area: north; }
@@ -131,5 +163,14 @@
       'south';
     grid-template-columns: 1fr;
     grid-template-rows: repeat(5, auto);
+  }
+  .board-grid-alt {
+    grid-template-areas:
+      'north'
+      'east'
+      'west'
+      'south';
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(4, auto);
   }
 }


### PR DESCRIPTION
## Summary
- add optional player panel layout to GameBoard
- allow layout selection in App
- document new board layout option and update feature list
- style adjustments for the new layout
- test for new layout classes

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e0ab51ec832aa621b666dfad029a