### PR TITLE
Relax flake8 rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
-max-line-length = 88
-extend-ignore = E203
+# Extremely permissive rules to avoid hindering development
+# Only check for serious syntax issues and undefined names
+max-line-length = 120
+select = E9,F63,F7,F82
 exclude = .venv
-per-file-ignores =
-    tests/*:F401

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ uv pip install -e ./core -e ./cli -e ./web
 uv pip install flake8 mypy pytest build
 python -m build core
 python -m build cli
-flake8
+flake8  # uses a very lenient rule set (E9,F63,F7,F82 only)
 mypy core web cli
 pytest -q
 ```
@@ -243,3 +243,5 @@ served from this subpath.
 GitHub Actions run linting, type checking, build and tests for every pull request
 using **uv** to install dependencies. Once these checks succeed, the workflow
 automatically approves and merges the PR.
+The flake8 step runs with only the `E9`, `F63`, `F7` and `F82` checks enabled to
+avoid excessive style warnings.


### PR DESCRIPTION
## Summary
- loosen flake8 configuration to only check severe issues
- document lenient flake8 rules in the build instructions and CI description

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6869f3e610d8832abd975c97b6f64c9e