### PR TITLE
Add tooltip and toggle style to peek/sort icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Future work will expand these components.
 - [x] Responsive layout for narrow screens
 - [x] Icon buttons using react-icons
 - [x] Human/robot icons for AI toggle
+- [x] Icon tooltips for peek and sort toggles
 - [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
 - [x] 6x4 discard grid rendering

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -224,22 +224,27 @@ export default function App() {
       )}
       {mode === 'game' && (
         <div className="field is-grouped is-align-items-flex-end">
-          <label className="label mr-2">Peek:</label>
           <div className="control">
-            <Button aria-label="Toggle peek" onClick={() => setPeek(!peek)}>
+            <Button
+              aria-label="Toggle peek"
+              title="Peek at opponents' hands"
+              className={peek ? 'active' : ''}
+              onClick={() => setPeek(!peek)}
+            >
               {peek ? <FiEyeOff /> : <FiEye />}
             </Button>
           </div>
         </div>
       )}
       <div className="field is-grouped is-align-items-flex-end">
-        <label className="label mr-2">Sort:</label>
         <div className="control">
           <Button
             aria-label="Toggle sort"
+            title="Sort hand"
+            className={sortHand ? 'active' : ''}
             onClick={() => setSortHand(!sortHand)}
           >
-            <FiShuffle />
+            {sortHand ? <FiCheck /> : <FiShuffle />}
           </Button>
         </div>
       </div>

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -109,6 +109,15 @@ describe('App icons', () => {
     await userEvent.click(peekButton);
     expect(peekButton.innerHTML).not.toBe(first);
   });
+
+  it('toggles sort icon', async () => {
+    global.fetch = mockFetch();
+    render(<App />);
+    const sortButton = screen.getByLabelText('Toggle sort');
+    const first = sortButton.innerHTML;
+    await userEvent.click(sortButton);
+    expect(sortButton.innerHTML).not.toBe(first);
+  });
 });
 
 describe('App settings modal', () => {

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -167,6 +167,10 @@
   background-color: #28a745;
 }
 
+.flat-btn.active {
+  background-color: #28a745;
+}
+
 @media (max-width: 600px) {
   .board-grid {
     grid-template-areas:


### PR DESCRIPTION
## Summary
- add tooltip bullet in README
- style active icon buttons in CSS
- show tooltip and change icon for peek/sort toggles
- test sort icon toggle behavior

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `.venv/bin/python -m build core`
- `.venv/bin/python -m build cli`
- `.venv/bin/flake8`
- `.venv/bin/mypy core web cli`
- `.venv/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`

------
https://chatgpt.com/codex/tasks/task_e_686a2ca022b4832a8701c94d863379b2