### PR TITLE
Swap east and west positions

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -23,11 +23,11 @@ Each seat has one meld zone. The North player's hand is drawn just above the riv
 ```
   🀫x13 (North Hand)
   +---------------+----------------------+---------------+
-  | North Fuuro   | North River          | East Fuuro    |
+  | North Fuuro   | North River          | West Fuuro    |
   +---------------+----------------------+---------------+
-  | West River    | Wall / Dora / Round  | East River    |
+  | East River    | Wall / Dora / Round  | West River    |
   +---------------+----------------------+---------------+
-  | West Fuuro    | South River          | South Fuuro   |
+  | East Fuuro    | South River          | South Fuuro   |
   +---------------+----------------------+---------------+
 ```
 

--- a/tests/web_gui/test_orientation.py
+++ b/tests/web_gui/test_orientation.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 def test_grid_orientation() -> None:
     css = Path('web_gui/style.css').read_text()
-    assert 'north center east' in css
-    assert 'west center south' in css
+    assert 'north center west' in css
+    assert 'east center south' in css
 
 
 def test_dom_order() -> None:
@@ -15,4 +15,4 @@ def test_dom_order() -> None:
     west_idx = jsx.find('seat="west"')
     south_idx = jsx.find('seat="south"')
     assert -1 not in (north_idx, east_idx, center_idx, west_idx, south_idx)
-    assert north_idx < east_idx < center_idx < west_idx < south_idx
+    assert north_idx < west_idx < center_idx < east_idx < south_idx

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -85,19 +85,6 @@ export default function GameBoard({
         playerIndex={2}
       />
       <PlayerPanel
-        seat="east"
-        player={east}
-        hand={eastHand}
-        melds={eastMelds}
-        riverTiles={(east?.river ?? []).map(tileLabel)}
-        server={server}
-        gameId={gameId}
-        playerIndex={3}
-      />
-      <div className="center">
-        <CenterDisplay remaining={remaining} dora={dora} />
-      </div>
-      <PlayerPanel
         seat="west"
         player={west}
         hand={westHand}
@@ -106,6 +93,19 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={1}
+      />
+      <div className="center">
+        <CenterDisplay remaining={remaining} dora={dora} />
+      </div>
+      <PlayerPanel
+        seat="east"
+        player={east}
+        hand={eastHand}
+        melds={eastMelds}
+        riverTiles={(east?.river ?? []).map(tileLabel)}
+        server={server}
+        gameId={gameId}
+        playerIndex={3}
       />
       <PlayerPanel
         seat="south"

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -5,8 +5,8 @@
 .board-grid {
   display: grid;
   grid-template-areas:
-    'north center east'
-    'west center south';
+    'north center west'
+    'east center south';
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: auto auto;
   gap: 0.5rem;
@@ -145,9 +145,9 @@
   .board-grid {
     grid-template-areas:
       'north'
-      'east'
-      'center'
       'west'
+      'center'
+      'east'
       'south';
     grid-template-columns: 1fr;
     grid-template-rows: repeat(5, auto);


### PR DESCRIPTION
## Summary
- adjust CSS grid to flip east/west spots
- swap east and west PlayerPanel order
- update orientation tests
- update board layout docs

## Testing
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869ee11ea5c832abb1684e4a4acb5e5