### PR TITLE
Implement riichi validation and tenpai checks

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -5,6 +5,7 @@ from .models import GameState, Tile, Meld, GameEvent
 from .player import Player
 from .wall import Wall
 from .rules import RuleSet, StandardRuleSet
+from .shanten_quiz import is_tenpai
 from mahjong.hand_calculating.hand_response import HandResponse
 
 
@@ -137,7 +138,11 @@ class MahjongEngine:
 
     def declare_riichi(self, player_index: int) -> None:
         """Declare riichi for the given player."""
+
         player = self.state.players[player_index]
+        if player.has_open_melds() or not is_tenpai(player.hand.tiles, player.hand.melds):
+            raise ValueError("Player cannot declare riichi")
+
         player.declare_riichi()
         self.state.riichi_sticks += 1
         self._emit("riichi", {"player_index": player_index})

--- a/core/player.py
+++ b/core/player.py
@@ -39,3 +39,8 @@ class Player:
             return
         self.score -= 1000
         self.riichi = True
+
+    def has_open_melds(self) -> bool:
+        """Return ``True`` if the player has any open melds."""
+
+        return any(m.type in {"chi", "pon", "kan", "added_kan"} for m in self.hand.melds)

--- a/core/shanten_quiz.py
+++ b/core/shanten_quiz.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 from mahjong.shanten import Shanten
 
-from .mahjong_engine import MahjongEngine
-from .models import Tile
+from typing import TYPE_CHECKING, Any
+
+from .models import Tile, Meld
 from .rules import _tile_to_index
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking
+    from .mahjong_engine import MahjongEngine
+else:  # placeholder for runtime monkeypatching in tests
+    MahjongEngine: Any | None = None
 
 
 def generate_hand() -> list[Tile]:
     """Return a random 13-tile hand for the quiz."""
+    from .mahjong_engine import MahjongEngine
+
     engine = MahjongEngine()
     engine.pop_events()  # discard start event
     hand = engine.state.players[0].hand.tiles.copy()
@@ -30,3 +38,11 @@ def calculate_shanten(hand: list[Tile]) -> int:
     """Return the shanten number for ``hand``."""
     counts = _hand_counts(hand)
     return Shanten().calculate_shanten(counts)
+
+
+def is_tenpai(hand_tiles: list[Tile], melds: list[Meld]) -> bool:
+    """Return ``True`` if the hand is in tenpai."""
+
+    counts = _hand_counts(hand_tiles)
+    shanten = Shanten().calculate_shanten(counts)
+    return shanten == 0

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -1,4 +1,5 @@
 from core import api, models, practice
+import pytest
 
 
 def test_start_game() -> None:
@@ -55,10 +56,34 @@ def test_end_game_creates_new_state() -> None:
 def test_declare_riichi_api() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     player = state.players[0]
+    player.hand.tiles = [
+        models.Tile("man", 1),
+        models.Tile("man", 2),
+        models.Tile("man", 3),
+        models.Tile("man", 4),
+        models.Tile("man", 5),
+        models.Tile("man", 6),
+        models.Tile("man", 7),
+        models.Tile("man", 7),
+        models.Tile("pin", 7),
+        models.Tile("pin", 8),
+        models.Tile("pin", 9),
+        models.Tile("sou", 5),
+        models.Tile("wind", 1),
+        models.Tile("wind", 1),
+    ]
     score = player.score
     api.declare_riichi(0)
     assert player.riichi
     assert player.score == score - 1000
+
+
+def test_declare_riichi_api_invalid() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    player = state.players[0]
+    player.hand.tiles = [models.Tile("man", 1) for _ in range(14)]
+    with pytest.raises(ValueError):
+        api.declare_riichi(0)
 
 
 def test_start_kyoku_api() -> None:
@@ -92,3 +117,4 @@ def test_practice_api_external(monkeypatch) -> None:
     monkeypatch.setattr(practice, "suggest_discard", fake_suggest)
     tile = api.suggest_practice_discard(prob.hand, use_ai=True)
     assert tile.suit == "man"
+

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -1,7 +1,8 @@
 from core.mahjong_engine import MahjongEngine
-from core.models import Tile
+from core.models import Tile, Meld
 from core.rules import RuleSet
 from mahjong.hand_calculating.hand_response import HandResponse
+import pytest
 
 
 def test_engine_initialization() -> None:
@@ -105,6 +106,22 @@ def test_remaining_yama_tiles_property() -> None:
 def test_declare_riichi() -> None:
     engine = MahjongEngine()
     player = engine.state.players[0]
