### PR TITLE
Add Shanten quiz mode to web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Future work will expand these components.
   - [x] CLI practice command
   - [x] AI recommendation
   - [x] Web UI support
- - [x] シャンテン数クイズ
-   - [x] CLI quiz command
+- [x] シャンテン数クイズ
+  - [x] CLI quiz command
+  - [x] Web UI support
 
 ### Core engine capabilities
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Future work will expand these components.
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option
+- [x] Riipai (sort hand) button in GUI
 - [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
 - [x] Automatic draw on turn start
@@ -71,6 +72,7 @@ Future work will expand these components.
 - [x] Stylish form inputs with Bulma CSS
 - [x] Responsive layout for narrow screens
 - [x] Icon buttons using react-icons
+- [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
 - [x] 6x4 discard grid rendering
 - [x] Modal error display on failed discard actions
@@ -159,7 +161,9 @@ remain to be built:
 - [x] Tracking honba and riichi sticks in `GameState`.
 - [x] Automatic round progression with dealer repeats and hanchan end
   detection.
-- [x] Exhaustive draw condition: four kans (nine terminals pending).
+- [x] Exhaustive draw conditions: four kans and nine terminals detection.
+- [ ] Chankan ron on kan declarations.
+- [ ] Exhaustive draw condition: four riichi.
 - [ ] Complete MJAI protocol adapter for external AIs.
 - [ ] External AI integration using the adapter.
 
@@ -195,7 +199,7 @@ Two API endpoints are provided:
 ## Shanten quiz
 
 This quiz shows a random hand and asks for the shanten number.
-Run it with:
+Run it from the CLI with:
 
 ```bash
 python -m cli.main shanten-quiz
@@ -204,6 +208,10 @@ python -m cli.main shanten-quiz
 1. Generate a 13-tile starting hand.
 2. Display the tiles in short form.
 3. Prompt for the shanten number and reveal the answer.
+
+The web UI provides the same quiz. Select **Shanten Quiz** from the mode
+dropdown to fetch a hand from `/shanten-quiz` and submit your guess to
+`/shanten-quiz/check`.
 
 ## Running locally
 

--- a/core/api.py
+++ b/core/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile, GameEvent, GameAction
 from .simple_ai import tsumogiri_turn
-from . import practice
+from . import practice, shanten_quiz
 from mahjong.hand_calculating.hand_response import HandResponse
 
 # Singleton engine instance used by interfaces
@@ -127,6 +127,18 @@ def suggest_practice_discard(hand: list[Tile], use_ai: bool = False) -> Tile:
     """
 
     return practice.suggest_discard(hand, use_ai=use_ai)
+
+
+def generate_quiz_hand() -> list[Tile]:
+    """Return a random 13-tile hand for the shanten quiz."""
+
+    return shanten_quiz.generate_hand()
+
+
+def quiz_shanten(hand: list[Tile]) -> int:
+    """Return the shanten number for ``hand``."""
+
+    return shanten_quiz.calculate_shanten(hand)
 
 
 def apply_action(action: GameAction) -> object | None:

--- a/core/models.py
+++ b/core/models.py
@@ -15,6 +15,12 @@ class Tile:
     suit: str
     value: int
 
+    def is_terminal_or_honor(self) -> bool:
+        """Return True if the tile is a terminal or honor."""
+        if self.suit in {"wind", "dragon"}:
+            return True
+        return self.value in {1, 9}
+
 
 @dataclass
 class Meld:

--- a/tests/core/test_exhaustive_draw.py
+++ b/tests/core/test_exhaustive_draw.py
@@ -14,3 +14,33 @@ def test_four_kans_triggers_ryukyoku() -> None:
     assert engine.state.honba == 1
     assert engine.state.kan_count == 0
 
+
+def test_nine_terminals_triggers_ryukyoku() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    player = engine.state.players[1]
+    player.hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 9),
+        Tile("pin", 1),
+        Tile("pin", 9),
+        Tile("sou", 1),
+        Tile("sou", 9),
+        Tile("wind", 1),
+        Tile("wind", 2),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+    ]
+    engine.state.wall.tiles.append(Tile("dragon", 1))
+    engine.state.current_player = 1
+    engine.draw_tile(1)
+    events = engine.pop_events()
+    assert any(
+        e.name == "ryukyoku" and e.payload.get("reason") == "nine_terminals"
+        for e in events
+    )
+    assert engine.state.honba == 1
+

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -219,3 +219,15 @@ def test_auto_action_endpoint() -> None:
     assert resp.status_code == 200
     tile = resp.json()
     assert "suit" in tile and "value" in tile
+
+
+def test_shanten_quiz_endpoints() -> None:
+    quiz = client.get("/shanten-quiz")
+    assert quiz.status_code == 200
+    data = quiz.json()
+    assert "hand" in data
+
+    resp = client.post("/shanten-quiz/check", json={"hand": data["hand"], "guess": 0})
+    assert resp.status_code == 200
+    result = resp.json()
+    assert "actual" in result and "correct" in result

--- a/web/server.py
+++ b/web/server.py
@@ -33,6 +33,13 @@ class SuggestRequest(BaseModel):
     hand: list[dict]
 
 
+class QuizRequest(BaseModel):
+    """Request body for shanten quiz answer."""
+
+    hand: list[dict]
+    guess: int
+
+
 @app.get("/health")
 def health() -> dict[str, str]:
     """Simple health check endpoint."""
@@ -74,6 +81,23 @@ def practice_suggest(req: SuggestRequest, ai: bool = False) -> dict:
     hand = [models.Tile(**t) for t in req.hand]
     tile = api.suggest_practice_discard(hand, use_ai=ai)
     return asdict(tile)
+
+
+@app.get("/shanten-quiz")
+def shanten_quiz_hand() -> dict:
+    """Return a random hand for the shanten quiz."""
+
+    hand = api.generate_quiz_hand()
+    return {"hand": [asdict(t) for t in hand]}
+
+
+@app.post("/shanten-quiz/check")
+def shanten_quiz_check(req: QuizRequest) -> dict:
+    """Return whether the guess matches the hand's shanten number."""
+
+    hand = [models.Tile(**t) for t in req.hand]
+    actual = api.quiz_shanten(hand)
+    return {"correct": req.guess == actual, "actual": actual}
 
 
 class ActionRequest(BaseModel):

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -5,7 +5,7 @@ import ShantenQuiz from './ShantenQuiz.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import './style.css';
-import { FiRefreshCw, FiEye, FiEyeOff, FiCheck } from "react-icons/fi";
+import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle } from "react-icons/fi";
 
 export default function App() {
   const [server, setServer] = useState(
@@ -19,6 +19,7 @@ export default function App() {
   const [events, setEvents] = useState([]);
   const [mode, setMode] = useState('game');
   const [peek, setPeek] = useState(false);
+  const [sortHand, setSortHand] = useState(false);
   const wsRef = useRef(null);
 
   useEffect(() => {
@@ -116,7 +117,6 @@ export default function App() {
 
   return (
     <>
-      <h1>MyMahjong GUI</h1>
       <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">
           Server:
@@ -164,6 +164,17 @@ export default function App() {
         </div>
       </div>
       <div className="field is-grouped is-align-items-flex-end">
+        <label className="label mr-2">Sort:</label>
+        <div className="control">
+          <Button
+            aria-label="Toggle sort"
+            onClick={() => setSortHand(!sortHand)}
+          >
+            <FiShuffle />
+          </Button>
+        </div>
+      </div>
+      <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">
           Players:
           <input
@@ -199,6 +210,7 @@ export default function App() {
           server={server}
           gameId={gameId}
           peek={peek}
+          sortHand={sortHand}
         />
       ) : mode === 'practice' ? (
         <Practice server={server} />

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import GameBoard from './GameBoard.jsx';
 import Practice from './Practice.jsx';
+import ShantenQuiz from './ShantenQuiz.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import './style.css';
@@ -146,6 +147,7 @@ export default function App() {
             <select value={mode} onChange={(e) => setMode(e.target.value)}>
               <option value="game">Game</option>
               <option value="practice">Practice</option>
+              <option value="shanten-quiz">Shanten Quiz</option>
             </select>
           </span>
         </label>
@@ -198,8 +200,10 @@ export default function App() {
           gameId={gameId}
           peek={peek}
         />
-      ) : (
+      ) : mode === 'practice' ? (
         <Practice server={server} />
+      ) : (
+        <ShantenQuiz server={server} />
       )}
       {mode === 'game' && (
         <div className="event-log">

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -74,6 +74,33 @@ describe('App practice mode', () => {
   });
 });
 
+describe('App shanten quiz mode', () => {
+  it('fetches a quiz hand and checks the answer', async () => {
+    global.fetch = vi.fn((url, opts) => {
+      if (url.endsWith('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok' }) });
+      }
+      if (url.endsWith('/shanten-quiz') && (!opts || !opts.method)) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ hand: [{ suit: 'man', value: 1 }] }) });
+      }
+      if (url.endsWith('/shanten-quiz/check')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ correct: true, actual: 0 }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    render(<App />);
+    const modeSelect = screen.getAllByLabelText('Mode:')[0];
+    await userEvent.selectOptions(modeSelect, 'shanten-quiz');
+    await screen.findByText('Next Hand');
+    const input = screen.getByLabelText('Shanten guess');
+    await userEvent.type(input, '0');
+    await userEvent.click(screen.getByText('Submit'));
+    const result = await screen.findByText('Correct!');
+    expect(result).toBeTruthy();
+  });
+});
+
 describe('App reload', () => {
   it('restores server and game id from localStorage', async () => {
     localStorage.setItem('serverUrl', 'http://localhost:5678');

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -160,3 +160,12 @@ describe('App connection status indicator', () => {
     expect(msg.textContent).toMatch(/Failed to contact server/);
   });
 });
+
+describe('App header', () => {
+  it('does not render a heading', () => {
+    global.fetch = mockFetch();
+    render(<App />);
+    const heading = screen.queryByRole('heading', { level: 1 });
+    expect(heading).toBeNull();
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import CenterDisplay from './CenterDisplay.jsx';
 import PlayerPanel from './PlayerPanel.jsx';
-import { tileToEmoji } from './tileUtils.js';
+import { tileToEmoji, sortTiles } from './tileUtils.js';
 import ErrorModal from './ErrorModal.jsx';
 
 function tileLabel(tile) {
@@ -12,6 +12,7 @@ export default function GameBoard({
   server,
   gameId,
   peek = false,
+  sortHand = false,
 }) {
   const players = state?.players ?? [];
   const south = players[0];
@@ -59,7 +60,12 @@ export default function GameBoard({
     peek ? west?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(west);
   const eastHand =
     peek ? east?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(east);
-  const southHand = south?.hand?.tiles ?? defaultHand;
+  const southTiles = south?.hand?.tiles ?? null;
+  const southHand = southTiles
+    ? sortHand
+      ? sortTiles(southTiles)
+      : southTiles
+    : defaultHand;
 
   const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
   const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];

--- a/web_gui/ShantenQuiz.jsx
+++ b/web_gui/ShantenQuiz.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import Hand from './Hand.jsx';
+import Button from './Button.jsx';
+
+export default function ShantenQuiz({ server }) {
+  const [hand, setHand] = useState(null);
+  const [guess, setGuess] = useState('');
+  const [result, setResult] = useState(null);
+
+  async function loadHand() {
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/shanten-quiz`);
+      if (resp.ok) {
+        const data = await resp.json();
+        setHand(data.hand);
+        setGuess('');
+        setResult(null);
+      }
+    } catch {
+      setHand(null);
+    }
+  }
+
+  async function submit() {
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/shanten-quiz/check`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hand, guess: Number(guess) }),
+      });
+      if (resp.ok) {
+        setResult(await resp.json());
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  useEffect(() => {
+    loadHand();
+  }, []);
+
+  if (!hand) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="shanten-quiz">
+      <Hand tiles={hand} />
+      <div className="field has-addons mt-2">
+        <input
+          aria-label="Shanten guess"
+          className="input"
+          type="number"
+          value={guess}
+          onChange={(e) => setGuess(e.target.value)}
+          style={{ width: '5em' }}
+        />
+        <div className="control">
+          <Button onClick={submit}>Submit</Button>
+        </div>
+      </div>
+      {result && (
+        <div>{result.correct ? 'Correct!' : `Shanten is ${result.actual}`}</div>
+      )}
+      <Button onClick={loadHand}>Next Hand</Button>
+    </div>
+  );
+}

--- a/web_gui/assets/favicon.svg
+++ b/web_gui/assets/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text y="96" font-size="96">🀄</text>
+</svg>

--- a/web_gui/index.html
+++ b/web_gui/index.html
@@ -6,6 +6,7 @@
   <title>MyMahjong GUI</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
   <link rel="stylesheet" href="./style.css" />
+  <link rel="icon" type="image/svg+xml" href="./assets/favicon.svg" />
 </head>
 <body>
   <div id="app"></div>

--- a/web_gui/tileUtils.js
+++ b/web_gui/tileUtils.js
@@ -30,3 +30,14 @@ export function tileDescription(tile) {
   }
   return `${value} ${suit}`;
 }
+
+export function sortTiles(tiles) {
+  const order = { man: 0, pin: 1, sou: 2, wind: 3, dragon: 4 };
+  return tiles
+    .slice()
+    .sort((a, b) => {
+      const suitDiff = order[a.suit] - order[b.suit];
+      if (suitDiff !== 0) return suitDiff;
+      return a.value - b.value;
+    });
+}

--- a/web_gui/tileUtils.test.js
+++ b/web_gui/tileUtils.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { sortTiles } from './tileUtils.js';
+
+describe('sortTiles', () => {
+  it('sorts tiles by suit then value', () => {
+    const tiles = [
+      { suit: 'sou', value: 9 },
+      { suit: 'man', value: 3 },
+      { suit: 'pin', value: 1 },
+      { suit: 'wind', value: 4 },
+      { suit: 'dragon', value: 2 },
+      { suit: 'man', value: 1 },
+    ];
+    const sorted = sortTiles(tiles);
+    expect(sorted).toEqual([
+      { suit: 'man', value: 1 },
+      { suit: 'man', value: 3 },
+      { suit: 'pin', value: 1 },
+      { suit: 'sou', value: 9 },
+      { suit: 'wind', value: 4 },
+      { suit: 'dragon', value: 2 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ShantenQuiz` React component
- expose `/shanten-quiz` API endpoints
- wire new mode in `App` with tests
- support quiz helpers in `core.api`
- document web UI support in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a257cbdfc832a955f63ee77a46183