### PR TITLE
Implement discard UI with river grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Future work will expand these components.
 - [x] Responsive layout for narrow screens
 - [x] Icon buttons using react-icons
 - [x] Highlight active player on board
+- [x] 6x4 discard grid rendering
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -131,7 +131,7 @@ def test_game_board_passes_remaining_prop() -> None:
 
 def test_south_hand_displays_images() -> None:
     board = Path('web_gui/GameBoard.jsx').read_text()
-    assert 'south?.hand?.tiles.map(tileLabel)' in board
+    assert 'south?.hand?.tiles' in board
 
 
 def test_app_updates_wall_on_draw() -> None:

--- a/web_gui/GameBoard.discard.test.jsx
+++ b/web_gui/GameBoard.discard.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+import { tileDescription } from './tileUtils.js';
+
+function mockPlayers() {
+  return new Array(4).fill(0).map(() => ({
+    hand: { tiles: [{ suit: 'man', value: 1 }], melds: [] },
+    river: [],
+  }));
+}
+
+describe('GameBoard discard', () => {
+  it('sends discard when clicking tile on turn', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = fetchMock;
+    const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
+    render(<GameBoard state={state} server="http://s" gameId="1" />);
+    const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;
+    const btn = screen.getByRole('button', { name: label });
+    await userEvent.click(btn);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ player_index: 0, action: 'discard', tile: { suit: 'man', value: 1 } });
+  });
+
+  it('ignores click when not your turn', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = fetchMock;
+    const state = { current_player: 1, players: mockPlayers(), wall: { tiles: [] } };
+    const { container } = render(<GameBoard state={state} server="http://s" gameId="1" />);
+    const btn = container.querySelector('.south .hand button');
+    expect(btn).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -47,7 +47,7 @@ export default function GameBoard({
     peek ? west?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(west);
   const eastHand =
     peek ? east?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(east);
-  const southHand = south?.hand?.tiles.map(tileLabel) ?? defaultHand;
+  const southHand = south?.hand?.tiles ?? defaultHand;
 
   const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
   const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
@@ -60,6 +60,7 @@ export default function GameBoard({
   async function discard(tile) {
     try {
       if (!gameId) return;
+      if (typeof tile === 'string') return;
       await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -115,7 +116,7 @@ export default function GameBoard({
         hand={southHand}
         melds={southMelds}
         riverTiles={(south?.river ?? []).map(tileLabel)}
-        onDiscard={discard}
+        onDiscard={state?.current_player === 0 ? discard : undefined}
         server={server}
         gameId={gameId}
         playerIndex={0}

--- a/web_gui/River.jsx
+++ b/web_gui/River.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
 export default function River({ tiles = [] }) {
+  const cells = Array.from({ length: 24 }, (_, i) => tiles[i] || null);
   return (
     <div className="river">
-      {tiles.map((t, i) => (
-        <span key={i} className="tile">{t}</span>
+      {cells.map((t, i) => (
+        <span key={i} className="tile">
+          {t ?? '\u00a0'}
+        </span>
       ))}
     </div>
   );

--- a/web_gui/River.test.jsx
+++ b/web_gui/River.test.jsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import River from './River.jsx';
+
+describe('River layout', () => {
+  it('reserves 24 grid cells', () => {
+    const { container } = render(<River tiles={['A', 'B']} />);
+    const cells = container.querySelectorAll('.river .tile');
+    expect(cells).toHaveLength(24);
+    expect(cells[0].textContent).toBe('A');
+    expect(cells[1].textContent).toBe('B');
+  });
+});

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -59,11 +59,12 @@
 }
 
 .river {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(6, calc(var(--tile-font-size) * 1.2));
+  grid-template-rows: repeat(4, calc(var(--tile-font-size) * 1.6));
   justify-content: center;
   gap: 0.25rem;
-  min-height: 24px;
+  min-height: calc(var(--tile-font-size) * 1.6 * 4 + 0.25rem * 3);
 }
 
 .meld-area {


### PR DESCRIPTION
## Summary
- allow discarding only on the player's turn
- display each player's river in a fixed 6x4 grid
- maintain tile objects for the local hand so discards send the correct data
- update README to mention the discard grid
- add unit tests for discarding and the river layout

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `uv pip install --system mypy pytest`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a034df2c0832abc1329d2246e800b