### PR TITLE
Add simple AI for automated turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Future work will expand these components.
 - [x] Discard tiles via GUI
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
+- [x] Simple tsumogiri AI for automated turns
 - [x] Handle start_kyoku event in GUI
 - [x] Join game by ID via GUI
 - [x] Reconnect to running game after reload
@@ -125,8 +126,9 @@ Future work will expand these components.
   the GUI updates instantly.
  - [x] **10. Connect GUI state** – update React components to fetch the initial game,
   handle WebSocket events and send player actions.
-- [ ] **11. Provide a mock AI** – run a simple MJAI-compatible process through the
-  adapter with an interface that later swaps in a stronger engine.
+ - [ ] **11. Provide a mock AI** – run a simple MJAI-compatible process through the
+  adapter with an interface that later swaps in a stronger engine. A minimal
+  tsumogiri AI exists for local automation.
 - [ ] **12. Write end-to-end tests** – cover REST routes, WebSocket updates and basic
   GUI interactions.
  - [x] **13. Add `何切る問題` mode** – offer a practice scenario with a random seat wind

--- a/cli/local_game.py
+++ b/cli/local_game.py
@@ -11,7 +11,6 @@ def run_game(players: list[str]) -> None:
     state = api.start_game(players)
     players_display = ', '.join(p.name for p in state.players)
     click.echo(f"Game started with players: {players_display}")
-    turn = 0
     start_round = state.round_number
     start_honba = state.honba
     while (
@@ -20,15 +19,9 @@ def run_game(players: list[str]) -> None:
         and state.round_number == start_round
         and state.honba == start_honba
     ):
-        tile = api.draw_tile(turn)
-        name = state.players[turn].name
-        click.echo(f"{name} drew {tile.suit}{tile.value}")
-        try:
-            api.discard_tile(turn, tile)
-        except ValueError:
-            # Tile may have already been removed; end the loop gracefully
-            break
-        click.echo(f"{name} discarded {tile.suit}{tile.value}")
-        turn = (turn + 1) % len(state.players)
+        player_index = state.current_player
+        name = state.players[player_index].name
+        tile = api.auto_play_turn()
+        click.echo(f"{name} drew {tile.suit}{tile.value} and discarded it")
     api.end_game()
     click.echo("Game ended")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "wall",
     "ai_adapter",
     "ai_runner",
+    "simple_ai",
     "api",
     "tenhou_log",
     "models",

--- a/core/api.py
+++ b/core/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile, GameEvent, GameAction
+from .simple_ai import tsumogiri_turn
 from . import practice
 from mahjong.hand_calculating.hand_response import HandResponse
 
@@ -85,6 +86,13 @@ def skip(player_index: int) -> None:
     """Skip action for the player."""
     assert _engine is not None, "Game not started"
     _engine.skip(player_index)
+
+
+def auto_play_turn(player_index: int | None = None) -> Tile:
+    """Have a simple AI draw and discard for ``player_index``."""
+    assert _engine is not None, "Game not started"
+    idx = player_index if player_index is not None else _engine.state.current_player
+    return tsumogiri_turn(_engine, idx)
 
 
 def advance_hand(winner_index: int | None = None) -> GameState:

--- a/core/simple_ai.py
+++ b/core/simple_ai.py
@@ -1,0 +1,14 @@
+"""Very basic AI helpers."""
+from __future__ import annotations
+
+from .mahjong_engine import MahjongEngine
+from .models import Tile
+
+
+def tsumogiri_turn(engine: MahjongEngine, player_index: int) -> Tile:
+    """Draw and immediately discard a tile for ``player_index``."""
+    tile = engine.draw_tile(player_index)
+    hand = engine.state.players[player_index].hand.tiles
+    if tile in hand:
+        engine.discard_tile(player_index, tile)
+    return tile

--- a/tests/core/test_simple_ai.py
+++ b/tests/core/test_simple_ai.py
@@ -1,0 +1,16 @@
+from core import api, models
+
+
+def test_auto_play_turn_discards_drawn_tile() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    assert state.wall is not None
+    tile = models.Tile(suit="man", value=9)
+    state.wall.tiles.append(tile)
+    player = state.current_player
+    hand_len = len(state.players[player].hand.tiles)
+    discarded = api.auto_play_turn()
+    assert discarded == tile
+    assert state.players[player].river[-1] == tile
+    assert len(state.players[player].hand.tiles) == hand_len
+    assert state.current_player == (player + 1) % 4
+


### PR DESCRIPTION
## Summary
- implement `simple_ai.tsumogiri_turn` and expose via `api.auto_play_turn`
- use this helper in `cli.local_game.run_game`
- document the AI in the feature list
- test the new API

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6869fa07148c832a9f198aa54bda10b6