### PR TITLE
Display server and mode permanently

### DIFF
--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -103,7 +103,7 @@ export default function App() {
     wsRef.current = ws;
   }
 
-  function SetupFields() {
+  function ServerModeFields() {
     return (
       <>
         <div className="field is-grouped is-align-items-flex-end">
@@ -142,6 +142,13 @@ export default function App() {
             </span>
           </label>
         </div>
+      </>
+    );
+  }
+
+  function SetupFields() {
+    return (
+      <>
         <div className="field is-grouped is-align-items-flex-end">
           <label className="label mr-2">
             Players:
@@ -195,6 +202,7 @@ export default function App() {
 
   return (
     <>
+      <ServerModeFields />
       {gameState ? (
         <>
           <div className="field">

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Server } from 'mock-socket';
 import { describe, it, vi, expect, afterEach } from 'vitest';
@@ -86,8 +86,8 @@ describe('App reload', () => {
     const server = new Server('ws://localhost:5678/ws/1');
     render(<App />);
     await screen.findByText('WebSocket connected');
-    await userEvent.click(screen.getByText('Options'));
     expect(screen.getByLabelText('Server:').value).toBe('http://localhost:5678');
+    await userEvent.click(screen.getByText('Options'));
     expect(screen.getByLabelText('Game ID:').value).toBe('1');
     server.stop();
   });
@@ -124,6 +124,8 @@ describe('App settings modal', () => {
     expect(screen.queryByText('Start Game')).toBeNull();
     expect(options).toBeTruthy();
     await userEvent.click(options);
+    const modal = document.querySelector('.modal');
+    expect(within(modal).queryByLabelText('Server:')).toBeNull();
     expect(screen.getByLabelText('Server:')).toBeTruthy();
     server.stop();
   });


### PR DESCRIPTION
## Summary
- keep server URL and mode selectors visible at all times
- update tests for the new layout

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a2d721770832abe6510a134a32fcc