+    player.hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("man", 7),
+        Tile("man", 7),
+        Tile("pin", 7),
+        Tile("pin", 8),
+        Tile("pin", 9),
+        Tile("sou", 5),
+        Tile("wind", 1),
+        Tile("wind", 1),
+    ]
     start_score = player.score
     engine.declare_riichi(0)
     assert player.riichi
@@ -117,6 +134,22 @@ def test_tsumo_updates_scores_and_emits_event() -> None:
     engine.pop_events()
     tile = Tile("man", 1)
     engine.state.players[0].hand.tiles.append(tile)
+    engine.state.players[1].hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("man", 7),
+        Tile("man", 7),
+        Tile("pin", 7),
+        Tile("pin", 8),
+        Tile("pin", 9),
+        Tile("sou", 5),
+        Tile("wind", 1),
+        Tile("wind", 1),
+    ]
     engine.declare_riichi(1)
     start_score = engine.state.players[0].score
     loser_start = engine.state.players[1].score
@@ -134,6 +167,22 @@ def test_ron_updates_scores_and_emits_event() -> None:
     engine.pop_events()
     tile = Tile("man", 2)
     engine.state.players[0].hand.tiles.append(tile)
+    engine.state.players[2].hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("man", 7),
+        Tile("man", 7),
+        Tile("pin", 7),
+        Tile("pin", 8),
+        Tile("pin", 9),
+        Tile("sou", 5),
+        Tile("wind", 1),
+        Tile("wind", 1),
+    ]
     engine.declare_riichi(2)
     engine.state.players[1].hand.tiles.append(Tile("man", 2))
     engine.discard_tile(1, engine.state.players[1].hand.tiles[-1])
@@ -165,6 +214,22 @@ def test_event_log() -> None:
     engine.state.wall.tiles.append(tile)
     drawn = engine.draw_tile(0)
     engine.discard_tile(0, drawn)
+    engine.state.players[0].hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("man", 7),
+        Tile("man", 7),
+        Tile("pin", 7),
+        Tile("pin", 8),
+        Tile("pin", 9),
+        Tile("sou", 5),
+        Tile("wind", 1),
+        Tile("wind", 1),
+    ]
     engine.declare_riichi(0)
     engine.declare_tsumo(0, drawn)
     engine.end_game()
@@ -226,3 +291,51 @@ def test_ryukyoku_event_on_wall_empty() -> None:
     events = engine.pop_events()
     names = [e.name for e in events]
     assert "ryukyoku" in names
+
+
+def test_declare_riichi_invalid_open_meld() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    player.hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("man", 7),
+        Tile("man", 7),
+        Tile("pin", 7),
+        Tile("pin", 8),
+        Tile("pin", 9),
+        Tile("sou", 5),
+        Tile("wind", 1),
+        Tile("wind", 1),
+    ]
+    player.hand.melds.append(Meld(tiles=[Tile("sou", 1)] * 3, type="pon"))
+    with pytest.raises(ValueError):
+        engine.declare_riichi(0)
+
+
+def test_declare_riichi_invalid_not_tenpai() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    player.hand.tiles = [
+        Tile("man", 1),
+        Tile("man", 1),
+        Tile("man", 2),
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 5),
+        Tile("man", 6),
+        Tile("pin", 2),
+        Tile("pin", 4),
+        Tile("pin", 6),
+        Tile("sou", 2),
+        Tile("sou", 4),
+        Tile("sou", 6),
+        Tile("wind", 1),
+    ]
+    with pytest.raises(ValueError):
+        engine.declare_riichi(0)
+

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -132,6 +132,23 @@ def test_additional_action_endpoints() -> None:
     )
     assert resp.status_code == 200
 
+    state.players[0].hand.melds.clear()
+    state.players[0].hand.tiles = [
+        models.Tile("man", 1),
+        models.Tile("man", 2),
+        models.Tile("man", 3),
+        models.Tile("man", 4),
+        models.Tile("man", 5),
+        models.Tile("man", 6),
+        models.Tile("man", 7),
+        models.Tile("man", 7),
+        models.Tile("pin", 7),
+        models.Tile("pin", 8),
+        models.Tile("pin", 9),
+        models.Tile("sou", 5),
+        models.Tile("wind", 1),
+        models.Tile("wind", 1),
+    ]
     resp = client.post(
         "/games/1/action",
         json={"player_index": 0, "action": "riichi"},


### PR DESCRIPTION
## Summary
- add `Player.has_open_melds` method
- add `shanten_quiz.is_tenpai` helper
- validate tenpai and closed hand in `declare_riichi`
- test riichi logic through engine, API and server layers

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a3502bd74832ab66c7701a0a3e7dc