### PR TITLE
Add center info to player panels and unified controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Center display visible in panel layout
+- [x] Action buttons for each player
 - [x] Meld display from game state
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)

--- a/tests/web_gui/test_player_controls.py
+++ b/tests/web_gui/test_player_controls.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_center_display_in_panel_layout() -> None:
+    text = Path('web_gui/GameBoard.jsx').read_text()
+    assert text.count('CenterDisplay') >= 2
+
+
+def test_controls_accept_player_index() -> None:
+    text = Path('web_gui/Controls.jsx').read_text()
+    assert 'playerIndex' in text
+    assert 'player_index: playerIndex' in text
+
+
+def test_game_board_has_controls_for_all_players() -> None:
+    text = Path('web_gui/GameBoard.jsx').read_text()
+    assert text.count('<Controls') >= 4

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Button from './Button.jsx';
 
-export default function Controls({ server, gameId }) {
+export default function Controls({ server, gameId, playerIndex = 0 }) {
   const [message, setMessage] = useState('');
 
 
@@ -10,7 +10,7 @@ export default function Controls({ server, gameId }) {
       await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ player_index: 0, action, ...payload }),
+        body: JSON.stringify({ player_index: playerIndex, action, ...payload }),
       });
       setMessage(action);
     } catch {

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -78,7 +78,7 @@ export default function GameBoard({
   const boardClass = layout === 'classic' ? 'board-grid' : 'board-grid-alt';
 
   if (layout !== 'classic') {
-    const panel = (p, hand, melds, riverTiles, seat, onDiscard) => (
+    const panel = (p, hand, melds, riverTiles, seat, onDiscard, idx) => (
       <div className={`${seat} seat player-panel`}>
         <div className="player-header">
           <span className="riichi-stick">{p?.riichi ? '|' : '\u00a0'}</span>
@@ -89,16 +89,20 @@ export default function GameBoard({
           <Hand tiles={hand} onDiscard={onDiscard} />
           <MeldArea melds={melds} />
         </div>
+        <Controls server={server} gameId={gameId} playerIndex={idx} />
       </div>
     );
 
     return (
-      <div className={boardClass}>
-        {panel(north, northHand, northMelds, (north?.river ?? []).map(tileLabel), 'north')}
-        {panel(east, eastHand, eastMelds, (east?.river ?? []).map(tileLabel), 'east')}
-        {panel(west, westHand, westMelds, (west?.river ?? []).map(tileLabel), 'west')}
-        {panel(south, southHand, southMelds, (south?.river ?? []).map(tileLabel), 'south', discard)}
-      </div>
+      <>
+        <div className={boardClass}>
+          {panel(north, northHand, northMelds, (north?.river ?? []).map(tileLabel), 'north', undefined, 2)}
+          {panel(east, eastHand, eastMelds, (east?.river ?? []).map(tileLabel), 'east', undefined, 3)}
+          {panel(west, westHand, westMelds, (west?.river ?? []).map(tileLabel), 'west', undefined, 1)}
+          {panel(south, southHand, southMelds, (south?.river ?? []).map(tileLabel), 'south', discard, 0)}
+        </div>
+        <CenterDisplay remaining={remaining} dora={dora} />
+      </>
     );
   }
 
@@ -109,6 +113,7 @@ export default function GameBoard({
         <MeldArea melds={northMelds} />
         <River tiles={(north?.river ?? []).map(tileLabel)} />
         <Hand tiles={northHand} />
+        <Controls server={server} gameId={gameId} playerIndex={2} />
       </div>
 
       <div className="west seat">
@@ -116,6 +121,7 @@ export default function GameBoard({
         <MeldArea melds={westMelds} />
         <River tiles={(west?.river ?? []).map(tileLabel)} />
         <Hand tiles={westHand} />
+        <Controls server={server} gameId={gameId} playerIndex={1} />
       </div>
 
       <div className="center">
@@ -127,6 +133,7 @@ export default function GameBoard({
         <MeldArea melds={eastMelds} />
         <River tiles={(east?.river ?? []).map(tileLabel)} />
         <Hand tiles={eastHand} />
+        <Controls server={server} gameId={gameId} playerIndex={3} />
       </div>
 
       <div className="south seat">
@@ -134,7 +141,7 @@ export default function GameBoard({
         <MeldArea melds={southMelds} />
         <River tiles={(south?.river ?? []).map(tileLabel)} />
         <Hand tiles={southHand} onDiscard={discard} />
-        <Controls server={server} gameId={gameId} />
+        <Controls server={server} gameId={gameId} playerIndex={0} />
         <MeldArea melds={southMelds} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show center display for remaining tiles and dora in panel layout
- provide action controls for every player
- share Controls component using `playerIndex` prop
- document new GUI features
- test Controls updates and panel info

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e5acee44832a97e3c0032ff54d07