### PR TITLE
Centralize event handling in React GUI

### DIFF
--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -23,3 +23,15 @@ tile: {suit: 'pin', value: 1}}};\n"
     )
     output = run_node(code)
     assert output == '1'
+
+
+def test_skip_updates_current_player() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {current_player: 0, players: [{}, {}]};\n"
+        "const evt = {name: 'skip', payload: {player_index: 0}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.current_player);"
+    )
+    output = run_node(code)
+    assert output == '1'

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -143,7 +143,7 @@ def test_controls_include_extra_actions() -> None:
 
 
 def test_app_handles_new_events() -> None:
-    text = Path('web_gui/App.jsx').read_text()
+    text = Path('web_gui/applyEvent.js').read_text()
     for evt in ['meld', 'riichi', 'tsumo', 'ron', 'skip']:
         assert evt in text
 

--- a/tests/web_gui/test_start_kyoku_event.py
+++ b/tests/web_gui/test_start_kyoku_event.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 def test_start_kyoku_event_resets_state() -> None:
-    text = Path('web_gui/App.jsx').read_text()
+    text = Path('web_gui/applyEvent.js').read_text()
     assert "case 'start_kyoku'" in text, 'start_kyoku event not handled'
     idx = text.index("case 'start_kyoku'")
     snippet = text[idx: idx + 120]

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -75,65 +75,6 @@ export default function App() {
     }
   }
 
-  function applyEvent(state, event) {
-    if (!state) return state;
-    const newState = JSON.parse(JSON.stringify(state));
-    switch (event.name) {
-      case 'start_game':
-        return event.payload.state;
-      case 'start_kyoku':
-        return event.payload.state;
-      case 'draw_tile': {
-        const p = newState.players[event.payload.player_index];
-        if (p) p.hand.tiles.push(event.payload.tile);
-        if (newState.wall?.tiles?.length) newState.wall.tiles.pop();
-        break;
-      }
-      case 'discard': {
-        const p = newState.players[event.payload.player_index];
-        if (p) {
-          const { tile } = event.payload;
-          const idx = p.hand.tiles.findIndex(
-            (t) => t.suit === tile.suit && t.value === tile.value,
-          );
-          if (idx !== -1) p.hand.tiles.splice(idx, 1);
-          p.river.push(tile);
-        }
-        break;
-      }
-      case 'meld': {
-        const p = newState.players[event.payload.player_index];
-        if (p) {
-          event.payload.meld.tiles.forEach((m) => {
-            const idx = p.hand.tiles.findIndex(
-              (t) => t.suit === m.suit && t.value === m.value,
-            );
-            if (idx !== -1) p.hand.tiles.splice(idx, 1);
-          });
-          p.hand.melds.push(event.payload.meld);
-        }
-        break;
-      }
-      case 'riichi': {
-        const p = newState.players[event.payload.player_index];
-        if (p) p.riichi = true;
-        break;
-      }
-      case 'tsumo':
-      case 'ron': {
-        newState.result = event.payload;
-        break;
-      }
-      case 'skip': {
-        const next = (event.payload.player_index + 1) % newState.players.length;
-        newState.current_player = next;
-        break;
-      }
-      default:
-        break;
-    }
-    return newState;
-  }
 
   function handleMessage(e) {
     try {

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -4,6 +4,8 @@ export function applyEvent(state, event) {
   switch (event.name) {
     case 'start_game':
       return event.payload.state;
+    case 'start_kyoku':
+      return event.payload.state;
     case 'draw_tile': {
       const p = newState.players[event.payload.player_index];
       if (p) p.hand.tiles.push(event.payload.tile);
@@ -20,6 +22,34 @@ export function applyEvent(state, event) {
         if (idx !== -1) p.hand.tiles.splice(idx, 1);
         p.river.push(tile);
       }
+      break;
+    }
+    case 'meld': {
+      const p = newState.players[event.payload.player_index];
+      if (p) {
+        event.payload.meld.tiles.forEach((m) => {
+          const idx = p.hand.tiles.findIndex(
+            (t) => t.suit === m.suit && t.value === m.value,
+          );
+          if (idx !== -1) p.hand.tiles.splice(idx, 1);
+        });
+        p.hand.melds.push(event.payload.meld);
+      }
+      break;
+    }
+    case 'riichi': {
+      const p = newState.players[event.payload.player_index];
+      if (p) p.riichi = true;
+      break;
+    }
+    case 'tsumo':
+    case 'ron': {
+      newState.result = event.payload;
+      break;
+    }
+    case 'skip': {
+      const next = (event.payload.player_index + 1) % newState.players.length;
+      newState.current_player = next;
       break;
     }
     default:


### PR DESCRIPTION
## Summary
- extend `applyEvent.js` to support all events
- reuse `applyEvent` module in `App.jsx`
- update tests for the unified helper
- add a new test for skip events

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6869e2ecc9c4832a86f001aef5c02489