### PR TITLE
Enhance AI toggle button icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Future work will expand these components.
 - [x] Stylish form inputs with Bulma CSS
 - [x] Responsive layout for narrow screens
 - [x] Icon buttons using react-icons
+- [x] Human/robot icons for AI toggle
 - [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
 - [x] 6x4 discard grid rendering

--- a/tests/web_gui/test_ai_button.py
+++ b/tests/web_gui/test_ai_button.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 def test_ai_button_added() -> None:
     jsx = Path('web_gui/PlayerPanel.jsx').read_text()
-    assert 'ai-btn' in jsx and 'FiCpu' in jsx
+    assert 'ai-btn' in jsx and 'FaRobot' in jsx and 'FaUser' in jsx
 
 
 def test_ai_button_css() -> None:

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FiCpu } from 'react-icons/fi';
+import { FaUser, FaRobot } from 'react-icons/fa';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
@@ -31,7 +31,7 @@ export default function PlayerPanel({
           className={`ai-btn${aiActive ? ' active' : ''}`}
           onClick={() => toggleAI?.(playerIndex)}
         >
-          <FiCpu />
+          {aiActive ? <FaRobot /> : <FaUser />}
         </Button>
       </div>
       <River tiles={riverTiles} />

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PlayerPanel from './PlayerPanel.jsx';
+
+function panel(aiActive) {
+  return (
+    <PlayerPanel
+      seat="east"
+      player={{}}
+      hand={[]}
+      melds={[]}
+      riverTiles={[]}
+      server=""
+      gameId="1"
+      playerIndex={0}
+      activePlayer={0}
+      aiActive={aiActive}
+    />
+  );
+}
+
+describe('PlayerPanel AI button icon', () => {
+  it('changes icon when aiActive toggles', () => {
+    const { rerender, getByLabelText } = render(panel(false));
+    const first = getByLabelText('Enable AI').innerHTML;
+    rerender(panel(true));
+    expect(getByLabelText('Disable AI').innerHTML).not.toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
- use human and robot icons to represent AI toggle state
- adjust AI button test to detect new icons
- add PlayerPanel tests for icon switching
- list human/robot icon feature in README

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a2ab730b0832a9a5de5e14d6e28d6