### PR TITLE
Fix practice hand layout

### DIFF
--- a/tests/web_gui/test_tile_style.py
+++ b/tests/web_gui/test_tile_style.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 def test_tile_size_and_border() -> None:
     css = Path('web_gui/style.css').read_text()
-    start = css.index('.tile {')
+    start = css.index('.mj-tile {')
     end = css.index('}', start)
     tile_block = css[start:end]
     assert 'width: calc(var(--tile-font-size) * 1.2);' in tile_block

--- a/web_gui/Hand.jsx
+++ b/web_gui/Hand.jsx
@@ -10,14 +10,14 @@ export default function Hand({ tiles = [], onDiscard }) {
         return onDiscard ? (
           <button
             key={i}
-            className="tile"
+            className="mj-tile"
             onClick={() => onDiscard(t)}
             aria-label={`Discard ${alt}`}
           >
             {label}
           </button>
         ) : (
-          <span key={i} className="tile">{label}</span>
+          <span key={i} className="mj-tile">{label}</span>
         );
       })}
     </div>

--- a/web_gui/MeldArea.jsx
+++ b/web_gui/MeldArea.jsx
@@ -6,7 +6,7 @@ export default function MeldArea({ melds = [] }) {
       {melds.map((meld, mIdx) => (
         <div key={mIdx} className="meld">
           {meld.map((t, i) => (
-            <span key={i} className="tile">{t}</span>
+            <span key={i} className="mj-tile">{t}</span>
           ))}
         </div>
       ))}

--- a/web_gui/River.jsx
+++ b/web_gui/River.jsx
@@ -5,7 +5,7 @@ export default function River({ tiles = [] }) {
   return (
     <div className="river">
       {cells.map((t, i) => (
-        <span key={i} className="tile">
+        <span key={i} className="mj-tile">
           {t ?? '\u00a0'}
         </span>
       ))}

--- a/web_gui/River.test.jsx
+++ b/web_gui/River.test.jsx
@@ -5,7 +5,7 @@ import River from './River.jsx';
 describe('River layout', () => {
   it('reserves 24 grid cells', () => {
     const { container } = render(<River tiles={['A', 'B']} />);
-    const cells = container.querySelectorAll('.river .tile');
+    const cells = container.querySelectorAll('.river .mj-tile');
     expect(cells).toHaveLength(24);
     expect(cells[0].textContent).toBe('A');
     expect(cells[1].textContent).toBe('B');

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -101,7 +101,7 @@
   gap: 0.1rem;
 }
 
-.tile {
+.mj-tile {
   display: inline-block;
   width: calc(var(--tile-font-size) * 1.2);
   height: calc(var(--tile-font-size) * 1.6);
@@ -112,13 +112,17 @@
   transition: transform 0.2s;
 }
 
-.tile:hover {
+.mj-tile:hover {
   transform: translateY(-2px);
 }
 
-.tile img {
+.mj-tile img {
   width: 100%;
   height: 100%;
+}
+
+.practice .hand {
+  justify-content: flex-start;
 }
 
 .east .river { transform: rotate(90deg); }


### PR DESCRIPTION
## Summary
- resolve styling clash with Bulma `.tile`
- left-align practice mode hand
- update tests for new `.mj-tile` class

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a268198ac832a8fa815081ed2cbdd