### PR TITLE
Implement tsumogiri restriction after riichi

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Future work will expand these components.
 - [x] configurable ruleset
 - [x] event log
 - [x] current player tracking
+- [x] Enforce tsumogiri after riichi
 - [x] action dispatch helper
 - [x] seat wind tracking
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -100,6 +100,7 @@ class MahjongEngine:
             p.hand.melds.clear()
             p.river.clear()
             p.riichi = False
+            p.must_tsumogiri = False
         self.state.last_discard = None
         self.state.last_discard_player = None
         self.state.kan_count = 0
@@ -160,7 +161,11 @@ class MahjongEngine:
 
     def discard_tile(self, player_index: int, tile: Tile) -> None:
         """Discard a tile from the specified player's hand."""
-        self.state.players[player_index].discard(tile)
+        player = self.state.players[player_index]
+        if player.must_tsumogiri and player.hand.tiles and player.hand.tiles[-1] is not tile:
+            raise ValueError("Must discard the drawn tile after declaring riichi")
+        player.discard(tile)
+        player.must_tsumogiri = False
         self._emit("discard", {"player_index": player_index, "tile": tile})
         self.state.current_player = (player_index + 1) % len(self.state.players)
         self.state.last_discard = tile

--- a/core/player.py
+++ b/core/player.py
@@ -16,6 +16,7 @@ class Player:
     river: list[Tile] = field(default_factory=list)
     riichi: bool = False
     seat_wind: str = "east"
+    must_tsumogiri: bool = False
 
     def draw(self, tile: Tile) -> None:
         """Add a tile to the player's hand."""
@@ -39,3 +40,4 @@ class Player:
             return
         self.score -= 1000
         self.riichi = True
+        self.must_tsumogiri = True

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -1,3 +1,4 @@
+import pytest
 from core.mahjong_engine import MahjongEngine
 from core.models import Tile
 from core.rules import RuleSet
@@ -110,6 +111,25 @@ def test_declare_riichi() -> None:
     assert player.riichi
     assert player.score == start_score - 1000
     assert engine.state.riichi_sticks == 1
+
+
+def test_discard_requires_tsumogiri_after_riichi() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    tile_to_discard = player.hand.tiles[0]
+    engine.declare_riichi(0)
+    with pytest.raises(ValueError):
+        engine.discard_tile(0, tile_to_discard)
+
+
+def test_tsumogiri_allowed_after_riichi() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    drawn = player.hand.tiles[-1]
+    engine.declare_riichi(0)
+    engine.discard_tile(0, drawn)
+    assert drawn in player.river
+    assert not player.must_tsumogiri
 
 
 def test_tsumo_updates_scores_and_emits_event() -> None:

--- a/tests/core/test_player.py
+++ b/tests/core/test_player.py
@@ -20,6 +20,12 @@ def test_player_declare_riichi() -> None:
     assert player.score == start_score - 1000
 
 
+def test_riichi_sets_tsumogiri_flag() -> None:
+    player = Player(name="Test")
+    player.declare_riichi()
+    assert player.must_tsumogiri
+
+
 def test_discard_removes_specific_instance() -> None:
     player = Player(name="Test")
     tile1 = Tile(suit="man", value=1)


### PR DESCRIPTION
## Summary
- enforce tsumogiri after declaring riichi
- reset tsumogiri flag every hand
- document feature in README
- test player tsumogiri flag and engine discard rule

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686a3849fa04832aa390d3295ce945f8