### PR TITLE
Fix tile overlap in GUI

### DIFF
--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -34,8 +34,11 @@ export default function PlayerPanel({
           {aiActive ? <FaRobot /> : <FaUser />}
         </Button>
       </div>
-      <River tiles={riverTiles} />
-      <div className="hand-with-melds">
+      <River
+        tiles={riverTiles}
+        style={{ marginBottom: 'calc(var(--tile-font-size) * 0.8)' }}
+      />
+      <div className="hand-with-melds" style={{ position: 'relative', zIndex: 1 }}>
         <Hand tiles={hand} onDiscard={onDiscard} />
         <MeldArea melds={melds} />
       </div>

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -27,3 +27,13 @@ describe('PlayerPanel AI button icon', () => {
     expect(getByLabelText('Disable AI').innerHTML).not.toBe(first);
   });
 });
+
+describe('PlayerPanel layout styles', () => {
+  it('sets river margin and hand z-index', () => {
+    const { container } = render(panel(false));
+    const river = container.querySelector('.river');
+    const hand = container.querySelector('.hand-with-melds');
+    expect(river.style.marginBottom).toBe('calc(var(--tile-font-size) * 0.8)');
+    expect(hand.style.zIndex).toBe('1');
+  });
+});

--- a/web_gui/River.jsx
+++ b/web_gui/River.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-export default function River({ tiles = [] }) {
+export default function River({ tiles = [], style = {} }) {
   const cells = Array.from({ length: 24 }, (_, i) => tiles[i] || null);
   return (
-    <div className="river">
+    <div className="river" style={style}>
       {cells.map((t, i) => (
         <span key={i} className="mj-tile">
           {t ?? '\u00a0'}


### PR DESCRIPTION
## Summary
- ensure River component accepts style prop
- bump PlayerPanel layout: give River extra margin, show hand above river
- test PlayerPanel layout styles

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a2e7a970c832ab9a89130df601063