### PR TITLE
Highlight current player

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Future work will expand these components.
 - [x] Stylish form inputs with Bulma CSS
 - [x] Responsive layout for narrow screens
 - [x] Icon buttons using react-icons
+- [x] Highlight active player on board
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/tests/web_gui/test_active_player.py
+++ b/tests/web_gui/test_active_player.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+def test_active_player_css() -> None:
+    css = Path('web_gui/style.css').read_text()
+    block_start = css.index('.active-player')
+    block = css[block_start:css.index('}', block_start)]
+    assert 'font-weight: bold' in block
+
+
+def test_game_board_passes_prop() -> None:
+    jsx = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'activePlayer={state?.current_player}' in jsx
+
+
+def test_player_panel_accepts_prop() -> None:
+    jsx = Path('web_gui/PlayerPanel.jsx').read_text()
+    assert 'activePlayer' in jsx
+    assert 'active-player' in jsx

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -85,6 +85,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={2}
+        activePlayer={state?.current_player}
       />
       <PlayerPanel
         seat="west"
@@ -95,6 +96,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={1}
+        activePlayer={state?.current_player}
       />
       <PlayerPanel
         seat="east"
@@ -105,6 +107,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={3}
+        activePlayer={state?.current_player}
       />
       <PlayerPanel
         seat="south"
@@ -116,6 +119,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={0}
+        activePlayer={state?.current_player}
       />
     </div>
     </>

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -14,12 +14,14 @@ export default function PlayerPanel({
   server,
   gameId,
   playerIndex,
+  activePlayer,
 }) {
+  const active = playerIndex === activePlayer;
   return (
-    <div className={`${seat} seat player-panel`}>
+    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}> 
       <div className="player-header">
         <span className="riichi-stick">{player?.riichi ? '|' : '\u00a0'}</span>
-        <span>{(player ? player.name : seat) + (player ? ` ${player.score}` : '')}</span>
+        <span className="player-name">{(player ? player.name : seat) + (player ? ` ${player.score}` : '')}</span>
       </div>
       <River tiles={riverTiles} />
       <div className="hand-with-melds">

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -141,6 +141,11 @@
   background-color: #004a99;
 }
 
+.active-player .player-header {
+  font-weight: bold;
+  background-color: #fff4ce;
+}
+
 @media (max-width: 600px) {
   .board-grid {
     grid-template-areas:


### PR DESCRIPTION
## Summary
- highlight active player with a new style in PlayerPanel
- wire up PlayerPanel to receive active player index from GameBoard
- expose new CSS rule and tests for highlighting
- document the feature in the README

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `.venv/bin/python -m build core`
- `.venv/bin/python -m build cli`
- `.venv/bin/flake8`
- `.venv/bin/mypy core web cli`
- `.venv/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`
- `git fetch origin main` *(fails: `/tmp/null` does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_6869fdc060e8832a89f316a8659faa62