### PR TITLE
Add shanten quiz CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Future work will expand these components.
   - [x] CLI practice command
   - [x] AI recommendation
   - [x] Web UI support
+ - [x] シャンテン数クイズ
+   - [x] CLI quiz command
 
 ### Core engine capabilities
 
@@ -181,6 +183,19 @@ Two API endpoints are provided:
 
 - `GET /practice` returns a new problem.
 - `POST /practice/suggest` returns the AI's suggested discard.
+
+## Shanten quiz
+
+This quiz shows a random hand and asks for the shanten number.
+Run it with:
+
+```bash
+python -m cli.main shanten-quiz
+```
+
+1. Generate a 13-tile starting hand.
+2. Display the tiles in short form.
+3. Prompt for the shanten number and reveal the answer.
 
 ## Running locally
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2,7 +2,7 @@ import click
 
 from . import remote_game
 from .local_game import run_game
-from core import practice, models
+from core import practice, models, shanten_quiz
 
 
 @click.group()
@@ -111,6 +111,25 @@ def practice_cmd(ai: bool) -> None:
     click.echo(f"You discarded {fmt(chosen)}")
     ai_suggestion = practice.suggest_discard(problem.hand, use_ai=ai)
     click.echo(f"AI suggests discarding {fmt(ai_suggestion)}")
+
+
+@cli.command(name="shanten-quiz")
+def shanten_quiz_cmd() -> None:
+    """Run a simple shanten number quiz."""
+
+    hand = shanten_quiz.generate_hand()
+
+    def fmt(tile: models.Tile) -> str:
+        return f"{tile.suit[0]}{tile.value}"
+
+    hand_str = " ".join(fmt(t) for t in hand)
+    click.echo(f"Hand: {hand_str}")
+    guess = click.prompt("Shanten number?", type=int)
+    actual = shanten_quiz.calculate_shanten(hand)
+    if guess == actual:
+        click.echo("Correct!")
+    else:
+        click.echo(f"Incorrect. Shanten is {actual}")
 
 
 if __name__ == "__main__":

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -13,4 +13,5 @@ __all__ = [
     "tenhou_log",
     "models",
     "rules",
+    "shanten_quiz",
 ]

--- a/core/shanten_quiz.py
+++ b/core/shanten_quiz.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Helpers for a simple shanten count quiz."""
+
+from mahjong.shanten import Shanten
+
+from .mahjong_engine import MahjongEngine
+from .models import Tile
+from .rules import _tile_to_index
+
+
+def generate_hand() -> list[Tile]:
+    """Return a random 13-tile hand for the quiz."""
+    engine = MahjongEngine()
+    engine.pop_events()  # discard start event
+    hand = engine.state.players[0].hand.tiles.copy()
+    if len(hand) > 13:
+        hand = hand[:-1]
+    return hand
+
+
+def _hand_counts(hand: list[Tile]) -> list[int]:
+    counts = [0] * 34
+    for tile in hand:
+        counts[_tile_to_index(tile)] += 1
+    return counts
+
+
+def calculate_shanten(hand: list[Tile]) -> int:
+    """Return the shanten number for ``hand``."""
+    counts = _hand_counts(hand)
+    return Shanten().calculate_shanten(counts)

--- a/tests/cli/test_shanten_quiz_command.py
+++ b/tests/cli/test_shanten_quiz_command.py
@@ -1,0 +1,15 @@
+from click.testing import CliRunner
+
+from cli.main import cli
+from core import shanten_quiz, models
+
+
+def test_shanten_quiz_command(monkeypatch):
+    hand = [models.Tile("man", 1) for _ in range(13)]
+    monkeypatch.setattr(shanten_quiz, "generate_hand", lambda: hand)
+    monkeypatch.setattr(shanten_quiz, "calculate_shanten", lambda h: 1)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shanten-quiz"], input="1\n")
+    assert result.exit_code == 0
+    assert "Hand:" in result.output
+    assert "Correct!" in result.output

--- a/tests/core/test_shanten_quiz.py
+++ b/tests/core/test_shanten_quiz.py
@@ -1,0 +1,37 @@
+from core import shanten_quiz, models
+
+
+def test_generate_hand(monkeypatch):
+    class DummyPlayer:
+        def __init__(self) -> None:
+            self.hand = models.Hand(tiles=[models.Tile("man", 1) for _ in range(14)])
+
+    class DummyState:
+        def __init__(self) -> None:
+            self.players = [DummyPlayer()]
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.state = DummyState()
+
+        def pop_events(self) -> None:
+            pass
+
+    monkeypatch.setattr(shanten_quiz, "MahjongEngine", DummyEngine)
+    hand = shanten_quiz.generate_hand()
+    assert len(hand) == 13
+
+
+def test_calculate_shanten(monkeypatch):
+    called = {}
+
+    class DummyShanten:
+        def calculate_shanten(self, counts: list[int]) -> int:
+            called["counts"] = counts
+            return 2
+
+    monkeypatch.setattr(shanten_quiz, "Shanten", DummyShanten)
+    hand = [models.Tile("man", 1) for _ in range(13)]
+    value = shanten_quiz.calculate_shanten(hand)
+    assert value == 2
+    assert called["counts"][0] == 13


### PR DESCRIPTION
## Summary
- add a small `shanten_quiz` helper module in `core`
- expose a new `shanten-quiz` command in the CLI
- document the new feature and how to run it in the README
- cover the quiz helper and command with unit tests

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6869f98a398c832a96bdc62c91a91063