### PR TITLE
Add shanten CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Future work will expand these components.
 - [x] Join remote games via CLI
 - [x] Draw tile in remote games via CLI
 - [x] View remote game state via CLI
+- [x] Display player hand shanten via CLI
 - [x] Remote server health check via CLI
 - [x] REST + WebSocket API
 - [x] Basic REST endpoints (create game, fetch game, health)

--- a/core/api.py
+++ b/core/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile, GameEvent, GameAction
 from .ai import AI_REGISTRY
-from . import practice
+from . import practice, shanten_quiz
 from mahjong.hand_calculating.hand_response import HandResponse
 
 # Singleton engine instance used by interfaces
@@ -131,6 +131,12 @@ def suggest_practice_discard(hand: list[Tile], use_ai: bool = False) -> Tile:
     """
 
     return practice.suggest_discard(hand, use_ai=use_ai)
+
+
+def calculate_shanten(hand: list[Tile]) -> int:
+    """Return the shanten number for ``hand``."""
+
+    return shanten_quiz.calculate_shanten(hand)
 
 
 def apply_action(action: GameAction) -> object | None:

--- a/tests/cli/test_shanten_command.py
+++ b/tests/cli/test_shanten_command.py
@@ -1,0 +1,33 @@
+from click.testing import CliRunner
+
+from cli.main import cli
+from core import models, api
+from core import player as player_module
+
+
+def test_shanten_command_remote(monkeypatch) -> None:
+    def fake_get(server: str, game_id: int) -> dict:
+        return {
+            "players": [
+                {"hand": {"tiles": [{"suit": "man", "value": 1} for _ in range(13)], "melds": []}}
+            ]
+        }
+
+    monkeypatch.setattr("cli.remote_game.get_game", fake_get)
+    monkeypatch.setattr(api, "calculate_shanten", lambda h: 2)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shanten", "1", "0", "-s", "http://host"])
+    assert result.exit_code == 0
+    assert "Shanten: 2" in result.output
+
+
+def test_shanten_command_local(monkeypatch) -> None:
+    player = player_module.Player(name="A")
+    player.hand.tiles = [models.Tile("man", 1) for _ in range(13)]
+    state = models.GameState(players=[player])
+    monkeypatch.setattr(api, "get_state", lambda: state)
+    monkeypatch.setattr(api, "calculate_shanten", lambda h: 3)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shanten", "1", "0"])
+    assert result.exit_code == 0
+    assert "Shanten: 3" in result.output


### PR DESCRIPTION
## Summary
- add `shanten` command to CLI and tests
- expose `calculate_shanten` in core API
- document new CLI feature in README

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a35ba1fcc832a9f0cef457ba881b7