### PR TITLE
Separate drawn tile in GUI hand

### DIFF
--- a/tests/web_gui/test_drawn_tile.py
+++ b/tests/web_gui/test_drawn_tile.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import subprocess
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run(
+        ["node", "-e", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_drawn_tile_css() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert '.drawn-tile' in css
+    start = css.index('.drawn-tile')
+    block = css[start:css.index('}', start)]
+    assert 'margin-left:' in block
+
+
+def test_sort_tiles_except_last() -> None:
+    output = run_node(
+        "import { sortTilesExceptLast } from './web_gui/tileUtils.js';\n"
+        "const tiles = [\n"
+        "  {suit: 'sou', value: 3},\n"
+        "  {suit: 'man', value: 2},\n"
+        "  {suit: 'pin', value: 1},\n"
+        "  {suit: 'sou', value: 5}\n"
+        "];\n"
+        "const res = sortTilesExceptLast(tiles);\n"
+        "console.log(JSON.stringify(res));"
+    )
+    assert output == (
+        '[{"suit":"man","value":2},' +
+        '{"suit":"pin","value":1},' +
+        '{"suit":"sou","value":3},' +
+        '{"suit":"sou","value":5}]'
+    )
+
+
+def test_hand_marks_last_tile() -> None:
+    text = Path('web_gui/Hand.jsx').read_text()
+    assert 'drawn-tile' in text

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import CenterDisplay from './CenterDisplay.jsx';
 import PlayerPanel from './PlayerPanel.jsx';
-import { tileToEmoji, sortTiles } from './tileUtils.js';
+import { tileToEmoji, sortTiles, sortTilesExceptLast } from './tileUtils.js';
 import ErrorModal from './ErrorModal.jsx';
 
 function tileLabel(tile) {
@@ -86,7 +86,7 @@ export default function GameBoard({
   const southTiles = south?.hand?.tiles ?? null;
   const southHand = southTiles
     ? sortHand
-      ? sortTiles(southTiles)
+      ? sortTilesExceptLast(southTiles)
       : southTiles
     : defaultHand;
 

--- a/web_gui/Hand.jsx
+++ b/web_gui/Hand.jsx
@@ -7,17 +7,18 @@ export default function Hand({ tiles = [], onDiscard }) {
       {tiles.map((t, i) => {
         const label = typeof t === 'string' ? t : tileToEmoji(t);
         const alt = typeof t === 'string' ? t : tileDescription(t);
+        const cls = `mj-tile${i === tiles.length - 1 ? ' drawn-tile' : ''}`;
         return onDiscard ? (
           <button
             key={i}
-            className="mj-tile"
+            className={cls}
             onClick={() => onDiscard(t)}
             aria-label={`Discard ${alt}`}
           >
             {label}
           </button>
         ) : (
-          <span key={i} className="mj-tile">{label}</span>
+          <span key={i} className={cls}>{label}</span>
         );
       })}
     </div>

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -116,6 +116,10 @@
   transform: translateY(-2px);
 }
 
+.drawn-tile {
+  margin-left: calc(var(--tile-font-size) * 0.5);
+}
+
 .mj-tile img {
   width: 100%;
   height: 100%;

--- a/web_gui/tileUtils.js
+++ b/web_gui/tileUtils.js
@@ -41,3 +41,10 @@ export function sortTiles(tiles) {
       return a.value - b.value;
     });
 }
+
+export function sortTilesExceptLast(tiles) {
+  if (tiles.length <= 1) return tiles.slice();
+  const head = sortTiles(tiles.slice(0, -1));
+  head.push(tiles[tiles.length - 1]);
+  return head;
+}


### PR DESCRIPTION
## Summary
- keep newly drawn tile unsorted with `sortTilesExceptLast`
- add `drawn-tile` class to last tile
- show last tile with margin in CSS
- update GameBoard to use new sort function
- test new helper and CSS

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`

------
https://chatgpt.com/codex/tasks/task_e_686a348e0f74832aa126243f390169cb