### PR TITLE
Add meld/win waiting status display

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Future work will expand these components.
 - [x] Icon buttons using react-icons
 - [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
+- [x] Meld/win declaration waiting status display
 - [x] 6x4 discard grid rendering
 - [x] Modal error display on failed discard actions
 - [x] 何切る問題 mode

--- a/tests/web_gui/test_active_player.py
+++ b/tests/web_gui/test_active_player.py
@@ -10,7 +10,7 @@ def test_active_player_css() -> None:
 
 def test_game_board_passes_prop() -> None:
     jsx = Path('web_gui/GameBoard.jsx').read_text()
-    assert 'activePlayer={state?.current_player}' in jsx
+    assert 'activePlayer={active}' in jsx
 
 
 def test_player_panel_accepts_prop() -> None:

--- a/tests/web_gui/test_turn_status.py
+++ b/tests/web_gui/test_turn_status.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_center_display_supports_status_message() -> None:
+    jsx = Path('web_gui/CenterDisplay.jsx').read_text()
+    assert 'statusMessage' in jsx
+    assert 'turn-status' in jsx
+
+
+def test_game_board_passes_status_message() -> None:
+    jsx = Path('web_gui/GameBoard.jsx').read_text()
+    assert 'statusMessage={statusMessage}' in jsx
+    assert 'const active' in jsx

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -5,6 +5,7 @@ export default function CenterDisplay({
   dora = [],
   honba = 0,
   riichiSticks = 0,
+  statusMessage = '',
 }) {
   return (
     <div className="center-display">
@@ -13,6 +14,9 @@ export default function CenterDisplay({
       <div className="counts">
         Honba: {honba} | Riichi: {riichiSticks}
       </div>
+      {statusMessage && (
+        <div className="turn-status">{statusMessage}</div>
+      )}
     </div>
   );
 }

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -75,6 +75,19 @@ export default function GameBoard({
   const remaining = state?.wall?.tiles?.length ?? 0;
   const dora = state?.wall?.tiles?.[0] ? [tileLabel(state.wall.tiles[0])] : [];
 
+  const active =
+    state?.waiting_for != null ? state.waiting_for : state?.current_player;
+
+  let statusMessage = '';
+  if (state?.waiting_for != null) {
+    statusMessage = '副露・和了の宣言待ち';
+  } else if (state?.result) {
+    statusMessage = '流局しました';
+  } else if (state?.current_player != null) {
+    const name = players[state.current_player]?.name ?? `Player ${state.current_player}`;
+    statusMessage = `${name} の手番です`;
+  }
+
   async function discard(tile) {
     try {
       if (!gameId) return;
@@ -101,6 +114,7 @@ export default function GameBoard({
         dora={dora}
         honba={state?.honba ?? 0}
         riichiSticks={state?.riichi_sticks ?? 0}
+        statusMessage={statusMessage}
       />
       <div className={boardClass}>
       <PlayerPanel
@@ -112,7 +126,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={2}
-        activePlayer={state?.current_player}
+        activePlayer={active}
         aiActive={aiPlayers[2]}
         toggleAI={toggleAI}
       />
@@ -125,7 +139,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={1}
-        activePlayer={state?.current_player}
+        activePlayer={active}
         aiActive={aiPlayers[1]}
         toggleAI={toggleAI}
       />
@@ -138,7 +152,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={3}
-        activePlayer={state?.current_player}
+        activePlayer={active}
         aiActive={aiPlayers[3]}
         toggleAI={toggleAI}
       />
@@ -152,7 +166,7 @@ export default function GameBoard({
         server={server}
         gameId={gameId}
         playerIndex={0}
-        activePlayer={state?.current_player}
+        activePlayer={active}
         aiActive={aiPlayers[0]}
         toggleAI={toggleAI}
       />

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -52,6 +52,9 @@
 .center-display .counts {
   font-size: 0.9rem;
 }
+.turn-status {
+  font-weight: bold;
+}
 .east { grid-area: east; }
 .south { grid-area: south; }
 


### PR DESCRIPTION
## Summary
- show a waiting status message in the board center display
- highlight whichever player is being waited on
- add related unit tests
- document feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a2a52bd80832a9d2b537bbc9b4ca0