### PR TITLE
Fix 500 on fetching game before start

### DIFF
--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -7,6 +7,12 @@ from core import api, models
 client = TestClient(app)
 
 
+def test_get_game_returns_404_when_not_started() -> None:
+    api._engine = None  # type: ignore[assignment]
+    response = client.get("/games/1")
+    assert response.status_code == 404
+
+
 def test_health_endpoint() -> None:
     response = client.get("/health")
     assert response.status_code == 200

--- a/web/server.py
+++ b/web/server.py
@@ -53,7 +53,10 @@ def create_game(req: CreateGameRequest) -> dict:
 def get_game(game_id: int) -> dict:
     """Return basic game state for the given game id."""
     # For now we ignore game_id and return the singleton engine state
-    return asdict(api.get_state())
+    try:
+        return asdict(api.get_state())
+    except AssertionError:
+        raise HTTPException(status_code=404, detail="Game not started")
 
 
 @app.get("/practice")


### PR DESCRIPTION
## Summary
- return 404 if the game has not been started when fetching `/games/{id}`
- test that the endpoint behaves correctly when no game is running

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `.venv/bin/python -m build core`
- `.venv/bin/python -m build cli`
- `.venv/bin/flake8`
- `.venv/bin/mypy core web cli`
- `.venv/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a213e7af4832a88682959dc48e858