### PR TITLE
Add Shanten quiz to web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Future work will expand these components.
   - [x] CLI practice command
   - [x] AI recommendation
   - [x] Web UI support
- - [x] シャンテン数クイズ
-   - [x] CLI quiz command
+- [x] シャンテン数クイズ
+  - [x] CLI quiz command
+  - [x] Web UI support
 
 ### Core engine capabilities
 

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -210,6 +210,18 @@ def test_practice_endpoints_external(monkeypatch) -> None:
     assert resp.status_code == 200
 
 
+def test_shanten_quiz_endpoints() -> None:
+    hand_resp = client.get("/shanten-quiz")
+    assert hand_resp.status_code == 200
+    hand = hand_resp.json()
+    assert isinstance(hand, list)
+
+    check = client.post("/shanten-quiz/check", json={"hand": hand})
+    assert check.status_code == 200
+    data = check.json()
+    assert "shanten" in data
+
+
 def test_auto_action_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     resp = client.post(

--- a/tests/web_gui/test_shanten_quiz.py
+++ b/tests/web_gui/test_shanten_quiz.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_shanten_quiz_component_exists() -> None:
+    comp = Path('web_gui/ShantenQuiz.jsx')
+    assert comp.is_file(), 'ShantenQuiz.jsx missing'
+
+
+def test_app_has_shanten_mode() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Shanten Quiz' in text
+    assert 'ShantenQuiz' in text

--- a/web/server.py
+++ b/web/server.py
@@ -7,7 +7,7 @@ import asyncio
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from core import api, models
+from core import api, models, shanten_quiz
 
 app = FastAPI()
 # very small in-memory id tracker until multi-game support exists
@@ -74,6 +74,29 @@ def practice_suggest(req: SuggestRequest, ai: bool = False) -> dict:
     hand = [models.Tile(**t) for t in req.hand]
     tile = api.suggest_practice_discard(hand, use_ai=ai)
     return asdict(tile)
+
+
+class QuizRequest(BaseModel):
+    """Request body for shanten quiz check."""
+
+    hand: list[dict]
+
+
+@app.get("/shanten-quiz")
+def shanten_quiz_hand() -> list[dict]:
+    """Return a random hand for the shanten quiz."""
+
+    hand = shanten_quiz.generate_hand()
+    return [asdict(t) for t in hand]
+
+
+@app.post("/shanten-quiz/check")
+def shanten_quiz_check(req: QuizRequest) -> dict:
+    """Return the shanten number for the provided hand."""
+
+    hand = [models.Tile(**t) for t in req.hand]
+    value = shanten_quiz.calculate_shanten(hand)
+    return {"shanten": value}
 
 
 class ActionRequest(BaseModel):

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import GameBoard from './GameBoard.jsx';
 import Practice from './Practice.jsx';
+import ShantenQuiz from './ShantenQuiz.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import './style.css';
@@ -138,6 +139,7 @@ export default function App() {
               <select value={mode} onChange={(e) => setMode(e.target.value)}>
                 <option value="game">Game</option>
                 <option value="practice">Practice</option>
+                <option value="shanten">Shanten Quiz</option>
               </select>
             </span>
           </label>
@@ -264,8 +266,10 @@ export default function App() {
           peek={peek}
           sortHand={sortHand}
         />
-      ) : (
+      ) : mode === 'practice' ? (
         <Practice server={server} />
+      ) : (
+        <ShantenQuiz server={server} />
       )}
       {mode === 'game' && (
         <div className="event-log">

--- a/web_gui/ShantenQuiz.jsx
+++ b/web_gui/ShantenQuiz.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import Hand from './Hand.jsx';
+import Button from './Button.jsx';
+
+export default function ShantenQuiz({ server }) {
+  const [hand, setHand] = useState(null);
+  const [guess, setGuess] = useState('');
+  const [answer, setAnswer] = useState(null);
+
+  async function loadHand() {
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/shanten-quiz`);
+      if (resp.ok) {
+        setHand(await resp.json());
+        setGuess('');
+        setAnswer(null);
+      }
+    } catch {
+      setHand(null);
+    }
+  }
+
+  async function check() {
+    try {
+      const resp = await fetch(
+        `${server.replace(/\/$/, '')}/shanten-quiz/check`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ hand }),
+        },
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        setAnswer(data.shanten);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  useEffect(() => {
+    loadHand();
+  }, []);
+
+  if (!hand) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="shanten-quiz">
+      <Hand tiles={hand} />
+      <div className="field is-grouped is-align-items-flex-end">
+        <label className="label mr-2">
+          Shanten:
+          <input
+            className="input"
+            type="number"
+            value={guess}
+            onChange={(e) => setGuess(e.target.value)}
+            style={{ width: '4em' }}
+          />
+        </label>
+        <div className="control">
+          <Button onClick={check}>Check</Button>
+        </div>
+      </div>
+      {answer !== null && (
+        <div>{Number(guess) === answer ? 'Correct!' : `Shanten is ${answer}`}</div>
+      )}
+      <Button onClick={loadHand}>Next Hand</Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose shanten quiz endpoints in FastAPI server
- add new ShantenQuiz component and option in the React app
- update README feature list
- cover new functionality with tests

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a31cbc344832aa9438a158fa22d64