### PR TITLE
Enable AI by default for 3 seats

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Future work will expand these components.
 - [x] Start game via GUI
 - [x] Simple tsumogiri AI for automated turns
 - [x] Toggle simple AI per player from GUI
+- [x] Players 2-4 use AI by default in GUI
 - [x] Handle start_kyoku event in GUI
 - [x] Join game by ID via GUI
 - [x] Reconnect to running game after reload

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -25,8 +25,8 @@ describe('GameBoard auto draw', () => {
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);
     await Promise.resolve();
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ player_index: 1, action: 'draw' });
-    fireEvent.click(getAllByLabelText('Enable AI')[3]);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ player_index: 1, action: 'auto' });
+    fireEvent.click(getAllByLabelText('Enable AI')[0]);
     await Promise.resolve();
     state.current_player = 0;
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -22,7 +22,8 @@ export default function GameBoard({
 
   const prevPlayer = useRef(null);
   const [error, setError] = useState(null);
-  const [aiPlayers, setAiPlayers] = useState([false, false, false, false]);
+  // Players 1-3 (west, north, east) act as AI by default
+  const [aiPlayers, setAiPlayers] = useState([false, true, true, true]);
 
   function toggleAI(idx) {
     setAiPlayers((a) => {


### PR DESCRIPTION
## Summary
- default AI enabled for seats 2-4 in `GameBoard`
- update auto-draw test for new AI defaults
- document the new default in the README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a28e58514832abc3a3df76436975c