### PR TITLE
Update riichi event payload and client handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Future work will expand these components.
 - [x] event log
 - [x] current player tracking
 - [x] Enforce tsumogiri after riichi
+- [x] Riichi event includes player score and stick count
 - [x] action dispatch helper
 - [x] seat wind tracking
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -176,7 +176,14 @@ class MahjongEngine:
         player = self.state.players[player_index]
         player.declare_riichi()
         self.state.riichi_sticks += 1
-        self._emit("riichi", {"player_index": player_index})
+        self._emit(
+            "riichi",
+            {
+                "player_index": player_index,
+                "score": player.score,
+                "riichi_sticks": self.state.riichi_sticks,
+            },
+        )
 
     def calculate_score(
         self, player_index: int, win_tile: Tile

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -113,6 +113,17 @@ def test_declare_riichi() -> None:
     assert engine.state.riichi_sticks == 1
 
 
+def test_riichi_event_includes_score_and_sticks() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()  # clear start_game
+    start_score = engine.state.players[0].score
+    engine.declare_riichi(0)
+    events = engine.pop_events()
+    riichi_evt = next(e for e in events if e.name == "riichi")
+    assert riichi_evt.payload["score"] == start_score - 1000
+    assert riichi_evt.payload["riichi_sticks"] == 1
+
+
 def test_discard_requires_tsumogiri_after_riichi() -> None:
     engine = MahjongEngine()
     player = engine.state.players[0]

--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -60,3 +60,15 @@ def test_ryukyoku_sets_result_and_scores() -> None:
     )
     output = run_node(code)
     assert output == 'ryukyoku:26500'
+
+
+def test_riichi_event_updates_score_and_sticks() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {players:[{score:25000,riichi:false}],riichi_sticks:0};\n"
+        "const evt = {name:'riichi', payload:{player_index:0, score:24000, riichi_sticks:1}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.players[0].score + ':' + newState.riichi_sticks + ':' + newState.players[0].riichi);"
+    )
+    output = run_node(code)
+    assert output == '24000:1:true'

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -43,7 +43,15 @@ export function applyEvent(state, event) {
     }
     case 'riichi': {
       const p = newState.players[event.payload.player_index];
-      if (p) p.riichi = true;
+      if (p) {
+        p.riichi = true;
+        if (typeof event.payload.score === 'number') {
+          p.score = event.payload.score;
+        }
+      }
+      if (typeof event.payload.riichi_sticks === 'number') {
+        newState.riichi_sticks = event.payload.riichi_sticks;
+      }
       break;
     }
     case 'tsumo':


### PR DESCRIPTION
## Summary
- include player score and riichi stick count in riichi events
- update applyEvent to update score and sticks on riichi
- cover new behavior in tests
- document riichi event details in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a3a2b3c0c832abc96f85262a49ab5