### PR TITLE
Add discard error modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Future work will expand these components.
 - [x] Icon buttons using react-icons
 - [x] Highlight active player on board
 - [x] 6x4 discard grid rendering
+- [x] Modal error display on failed discard actions
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/web_gui/ErrorModal.jsx
+++ b/web_gui/ErrorModal.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function ErrorModal({ message, onClose }) {
+  return (
+    <div className={`modal ${message ? 'is-active' : ''}`}>
+      <div className="modal-background" onClick={onClose}></div>
+      <div className="modal-content">
+        <div className="box">
+          <p>{message}</p>
+        </div>
+      </div>
+      <button
+        className="modal-close is-large"
+        aria-label="close"
+        onClick={onClose}
+      ></button>
+    </div>
+  );
+}

--- a/web_gui/GameBoard.discard.test.jsx
+++ b/web_gui/GameBoard.discard.test.jsx
@@ -18,7 +18,7 @@ describe('GameBoard discard', () => {
     const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
     render(<GameBoard state={state} server="http://s" gameId="1" />);
     const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;
-    const btn = screen.getByRole('button', { name: label });
+    const btn = screen.getAllByRole('button', { name: label })[0];
     await userEvent.click(btn);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ player_index: 0, action: 'discard', tile: { suit: 'man', value: 1 } });
@@ -32,5 +32,17 @@ describe('GameBoard discard', () => {
     const btn = container.querySelector('.south .hand button');
     expect(btn).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows modal on server error', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, status: 409 }));
+    global.fetch = fetchMock;
+    const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
+    render(<GameBoard state={state} server="http://s" gameId="1" />);
+    const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;
+    const btn = screen.getAllByRole('button', { name: label })[0];
+    await userEvent.click(btn);
+    const modal = await screen.findByText('Discard failed: 409');
+    expect(modal).toBeTruthy();
   });
 });

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import CenterDisplay from './CenterDisplay.jsx';
 import PlayerPanel from './PlayerPanel.jsx';
 import { tileToEmoji } from './tileUtils.js';
+import ErrorModal from './ErrorModal.jsx';
 
 function tileLabel(tile) {
   return tileToEmoji(tile);
@@ -19,6 +20,7 @@ export default function GameBoard({
   const east = players[3];
 
   const prevPlayer = useRef(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const current = state?.current_player;
@@ -61,13 +63,16 @@ export default function GameBoard({
     try {
       if (!gameId) return;
       if (typeof tile === 'string') return;
-      await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ player_index: 0, action: 'discard', tile }),
       });
+      if (!resp.ok) {
+        setError(`Discard failed: ${resp.status}`);
+      }
     } catch {
-      // ignore errors for now
+      setError('Failed to contact server');
     }
   }
 
@@ -128,6 +133,7 @@ export default function GameBoard({
         activePlayer={state?.current_player}
       />
     </div>
+    <ErrorModal message={error} onClose={() => setError(null)} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- display discard errors in a Bulma modal
- expose modal for failed server requests
- test GameBoard modal display on error
- document modal feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a06d06a60832ab1a92e2602aac1b5