### PR TITLE
Add favicon and cleanup header

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Future work will expand these components.
 - [x] Stylish form inputs with Bulma CSS
 - [x] Responsive layout for narrow screens
 - [x] Icon buttons using react-icons
+- [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
 - [x] 6x4 discard grid rendering
 - [x] Modal error display on failed discard actions

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -115,7 +115,6 @@ export default function App() {
 
   return (
     <>
-      <h1>MyMahjong GUI</h1>
       <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">
           Server:

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -133,3 +133,12 @@ describe('App connection status indicator', () => {
     expect(msg.textContent).toMatch(/Failed to contact server/);
   });
 });
+
+describe('App header', () => {
+  it('does not render a heading', () => {
+    global.fetch = mockFetch();
+    render(<App />);
+    const heading = screen.queryByRole('heading', { level: 1 });
+    expect(heading).toBeNull();
+  });
+});

--- a/web_gui/assets/favicon.svg
+++ b/web_gui/assets/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text y="96" font-size="96">🀄</text>
+</svg>

--- a/web_gui/index.html
+++ b/web_gui/index.html
@@ -6,6 +6,7 @@
   <title>MyMahjong GUI</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
   <link rel="stylesheet" href="./style.css" />
+  <link rel="icon" type="image/svg+xml" href="./assets/favicon.svg" />
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
## Summary
- add a mahjong emoji favicon to the web GUI
- remove the now redundant `MyMahjong GUI` page header
- test that no heading is rendered
- document the favicon in the README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a25010bcc832ab165e02e88b433a6