### PR TITLE
Add complete MJAI adapter and action validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ remain to be built:
 - [ ] Automatic round progression with dealer repeats and hanchan end
   detection.
 - [ ] Exhaustive draw conditions such as four kans and nine terminals.
-- [ ] Complete MJAI protocol adapter for external AIs.
+- [x] Complete MJAI protocol adapter for external AIs.
 - [ ] External AI integration using the adapter.
 
 See `docs/core-tasks.md` for detailed task descriptions.


### PR DESCRIPTION
## Summary
- expand `core/ai_adapter` to decode/encode all MJAI messages
- add `validate_action` helper
- mark MJAI adapter as complete in README
- test new message types and validation errors

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e4833228832a9747d99b67cead94