### PR TITLE
Add AI type selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Future work will expand these components.
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
 - [x] Simple tsumogiri AI for automated turns
-- [x] Toggle simple AI per player from GUI
+- [x] Toggle AI per player from GUI
+- [x] AI type selection framework (currently only 'simple')
 - [x] Players 2-4 use AI by default in GUI
 - [x] Handle start_kyoku event in GUI
 - [x] Join game by ID via GUI

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "ai_adapter",
     "ai_runner",
     "simple_ai",
+    "ai",
     "api",
     "tenhou_log",
     "models",

--- a/core/ai.py
+++ b/core/ai.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Registry for available AI strategies."""
+
+from typing import Callable, Dict
+
+from .mahjong_engine import MahjongEngine
+from .models import Tile
+from .simple_ai import tsumogiri_turn
+
+AI_REGISTRY: Dict[str, Callable[[MahjongEngine, int], Tile]] = {
+    "simple": tsumogiri_turn,
+}
+
+
+def register_ai(name: str, func: Callable[[MahjongEngine, int], Tile]) -> None:
+    """Register a new AI strategy under ``name``."""
+    AI_REGISTRY[name] = func

--- a/core/api.py
+++ b/core/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile, GameEvent, GameAction
-from .simple_ai import tsumogiri_turn
+from .ai import AI_REGISTRY
 from . import practice
 from mahjong.hand_calculating.hand_response import HandResponse
 
@@ -88,11 +88,15 @@ def skip(player_index: int) -> None:
     _engine.skip(player_index)
 
 
-def auto_play_turn(player_index: int | None = None) -> Tile:
-    """Have a simple AI draw and discard for ``player_index``."""
+def auto_play_turn(player_index: int | None = None, ai_type: str = "simple") -> Tile:
+    """Have the specified AI draw and discard for ``player_index``."""
+
     assert _engine is not None, "Game not started"
     idx = player_index if player_index is not None else _engine.state.current_player
-    return tsumogiri_turn(_engine, idx)
+    ai = AI_REGISTRY.get(ai_type)
+    if ai is None:
+        raise ValueError(f"Unknown ai_type: {ai_type}")
+    return ai(_engine, idx)
 
 
 def advance_hand(winner_index: int | None = None) -> GameState:

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -34,7 +34,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `declare_ron`      | `player_index`, `Tile`                  | Win on another player's discard. |
 | `declare_tsumo`    | `player_index`, `Tile`                  | Win on self-drawn tile. |
 | `skip`             | `player_index`                          | Pass on an action. |
-| `auto_play_turn`   | `player_index`                          | Draw and discard using the simple AI. |
+| `auto_play_turn`   | `player_index`, `ai_type`               | Draw and discard using the chosen AI. |
 | `end_game`         | none                                    | Terminate the current game. |
 | `get_state`        | none                                    | Retrieve the current `GameState`. |
 

--- a/tests/core/test_ai_registry.py
+++ b/tests/core/test_ai_registry.py
@@ -1,0 +1,8 @@
+from core import api
+import pytest
+
+
+def test_auto_play_unknown_ai():
+    api.start_game(["A", "B", "C", "D"])
+    with pytest.raises(ValueError):
+        api.auto_play_turn(ai_type="nonexistent")

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -214,7 +214,7 @@ def test_auto_action_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     resp = client.post(
         "/games/1/action",
-        json={"player_index": 0, "action": "auto"},
+        json={"player_index": 0, "action": "auto", "ai_type": "simple"},
     )
     assert resp.status_code == 200
     tile = resp.json()

--- a/web/server.py
+++ b/web/server.py
@@ -83,6 +83,7 @@ class ActionRequest(BaseModel):
     action: str
     tile: dict | None = None
     tiles: list[dict] | None = None
+    ai_type: str | None = None
 
 
 @app.post("/games/{game_id}/action")
@@ -126,7 +127,8 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
         api.skip(req.player_index)
         return {"status": "ok"}
     if req.action == "auto":
-        tile = api.auto_play_turn(req.player_index)
+        ai_type = req.ai_type or "simple"
+        tile = api.auto_play_turn(req.player_index, ai_type=ai_type)
         return asdict(tile)
     raise HTTPException(status_code=400, detail="Unknown action")
 

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -25,13 +25,13 @@ describe('GameBoard auto draw', () => {
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);
     await Promise.resolve();
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ player_index: 1, action: 'auto' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ player_index: 1, action: 'auto', ai_type: 'simple' });
     fireEvent.click(getAllByLabelText('Enable AI')[0]);
     await Promise.resolve();
     state.current_player = 0;
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);
     await Promise.resolve();
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({ player_index: 0, action: 'auto' });
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({ player_index: 0, action: 'auto', ai_type: 'simple' });
   });
 });

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -24,6 +24,7 @@ export default function GameBoard({
   const [error, setError] = useState(null);
   // Players 1-3 (west, north, east) act as AI by default
   const [aiPlayers, setAiPlayers] = useState([false, true, true, true]);
+  const [aiTypes] = useState(['simple', 'simple', 'simple', 'simple']);
 
   function toggleAI(idx) {
     setAiPlayers((a) => {
@@ -40,13 +41,15 @@ export default function GameBoard({
     const tiles = state?.players?.[current]?.hand?.tiles ?? [];
     if (tiles.length === 13) {
       const action = aiPlayers[current] ? 'auto' : 'draw';
+      const body = { player_index: current, action };
+      if (action === 'auto') body.ai_type = aiTypes[current];
       fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ player_index: current, action }),
+        body: JSON.stringify(body),
       }).catch(() => {});
     }
-  }, [state?.current_player, gameId, server, state?.players, aiPlayers]);
+  }, [state?.current_player, gameId, server, state?.players, aiPlayers, aiTypes]);
 
   const defaultHand = Array(13).fill('🀫');
 


### PR DESCRIPTION
## Summary
- add AI registry and selection support
- include AI type in auto_play_turn and REST action
- update GUI to send ai_type
- update README and docs
- add regression tests

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a2bb938cc832aac940ee52eb611db