### PR TITLE
Enable AI discard mid-turn

### DIFF
--- a/core/simple_ai.py
+++ b/core/simple_ai.py
@@ -6,9 +6,19 @@ from .models import Tile
 
 
 def tsumogiri_turn(engine: MahjongEngine, player_index: int) -> Tile:
-    """Draw and immediately discard a tile for ``player_index``."""
+    """Play a full turn by discarding the drawn tile.
+
+    If the player has already drawn (hand size >= 14), simply discard the last
+    tile instead of drawing again. This allows enabling AI mid-turn.
+    """
+
+    player = engine.state.players[player_index]
+    if len(player.hand.tiles) >= 14:
+        tile = player.hand.tiles[-1]
+        engine.discard_tile(player_index, tile)
+        return tile
+
     tile = engine.draw_tile(player_index)
-    hand = engine.state.players[player_index].hand.tiles
-    if tile in hand:
+    if tile in player.hand.tiles:
         engine.discard_tile(player_index, tile)
     return tile

--- a/core/tests/test_simple_ai.py
+++ b/core/tests/test_simple_ai.py
@@ -1,0 +1,24 @@
+from core.mahjong_engine import MahjongEngine
+from core.simple_ai import tsumogiri_turn
+
+
+def test_tsumogiri_turn_discards_when_already_drawn() -> None:
+    engine = MahjongEngine()
+    dealer = engine.state.dealer
+    player = engine.state.players[dealer]
+    assert len(player.hand.tiles) == 14
+    last_tile = player.hand.tiles[-1]
+    tsumogiri_turn(engine, dealer)
+    assert engine.state.current_player == (dealer + 1) % 4
+    assert player.river[-1] == last_tile
+    assert len(player.hand.tiles) == 13
+
+
+def test_tsumogiri_turn_draws_when_needed() -> None:
+    engine = MahjongEngine()
+    player_index = (engine.state.dealer + 1) % 4
+    player = engine.state.players[player_index]
+    assert len(player.hand.tiles) == 13
+    tsumogiri_turn(engine, player_index)
+    assert len(player.hand.tiles) == 13
+    assert len(player.river) == 1

--- a/tests/core/test_simple_ai.py
+++ b/tests/core/test_simple_ai.py
@@ -8,9 +8,11 @@ def test_auto_play_turn_discards_drawn_tile() -> None:
     state.wall.tiles.append(tile)
     player = state.current_player
     hand_len = len(state.players[player].hand.tiles)
+
     discarded = api.auto_play_turn()
-    assert discarded == tile
-    assert state.players[player].river[-1] == tile
-    assert len(state.players[player].hand.tiles) == hand_len
+
+    # With a full hand, the AI should discard without drawing
+    assert discarded == state.players[player].river[-1]
+    assert len(state.players[player].hand.tiles) == hand_len - 1
     assert state.current_player == (player + 1) % 4
 

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -27,11 +27,30 @@ export default function GameBoard({
   const [aiTypes] = useState(['simple', 'simple', 'simple', 'simple']);
 
   function toggleAI(idx) {
+    const enable = !aiPlayers[idx];
     setAiPlayers((a) => {
       const arr = a.slice();
-      arr[idx] = !arr[idx];
+      arr[idx] = enable;
       return arr;
     });
+    if (
+      enable &&
+      idx === state?.current_player &&
+      gameId &&
+      state?.players?.[idx]?.hand?.tiles?.length >= 14
+    ) {
+      const tiles = state.players[idx].hand.tiles;
+      const tile = tiles[tiles.length - 1];
+      fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          player_index: idx,
+          action: 'discard',
+          tile,
+        }),
+      }).catch(() => {});
+    }
   }
 
   useEffect(() => {

--- a/web_gui/GameBoard.toggleAI.test.jsx
+++ b/web_gui/GameBoard.toggleAI.test.jsx
@@ -1,0 +1,39 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState() {
+  // player 0 has already drawn a tile (14 tiles total)
+  const tiles = Array(14).fill({ suit: 'man', value: 1 });
+  return {
+    current_player: 0,
+    players: [
+      { hand: { tiles, melds: [] }, river: [] },
+      { hand: { tiles: Array(13), melds: [] }, river: [] },
+      { hand: { tiles: Array(13), melds: [] }, river: [] },
+      { hand: { tiles: Array(13), melds: [] }, river: [] },
+    ],
+    wall: { tiles: [] },
+  };
+}
+
+describe('GameBoard AI toggle mid-turn', () => {
+  it('discards immediately when enabling AI', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = mockState();
+    const { getAllByLabelText } = render(
+      <GameBoard state={state} server="http://s" gameId="1" />,
+    );
+    // no request on mount because hand has 14 tiles
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+    fireEvent.click(getAllByLabelText('Enable AI')[0]);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      player_index: 0,
+      action: 'discard',
+      tile: { suit: 'man', value: 1 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- let simple AI discard the latest tile if a player already drew
- allow AI toggle button to discard when activated during an active turn
- add regression tests for updated simple AI logic
- test immediate discard on mid-turn AI toggle

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a2fbdef14832a82ebf9c947bd8f79