### PR TITLE
Fix GUI action button enable logic

### DIFF
--- a/tests/web_gui/test_active_player.py
+++ b/tests/web_gui/test_active_player.py
@@ -17,3 +17,4 @@ def test_player_panel_accepts_prop() -> None:
     jsx = Path('web_gui/PlayerPanel.jsx').read_text()
     assert 'activePlayer' in jsx
     assert 'active-player' in jsx
+    assert 'aiActive' in jsx

--- a/tests/web_gui/test_controls_disabled.py
+++ b/tests/web_gui/test_controls_disabled.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_controls_accepts_disabled_props() -> None:
+    text = Path('web_gui/Controls.jsx').read_text()
+    assert 'activePlayer' in text
+    assert 'aiActive' in text
+    assert 'disabled={disabled}' in text

--- a/web_gui/Controls.disabled.test.jsx
+++ b/web_gui/Controls.disabled.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import Controls from './Controls.jsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Controls disabled state', () => {
+  it('disables when not active player', () => {
+    render(<Controls server="http://s" gameId="1" playerIndex={0} activePlayer={1} />);
+    expect(screen.getByRole('button', { name: 'Pon' }).disabled).toBe(true);
+  });
+  it('disables when AI is active', () => {
+    render(<Controls server="http://s" gameId="1" playerIndex={0} activePlayer={0} aiActive={true} />);
+    expect(screen.getByRole('button', { name: 'Pon' }).disabled).toBe(true);
+  });
+  it('enabled for active human', () => {
+    render(<Controls server="http://s" gameId="1" playerIndex={0} activePlayer={0} aiActive={false} />);
+    expect(screen.getByRole('button', { name: 'Pon' }).disabled).toBe(false);
+  });
+});

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 import Button from './Button.jsx';
 
-export default function Controls({ server, gameId, playerIndex = 0 }) {
+export default function Controls({
+  server,
+  gameId,
+  playerIndex = 0,
+  activePlayer = null,
+  aiActive = false,
+}) {
   const [message, setMessage] = useState('');
 
 
@@ -46,15 +52,17 @@ export default function Controls({ server, gameId, playerIndex = 0 }) {
     simple('skip');
   }
 
+  const disabled = playerIndex !== activePlayer || aiActive;
+
   return (
     <div className="controls">
-      <Button onClick={chi}>Chi</Button>
-      <Button onClick={pon}>Pon</Button>
-      <Button onClick={kan}>Kan</Button>
-      <Button onClick={riichi}>Riichi</Button>
-      <Button onClick={tsumo}>Tsumo</Button>
-      <Button onClick={ron}>Ron</Button>
-      <Button onClick={skip}>Skip</Button>
+      <Button onClick={chi} disabled={disabled}>Chi</Button>
+      <Button onClick={pon} disabled={disabled}>Pon</Button>
+      <Button onClick={kan} disabled={disabled}>Kan</Button>
+      <Button onClick={riichi} disabled={disabled}>Riichi</Button>
+      <Button onClick={tsumo} disabled={disabled}>Tsumo</Button>
+      <Button onClick={ron} disabled={disabled}>Ron</Button>
+      <Button onClick={skip} disabled={disabled}>Skip</Button>
       {message && <div className="message">{message}</div>}
     </div>
   );

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -148,7 +148,9 @@ export default function GameBoard({
         hand={southHand}
         melds={southMelds}
         riverTiles={(south?.river ?? []).map(tileLabel)}
-        onDiscard={state?.current_player === 0 ? discard : undefined}
+        onDiscard={
+          state?.current_player === 0 && !aiPlayers[0] ? discard : undefined
+        }
         server={server}
         gameId={gameId}
         playerIndex={0}

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -39,7 +39,13 @@ export default function PlayerPanel({
         <Hand tiles={hand} onDiscard={onDiscard} />
         <MeldArea melds={melds} />
       </div>
-      <Controls server={server} gameId={gameId} playerIndex={playerIndex} />
+      <Controls
+        server={server}
+        gameId={gameId}
+        playerIndex={playerIndex}
+        activePlayer={activePlayer}
+        aiActive={aiActive}
+      />
     </div>
   );
 }

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -148,6 +148,10 @@
 .flat-btn:active {
   background-color: #004a99;
 }
+.flat-btn:disabled {
+  background-color: #aaa;
+  cursor: not-allowed;
+}
 
 .active-player .player-header {
   font-weight: bold;


### PR DESCRIPTION
## Summary
- disable Pon and other action buttons when it's not the player's turn or AI is enabled
- pass active/AI state down to Controls component
- prevent discards when AI is playing
- style disabled buttons
- test disabled Controls state

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a2869b0c8832a9fee366952b5c10e