### PR TITLE
Add AI auto-play toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Future work will expand these components.
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
 - [x] Simple tsumogiri AI for automated turns
+- [x] Toggle simple AI per player from GUI
 - [x] Handle start_kyoku event in GUI
 - [x] Join game by ID via GUI
 - [x] Reconnect to running game after reload

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -34,6 +34,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `declare_ron`      | `player_index`, `Tile`                  | Win on another player's discard. |
 | `declare_tsumo`    | `player_index`, `Tile`                  | Win on self-drawn tile. |
 | `skip`             | `player_index`                          | Pass on an action. |
+| `auto_play_turn`   | `player_index`                          | Draw and discard using the simple AI. |
 | `end_game`         | none                                    | Terminate the current game. |
 | `get_state`        | none                                    | Retrieve the current `GameState`. |
 

--- a/docs/web-gui-architecture.md
+++ b/docs/web-gui-architecture.md
@@ -22,7 +22,9 @@ Each component receives only the data it needs so the interface remains simple a
 1. After the page loads, `App` fetches the current game state via `GET /games/{id}`.
 2. `App` opens a WebSocket to `/ws/{id}` and listens for events.
 3. Incoming events update the React state, which re-renders the `GameBoard`.
-4. When `current_player` changes, `GameBoard` posts `{action: 'draw'}` for that player so drawing occurs automatically.
+4. When `current_player` changes, `GameBoard` posts `{action: 'draw'}` for that player.
+   If the AI toggle is enabled for the seat it instead posts `{action: 'auto'}`
+   so drawing and discarding happen automatically.
 5. User actions send POST requests back to the server using the REST API.
 
 ## Future Enhancements

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -202,3 +202,14 @@ def test_practice_endpoints_external(monkeypatch) -> None:
     data = prob.json()
     resp = client.post("/practice/suggest?ai=true", json={"hand": data["hand"]})
     assert resp.status_code == 200
+
+
+def test_auto_action_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    resp = client.post(
+        "/games/1/action",
+        json={"player_index": 0, "action": "auto"},
+    )
+    assert resp.status_code == 200
+    tile = resp.json()
+    assert "suit" in tile and "value" in tile

--- a/tests/web_gui/test_ai_button.py
+++ b/tests/web_gui/test_ai_button.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_ai_button_added() -> None:
+    jsx = Path('web_gui/PlayerPanel.jsx').read_text()
+    assert 'ai-btn' in jsx and 'FiCpu' in jsx
+
+
+def test_ai_button_css() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert '.ai-btn' in css

--- a/web/server.py
+++ b/web/server.py
@@ -122,6 +122,9 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
     if req.action == "skip":
         api.skip(req.player_index)
         return {"status": "ok"}
+    if req.action == "auto":
+        tile = api.auto_play_turn(req.player_index)
+        return asdict(tile)
     raise HTTPException(status_code=400, detail="Unknown action")
 
 

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -21,6 +21,15 @@ export default function GameBoard({
 
   const prevPlayer = useRef(null);
   const [error, setError] = useState(null);
+  const [aiPlayers, setAiPlayers] = useState([false, false, false, false]);
+
+  function toggleAI(idx) {
+    setAiPlayers((a) => {
+      const arr = a.slice();
+      arr[idx] = !arr[idx];
+      return arr;
+    });
+  }
 
   useEffect(() => {
     const current = state?.current_player;
@@ -28,13 +37,14 @@ export default function GameBoard({
     prevPlayer.current = current;
     const tiles = state?.players?.[current]?.hand?.tiles ?? [];
     if (tiles.length === 13) {
+      const action = aiPlayers[current] ? 'auto' : 'draw';
       fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ player_index: current, action: 'draw' }),
+        body: JSON.stringify({ player_index: current, action }),
       }).catch(() => {});
     }
-  }, [state?.current_player, gameId, server, state?.players]);
+  }, [state?.current_player, gameId, server, state?.players, aiPlayers]);
 
   const defaultHand = Array(13).fill('🀫');
 
@@ -97,6 +107,8 @@ export default function GameBoard({
         gameId={gameId}
         playerIndex={2}
         activePlayer={state?.current_player}
+        aiActive={aiPlayers[2]}
+        toggleAI={toggleAI}
       />
       <PlayerPanel
         seat="west"
@@ -108,6 +120,8 @@ export default function GameBoard({
         gameId={gameId}
         playerIndex={1}
         activePlayer={state?.current_player}
+        aiActive={aiPlayers[1]}
+        toggleAI={toggleAI}
       />
       <PlayerPanel
         seat="east"
@@ -119,6 +133,8 @@ export default function GameBoard({
         gameId={gameId}
         playerIndex={3}
         activePlayer={state?.current_player}
+        aiActive={aiPlayers[3]}
+        toggleAI={toggleAI}
       />
       <PlayerPanel
         seat="south"
@@ -131,6 +147,8 @@ export default function GameBoard({
         gameId={gameId}
         playerIndex={0}
         activePlayer={state?.current_player}
+        aiActive={aiPlayers[0]}
+        toggleAI={toggleAI}
       />
     </div>
     <ErrorModal message={error} onClose={() => setError(null)} />

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { FiCpu } from 'react-icons/fi';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import Controls from './Controls.jsx';
+import Button from './Button.jsx';
 
 export default function PlayerPanel({
   seat,
@@ -15,6 +17,8 @@ export default function PlayerPanel({
   gameId,
   playerIndex,
   activePlayer,
+  aiActive = false,
+  toggleAI,
 }) {
   const active = playerIndex === activePlayer;
   return (
@@ -22,6 +26,13 @@ export default function PlayerPanel({
       <div className="player-header">
         <span className="riichi-stick">{player?.riichi ? '|' : '\u00a0'}</span>
         <span className="player-name">{(player ? player.name : seat) + (player ? ` ${player.score}` : '')}</span>
+        <Button
+          aria-label={aiActive ? 'Disable AI' : 'Enable AI'}
+          className={`ai-btn${aiActive ? ' active' : ''}`}
+          onClick={() => toggleAI?.(playerIndex)}
+        >
+          <FiCpu />
+        </Button>
       </div>
       <River tiles={riverTiles} />
       <div className="hand-with-melds">

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -150,6 +150,15 @@
   background-color: #fff4ce;
 }
 
+.player-header .ai-btn {
+  margin-left: auto;
+  padding: 0.25rem;
+}
+
+.ai-btn.active {
+  background-color: #28a745;
+}
+
 @media (max-width: 600px) {
   .board-grid {
     grid-template-areas:


### PR DESCRIPTION
## Summary
- add per-player AI toggle icon using FiCpu
- request `auto` action from GameBoard when enabled
- expose `auto` action in FastAPI server
- document new command in API and architecture docs
- cover AI button in unit tests

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a21d5f920832aad8f07a899fc4067