### PR TITLE
Enable riipai sorting by default in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Future work will expand these components.
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option
-- [x] Riipai (sort hand) button in GUI
+- [x] Riipai (sort hand) button in GUI (enabled by default)
 - [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
 - [x] Automatic draw on turn start

--- a/tests/web_gui/test_sort_default.py
+++ b/tests/web_gui/test_sort_default.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_sort_hand_default_on() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'useState(true)' in text and 'sortHand' in text
+

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -18,7 +18,7 @@ export default function App() {
   const [events, setEvents] = useState([]);
   const [mode, setMode] = useState('game');
   const [peek, setPeek] = useState(false);
-  const [sortHand, setSortHand] = useState(false);
+  const [sortHand, setSortHand] = useState(true);
   const [showSettings, setShowSettings] = useState(false);
   const wsRef = useRef(null);
 


### PR DESCRIPTION
## Summary
- sort player hand by default in `App.jsx`
- note default riipai behavior in README
- add regression test checking the default sort state

## Testing
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686a315b2f30832aab8c6c789d078dc0