### PR TITLE
Move dora display

### DIFF
--- a/tests/web_gui/test_orientation.py
+++ b/tests/web_gui/test_orientation.py
@@ -3,16 +3,16 @@ from pathlib import Path
 
 def test_grid_orientation() -> None:
     css = Path('web_gui/style.css').read_text()
-    assert 'north center west' in css
-    assert 'east center south' in css
+    assert "'north west'" in css or 'north west' in css
+    assert "'east south'" in css or 'east south' in css
 
 
 def test_dom_order() -> None:
     jsx = Path('web_gui/GameBoard.jsx').read_text()
     north_idx = jsx.find('seat="north"')
     east_idx = jsx.find('seat="east"')
-    center_idx = jsx.find('className="center"')
     west_idx = jsx.find('seat="west"')
     south_idx = jsx.find('seat="south"')
-    assert -1 not in (north_idx, east_idx, center_idx, west_idx, south_idx)
-    assert north_idx < west_idx < center_idx < east_idx < south_idx
+    center_idx = jsx.find('CenterDisplay')
+    assert -1 not in (north_idx, east_idx, west_idx, south_idx, center_idx)
+    assert center_idx < north_idx < west_idx < east_idx < south_idx

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -73,7 +73,9 @@ export default function GameBoard({
   const boardClass = 'board-grid';
 
   return (
-    <div className={boardClass}>
+    <>
+      <CenterDisplay remaining={remaining} dora={dora} />
+      <div className={boardClass}>
       <PlayerPanel
         seat="north"
         player={north}
@@ -94,9 +96,6 @@ export default function GameBoard({
         gameId={gameId}
         playerIndex={1}
       />
-      <div className="center">
-        <CenterDisplay remaining={remaining} dora={dora} />
-      </div>
       <PlayerPanel
         seat="east"
         player={east}
@@ -119,5 +118,6 @@ export default function GameBoard({
         playerIndex={0}
       />
     </div>
+    </>
   );
 }

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -5,9 +5,9 @@
 .board-grid {
   display: grid;
   grid-template-areas:
-    'north center west'
-    'east center south';
-  grid-template-columns: 1fr 1fr 1fr;
+    'north west'
+    'east south';
+  grid-template-columns: 1fr 1fr;
   grid-template-rows: auto auto;
   gap: 0.5rem;
   text-align: center;
@@ -42,7 +42,6 @@
 
 .north { grid-area: north; }
 .west { grid-area: west; }
-.center { grid-area: center; }
 .center-display {
   display: flex;
   flex-direction: column;
@@ -146,10 +145,9 @@
     grid-template-areas:
       'north'
       'west'
-      'center'
       'east'
       'south';
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(5, auto);
+    grid-template-rows: repeat(4, auto);
   }
 }


### PR DESCRIPTION
## Summary
- reposition dora indicator above the board grid
- clean up CSS grid layout
- adjust orientation tests for new DOM order

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869efc3d410832ab67688a543c4d54c