### PR TITLE
Enable riipai in practice and quiz modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Future work will expand these components.
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option
-- [x] Riipai (sort hand) button in GUI (enabled by default)
+- [x] Riipai (sort hand) button in GUI (enabled by default and used in Practice and Shanten Quiz)
 - [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
 - [x] Automatic draw on turn start

--- a/tests/web_gui/test_practice_quiz_sort.py
+++ b/tests/web_gui/test_practice_quiz_sort.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_practice_uses_sort_tiles() -> None:
+    text = Path('web_gui/Practice.jsx').read_text()
+    assert 'sortTilesExceptLast' in text
+
+
+def test_quiz_uses_sort_tiles() -> None:
+    text = Path('web_gui/ShantenQuiz.jsx').read_text()
+    assert 'sortTiles' in text
+
+
+def test_app_passes_sort_prop() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'Practice server={server} sortHand={sortHand}' in text
+    assert 'ShantenQuiz server={server} sortHand={sortHand}' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -267,9 +267,9 @@ export default function App() {
           sortHand={sortHand}
         />
       ) : mode === 'practice' ? (
-        <Practice server={server} />
+        <Practice server={server} sortHand={sortHand} />
       ) : (
-        <ShantenQuiz server={server} />
+        <ShantenQuiz server={server} sortHand={sortHand} />
       )}
       {mode === 'game' && (
         <div className="event-log">

--- a/web_gui/Practice.jsx
+++ b/web_gui/Practice.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import Hand from './Hand.jsx';
 import Button from './Button.jsx';
-import { tileToEmoji, tileDescription } from './tileUtils.js';
+import { tileToEmoji, tileDescription, sortTilesExceptLast } from './tileUtils.js';
 
-export default function Practice({ server }) {
+export default function Practice({ server, sortHand = true }) {
   const [problem, setProblem] = useState(null);
   const [suggestion, setSuggestion] = useState(null);
   const [chosen, setChosen] = useState(null);
@@ -45,11 +45,13 @@ export default function Practice({ server }) {
     return <div>Loading...</div>;
   }
 
+  const tiles = sortHand ? sortTilesExceptLast(problem.hand) : problem.hand;
+
   return (
     <div className="practice">
       <div>Seat wind: {problem.seat_wind}</div>
       <div> Dora indicator: {tileToEmoji(problem.dora_indicator)} </div>
-      <Hand tiles={problem.hand} onDiscard={choose} />
+      <Hand tiles={tiles} onDiscard={choose} />
       {chosen && (
         <div>You discarded {tileToEmoji(chosen)}</div>
       )}

--- a/web_gui/ShantenQuiz.jsx
+++ b/web_gui/ShantenQuiz.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import Hand from './Hand.jsx';
 import Button from './Button.jsx';
+import { sortTiles } from './tileUtils.js';
 
-export default function ShantenQuiz({ server }) {
+export default function ShantenQuiz({ server, sortHand = true }) {
   const [hand, setHand] = useState(null);
   const [guess, setGuess] = useState('');
   const [answer, setAnswer] = useState(null);
@@ -47,9 +48,11 @@ export default function ShantenQuiz({ server }) {
     return <div>Loading...</div>;
   }
 
+  const tiles = sortHand ? sortTiles(hand) : hand;
+
   return (
     <div className="shanten-quiz">
-      <Hand tiles={hand} />
+      <Hand tiles={tiles} />
       <div className="field is-grouped is-align-items-flex-end">
         <label className="label mr-2">
           Shanten:


### PR DESCRIPTION
## Summary
- default sort hand behavior now applies to Practice and Shanten Quiz
- pass `sortHand` prop through App to these modes
- document this feature in README
- test that components use sorting and that App passes the prop

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686a369ae95c832a8e89a61e8a4cfa1d