### PR TITLE
Fix discard turn advance

### DIFF
--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -35,3 +35,17 @@ def test_skip_updates_current_player() -> None:
     )
     output = run_node(code)
     assert output == '1'
+
+
+def test_discard_advances_turn_and_adds_river() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {current_player: 0, players: [\n"
+        "  {hand: {tiles: [{suit: 'pin', value: 1}]}, river: []}, {}\n"
+        "]};\n"
+        "const evt = {name: 'discard', payload: {player_index: 0, tile: {suit: 'pin', value: 1}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.current_player + ':' + newState.players[0].river.length);"
+    )
+    output = run_node(code)
+    assert output == '1:1'

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -22,6 +22,10 @@ export function applyEvent(state, event) {
         if (idx !== -1) p.hand.tiles.splice(idx, 1);
         p.river.push(tile);
       }
+      newState.current_player =
+        (event.payload.player_index + 1) % newState.players.length;
+      newState.last_discard = event.payload.tile;
+      newState.last_discard_player = event.payload.player_index;
       break;
     }
     case 'meld': {


### PR DESCRIPTION
## Summary
- update discard event handling to advance the turn and store last discard
- test that discard events update the turn and river

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a1f0df3c4832a97c9ab0bec53839b