### PR TITLE
Add hand sorting (riipai) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Future work will expand these components.
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option
+- [x] Riipai (sort hand) button in GUI
 - [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
 - [x] Automatic draw on turn start

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -4,7 +4,7 @@ import Practice from './Practice.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import './style.css';
-import { FiRefreshCw, FiEye, FiEyeOff, FiCheck } from "react-icons/fi";
+import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle } from "react-icons/fi";
 
 export default function App() {
   const [server, setServer] = useState(
@@ -18,6 +18,7 @@ export default function App() {
   const [events, setEvents] = useState([]);
   const [mode, setMode] = useState('game');
   const [peek, setPeek] = useState(false);
+  const [sortHand, setSortHand] = useState(false);
   const wsRef = useRef(null);
 
   useEffect(() => {
@@ -162,6 +163,17 @@ export default function App() {
         </div>
       </div>
       <div className="field is-grouped is-align-items-flex-end">
+        <label className="label mr-2">Sort:</label>
+        <div className="control">
+          <Button
+            aria-label="Toggle sort"
+            onClick={() => setSortHand(!sortHand)}
+          >
+            <FiShuffle />
+          </Button>
+        </div>
+      </div>
+      <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">
           Players:
           <input
@@ -197,6 +209,7 @@ export default function App() {
           server={server}
           gameId={gameId}
           peek={peek}
+          sortHand={sortHand}
         />
       ) : (
         <Practice server={server} />

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import CenterDisplay from './CenterDisplay.jsx';
 import PlayerPanel from './PlayerPanel.jsx';
-import { tileToEmoji } from './tileUtils.js';
+import { tileToEmoji, sortTiles } from './tileUtils.js';
 import ErrorModal from './ErrorModal.jsx';
 
 function tileLabel(tile) {
@@ -12,6 +12,7 @@ export default function GameBoard({
   server,
   gameId,
   peek = false,
+  sortHand = false,
 }) {
   const players = state?.players ?? [];
   const south = players[0];
@@ -59,7 +60,12 @@ export default function GameBoard({
     peek ? west?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(west);
   const eastHand =
     peek ? east?.hand?.tiles.map(tileLabel) ?? defaultHand : concealedHand(east);
-  const southHand = south?.hand?.tiles ?? defaultHand;
+  const southTiles = south?.hand?.tiles ?? null;
+  const southHand = southTiles
+    ? sortHand
+      ? sortTiles(southTiles)
+      : southTiles
+    : defaultHand;
 
   const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
   const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];

--- a/web_gui/tileUtils.js
+++ b/web_gui/tileUtils.js
@@ -30,3 +30,14 @@ export function tileDescription(tile) {
   }
   return `${value} ${suit}`;
 }
+
+export function sortTiles(tiles) {
+  const order = { man: 0, pin: 1, sou: 2, wind: 3, dragon: 4 };
+  return tiles
+    .slice()
+    .sort((a, b) => {
+      const suitDiff = order[a.suit] - order[b.suit];
+      if (suitDiff !== 0) return suitDiff;
+      return a.value - b.value;
+    });
+}

--- a/web_gui/tileUtils.test.js
+++ b/web_gui/tileUtils.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { sortTiles } from './tileUtils.js';
+
+describe('sortTiles', () => {
+  it('sorts tiles by suit then value', () => {
+    const tiles = [
+      { suit: 'sou', value: 9 },
+      { suit: 'man', value: 3 },
+      { suit: 'pin', value: 1 },
+      { suit: 'wind', value: 4 },
+      { suit: 'dragon', value: 2 },
+      { suit: 'man', value: 1 },
+    ];
+    const sorted = sortTiles(tiles);
+    expect(sorted).toEqual([
+      { suit: 'man', value: 1 },
+      { suit: 'man', value: 3 },
+      { suit: 'pin', value: 1 },
+      { suit: 'sou', value: 9 },
+      { suit: 'wind', value: 4 },
+      { suit: 'dragon', value: 2 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `sortTiles` helper and tests
- toggle riipai button in GUI
- support `sortHand` in `GameBoard`
- document new feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686a2553b544832abdd62d25bf717b5a