### PR TITLE
Fix docs for WebSocket warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ uv pip install -e ./core -e ./web
 uvicorn web.server:app --reload
 ```
 
+If `uvicorn` prints "Unsupported upgrade request" or
+"No supported WebSocket library detected" when starting, ensure the server was
+installed with WebSocket support. Installing the **web** package as shown above
+or running `pip install 'uvicorn[standard]'` will include the required
+`websockets` dependency.
+
 ### Start the web GUI
 
 The front-end is a small React app built with Vite. Start the development server


### PR DESCRIPTION
## Summary
- add troubleshooting tip for missing WebSocket support in `uvicorn`

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `uv run python -m build core`
- `uv run python -m build cli`
- `uv run flake8`
- `uv run mypy core web cli`
- `uv run pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a1e778a54832a9f7e5520e48d9a07