### PR TITLE
Add honba and riichi display

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Future work will expand these components.
 - [x] Hand & River components
 - [x] Meld area component
 - [x] Center display (dora & wall count)
+- [x] Display honba & riichi stick counts
 - [x] Meld display from game state
 - [x] Melds positioned to the right of the player's hand
 - [x] Tile image rendering in GUI with alt text

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -331,11 +331,12 @@ class MahjongEngine:
         player = self.state.players[player_index]
         if result.cost and "total" in result.cost:
             total = int(result.cost["total"])
-            player.score += total
+            honba_bonus = self.state.honba * 100
+            player.score += total + honba_bonus * (len(self.state.players) - 1)
             share = total // (len(self.state.players) - 1)
             for i, p in enumerate(self.state.players):
                 if i != player_index:
-                    p.score -= share
+                    p.score -= share + honba_bonus
             player.score += self.state.riichi_sticks * 1000
             self.state.riichi_sticks = 0
         scores = [p.score for p in self.state.players]
@@ -356,10 +357,11 @@ class MahjongEngine:
         player = self.state.players[player_index]
         if result.cost and "total" in result.cost:
             total = int(result.cost["total"])
-            player.score += total
+            honba_bonus = self.state.honba * 300
+            player.score += total + honba_bonus
             discarder = self.state.last_discard_player
             if discarder is not None and discarder != player_index:
-                self.state.players[discarder].score -= total
+                self.state.players[discarder].score -= total + honba_bonus
             player.score += self.state.riichi_sticks * 1000
             self.state.riichi_sticks = 0
         scores = [p.score for p in self.state.players]

--- a/tests/core/test_honba_scoring.py
+++ b/tests/core/test_honba_scoring.py
@@ -1,0 +1,35 @@
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile
+from core.rules import RuleSet
+from mahjong.hand_calculating.hand_response import HandResponse
+
+
+class ScoringRuleSet(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=1, cost={"total": 8000})
+
+
+def test_tsumo_honba_bonus() -> None:
+    engine = MahjongEngine(ruleset=ScoringRuleSet())
+    engine.pop_events()
+    engine.state.honba = 2
+    tile = Tile("man", 1)
+    engine.state.players[0].hand.tiles.append(tile)
+    start_scores = [p.score for p in engine.state.players]
+    engine.declare_tsumo(0, tile)
+    assert engine.state.players[0].score == start_scores[0] + 8000 + 600
+    assert engine.state.players[1].score == start_scores[1] - 2866
+
+
+def test_ron_honba_bonus() -> None:
+    engine = MahjongEngine(ruleset=ScoringRuleSet())
+    engine.pop_events()
+    engine.state.honba = 1
+    tile = Tile("man", 2)
+    engine.state.players[1].hand.tiles.append(tile)
+    engine.discard_tile(1, tile)
+    engine.state.players[0].hand.tiles.append(Tile("man", 2))
+    start_scores = [p.score for p in engine.state.players]
+    engine.declare_ron(0, Tile("man", 2))
+    assert engine.state.players[0].score == start_scores[0] + 8000 + 300
+    assert engine.state.players[1].score == start_scores[1] - (8000 + 300)

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
 
-export default function CenterDisplay({ remaining = 0, dora = [] }) {
+export default function CenterDisplay({
+  remaining = 0,
+  dora = [],
+  honba = 0,
+  riichiSticks = 0,
+}) {
   return (
     <div className="center-display">
       <div className="remaining">Remaining: {remaining}</div>
       <div className="dora">Dora: {dora.join(' ')}</div>
+      <div className="counts">
+        Honba: {honba} | Riichi: {riichiSticks}
+      </div>
     </div>
   );
 }

--- a/web_gui/CenterDisplay.test.jsx
+++ b/web_gui/CenterDisplay.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CenterDisplay from './CenterDisplay.jsx';
+
+describe('CenterDisplay', () => {
+  it('shows honba and riichi stick counts', () => {
+    render(<CenterDisplay remaining={10} dora={[]} honba={3} riichiSticks={2} />);
+    expect(screen.getByText('Remaining: 10')).toBeTruthy();
+    expect(screen.getByText(/Honba: 3/)).toBeTruthy();
+    expect(screen.getByText(/Riichi: 2/)).toBeTruthy();
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -74,7 +74,12 @@ export default function GameBoard({
 
   return (
     <>
-      <CenterDisplay remaining={remaining} dora={dora} />
+      <CenterDisplay
+        remaining={remaining}
+        dora={dora}
+        honba={state?.honba ?? 0}
+        riichiSticks={state?.riichi_sticks ?? 0}
+      />
       <div className={boardClass}>
       <PlayerPanel
         seat="north"

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -49,6 +49,9 @@
   align-items: center;
   gap: 0.25rem;
 }
+.center-display .counts {
+  font-size: 0.9rem;
+}
 .east { grid-area: east; }
 .south { grid-area: south; }
 


### PR DESCRIPTION
## Summary
- show honba and riichi stick counts on the board
- apply honba bonus points on tsumo/ron
- test honba scoring and new center display

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a03c08438832aad25b26f2fce6897