### PR TITLE
Remove outdated board layout example

### DIFF
--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -15,22 +15,6 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
   `.seat-east` rotates 90deg, `.seat-north` 180deg and `.seat-west` -90deg.
 - Melds are drawn in dedicated areas separate from discard piles so rivers remain intact.
 
-### Layout Example
-
-The following ASCII diagram shows where each discard pile (河) and meld area (鳴) is placed.
-Each seat has one meld zone. The North player's hand is drawn just above the river for clarity as `🀫x13`. Other opponents keep their hands outside their rivers though they are omitted from this diagram.
-
-```
-  🀫x13 (North Hand)
-  +---------------+----------------------+---------------+
-  | North Fuuro   | North River          | West Fuuro    |
-  +---------------+----------------------+---------------+
-  | East River    | Wall / Dora / Round  | West River    |
-  +---------------+----------------------+---------------+
-  | East Fuuro    | South River          | South Fuuro   |
-  +---------------+----------------------+---------------+
-```
-
 ### Player Panel Layout
 
 An alternative layout treats each player area as a self-contained panel:


### PR DESCRIPTION
## Summary
- remove an obsolete `Layout Example` diagram from `docs/board-layout.md`

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ef7ba9e4832a87c3eda79766cb0b