### PR TITLE
Display melds to the right of the hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Future work will expand these components.
 - [x] Meld area component
 - [x] Center display (dora & wall count)
 - [x] Meld display from game state
+- [x] Melds positioned to the right of the player's hand
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option

--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -8,7 +8,9 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
 - Tiles within each hand are laid out horizontally, matching a traditional table view.
 - Each player's discard pile (河) sits directly in front of their hand. For the bottom player this means discards appear above the hand.
 - Discards are grouped into rows of six to form a compact river. The `DiscardPile` component adds orientation classes so each seat's river aligns toward the center of the table.
-- Melded tiles (calls such as chi or pon) are displayed at the four corners of the table so discard piles remain clearly separated.
+- Melded tiles (chi, pon and kan) are shown to the right of each player's hand.
+  This follows the common convention where opened sets sit beside the hand.
+  Discard piles remain directly in front of the players.
 - Opponents occupy the top, left and right edges, surrounding a central area used for wall tiles or indicators.
 - Each opponent's concealed hand is drawn just outside their discard pile so the river remains visible.
 - Each seat's discard pile and meld area is rotated with CSS so tiles face the center.

--- a/tests/web_gui/test_meld_position.py
+++ b/tests/web_gui/test_meld_position.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_hand_with_melds_row() -> None:
+    css = Path('web_gui/style.css').read_text()
+    start = css.index('.hand-with-melds')
+    block = css[start:css.index('}', start)]
+    assert 'flex-direction: row' in block
+    jsx = Path('web_gui/PlayerPanel.jsx').read_text()
+    hand_idx = jsx.find('<Hand')
+    meld_idx = jsx.find('<MeldArea')
+    assert hand_idx != -1 and meld_idx != -1
+    assert hand_idx < meld_idx

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -37,7 +37,8 @@
 
 .hand-with-melds {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
 }
 
 .north { grid-area: north; }


### PR DESCRIPTION
## Summary
- align meld area beside the hand
- document meld positioning in board layout
- add test for meld placement

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6869f4490eb4832aba1db682a8adcc34