### PR TITLE
Implement four kans exhaustive draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ remain to be built:
 - [x] Tracking honba and riichi sticks in `GameState`.
 - [x] Automatic round progression with dealer repeats and hanchan end
   detection.
-- [ ] Exhaustive draw conditions such as four kans and nine terminals.
+- [x] Exhaustive draw condition: four kans (nine terminals pending).
 - [ ] Complete MJAI protocol adapter for external AIs.
 - [ ] External AI integration using the adapter.
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -59,6 +59,7 @@ class MahjongEngine:
             p.riichi = False
         self.state.last_discard = None
         self.state.last_discard_player = None
+        self.state.kan_count = 0
         winds = ["east", "south", "west", "north"]
         self.state.seat_winds = []
         for i, p in enumerate(self.state.players):
@@ -271,6 +272,10 @@ class MahjongEngine:
             self.state.last_discard_player = None
             self._draw_replacement_tile(player)
             self._emit("meld", {"player_index": player_index, "meld": meld})
+            self.state.kan_count += 1
+            if self.state.kan_count >= 4:
+                self._emit("ryukyoku", {"reason": "four_kans"})
+                self.advance_hand(None)
             return
 
         # Added kan upgrade from an existing pon
@@ -292,6 +297,10 @@ class MahjongEngine:
                 meld.type = "added_kan"
                 self._draw_replacement_tile(player)
                 self._emit("meld", {"player_index": player_index, "meld": meld})
+                self.state.kan_count += 1
+                if self.state.kan_count >= 4:
+                    self._emit("ryukyoku", {"reason": "four_kans"})
+                    self.advance_hand(None)
                 return
 
         # Closed kan from hand
@@ -311,6 +320,10 @@ class MahjongEngine:
         player.hand.melds.append(meld)
         self._draw_replacement_tile(player)
         self._emit("meld", {"player_index": player_index, "meld": meld})
+        self.state.kan_count += 1
+        if self.state.kan_count >= 4:
+            self._emit("ryukyoku", {"reason": "four_kans"})
+            self.advance_hand(None)
 
     def declare_tsumo(self, player_index: int, win_tile: Tile) -> HandResponse:
         """Declare a self-drawn win and return scoring info."""
@@ -394,6 +407,7 @@ class MahjongEngine:
         self.state.current_player = 0
         self.state.honba = 0
         self.state.riichi_sticks = 0
+        self.state.kan_count = 0
         self.state.seat_winds = []
         self.state.last_discard = None
         self.state.last_discard_player = None

--- a/core/models.py
+++ b/core/models.py
@@ -43,6 +43,7 @@ class GameState:
     round_number: int = 1
     honba: int = 0
     riichi_sticks: int = 0
+    kan_count: int = 0
     seat_winds: list[str] = field(default_factory=list)
     last_discard: Tile | None = None
     last_discard_player: int | None = None

--- a/tests/core/test_exhaustive_draw.py
+++ b/tests/core/test_exhaustive_draw.py
@@ -1,0 +1,16 @@
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile
+
+
+def test_four_kans_triggers_ryukyoku() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    engine.state.kan_count = 3
+    tiles = [Tile("man", 1) for _ in range(4)]
+    engine.state.players[0].hand.tiles = tiles.copy()
+    engine.call_kan(0, tiles)
+    names = [e.name for e in engine.pop_events()]
+    assert "ryukyoku" in names
+    assert engine.state.honba == 1
+    assert engine.state.kan_count == 0
+


### PR DESCRIPTION
## Summary
- detect four kans exhaustive draw in MahjongEngine
- reset kan count between hands
- expose `kan_count` in GameState
- test four kans draw logic
- document new feature in README

## Testing
- `flake8`
- `mypy core web cli`
- `python -m build core`
- `python -m build cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6869f0cd7b14832aba4214f00098605f