### PR TITLE
Add Tenhou log copy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Future work will expand these components.
 - [x] Basic MJAI event serialization
 - [x] GameState JSON serialization
 - [x] Tenhou.net/6 log export ([format described](docs/tenhou-json.md))
+- [x] Copy Tenhou log after each hand
 - [ ] Full Tenhou log features (meld notation, yaku info)
 - [x] RuleSet interface for scoring
 - [x] Local single-player play via CLI

--- a/core/api.py
+++ b/core/api.py
@@ -118,6 +118,15 @@ def pop_events() -> list[GameEvent]:
     return _engine.pop_events()
 
 
+def get_tenhou_log() -> str:
+    """Return the accumulated event log in Tenhou JSON format."""
+    assert _engine is not None, "Game not started"
+    from .tenhou_log import events_to_tenhou_json
+
+    history = _engine.get_event_history()
+    return events_to_tenhou_json(history)
+
+
 def generate_practice_problem() -> practice.PracticeProblem:
     """Return a new practice problem."""
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -18,6 +18,7 @@ class MahjongEngine:
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
         self.state.current_player = 0
         self.events: list[GameEvent] = []
+        self.event_history: list[GameEvent] = []
         self._emit("start_game", {"state": self.state})
         self.start_kyoku(dealer=0, round_number=1)
 
@@ -49,7 +50,9 @@ class MahjongEngine:
             self._resolve_ryukyoku("nine_terminals")
 
     def _emit(self, name: str, payload: dict) -> None:
-        self.events.append(GameEvent(name=name, payload=payload))
+        evt = GameEvent(name=name, payload=payload)
+        self.events.append(evt)
+        self.event_history.append(evt)
 
     def _is_tenpai(self, player: Player) -> bool:
         """Return True if ``player`` is in tenpai."""
@@ -87,6 +90,10 @@ class MahjongEngine:
         events = self.events[:]
         self.events.clear()
         return events
+
+    def get_event_history(self) -> list[GameEvent]:
+        """Return all events emitted since the engine was created."""
+        return self.event_history[:]
 
     def start_kyoku(self, dealer: int, round_number: int) -> None:
         """Begin a new hand with fresh tiles."""

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -92,3 +92,9 @@ def test_practice_api_external(monkeypatch) -> None:
     monkeypatch.setattr(practice, "suggest_discard", fake_suggest)
     tile = api.suggest_practice_discard(prob.hand, use_ai=True)
     assert tile.suit == "man"
+
+
+def test_get_tenhou_log_api() -> None:
+    api.start_game(["A", "B", "C", "D"])
+    log = api.get_tenhou_log()
+    assert log.startswith("{") and "name" in log

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -32,6 +32,14 @@ def test_create_and_get_game() -> None:
     assert "players" in data
 
 
+def test_get_log_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    resp = client.get("/games/1/log")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "log" in data and data["log"].startswith("{")
+
+
 def test_draw_action_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     resp = client.post(

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -188,3 +188,8 @@ def test_result_modal_component_exists() -> None:
 def test_game_board_references_result_modal() -> None:
     board = Path('web_gui/GameBoard.jsx').read_text()
     assert 'ResultModal' in board
+
+
+def test_result_modal_has_copy_button() -> None:
+    text = Path('web_gui/ResultModal.jsx').read_text()
+    assert 'Copy Log' in text

--- a/web/server.py
+++ b/web/server.py
@@ -59,6 +59,17 @@ def get_game(game_id: int) -> dict:
         raise HTTPException(status_code=404, detail="Game not started")
 
 
+@app.get("/games/{game_id}/log")
+def get_log(game_id: int) -> dict:
+    """Return the Tenhou-format log for the current game."""
+    _ = game_id  # placeholder for future multi-game support
+    try:
+        data = api.get_tenhou_log()
+    except AssertionError:
+        raise HTTPException(status_code=404, detail="Game not started")
+    return {"log": data}
+
+
 @app.get("/practice")
 def practice_problem() -> dict:
     """Return a random practice problem."""

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -76,6 +76,18 @@ export default function GameBoard({
     setResult(state?.result ?? null);
   }, [state?.result]);
 
+  async function copyLog() {
+    if (!gameId) return;
+    try {
+      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/log`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      await navigator.clipboard.writeText(data.log);
+    } catch {
+      /* ignore */
+    }
+  }
+
   const defaultHand = Array(13).fill('🀫');
 
   function concealedHand(p) {
@@ -192,7 +204,11 @@ export default function GameBoard({
         toggleAI={toggleAI}
       />
     </div>
-    <ResultModal result={result} onClose={() => setResult(null)} />
+    <ResultModal
+      result={result}
+      onClose={() => setResult(null)}
+      onCopyLog={copyLog}
+    />
     <ErrorModal message={error} onClose={() => setError(null)} />
     </>
   );

--- a/web_gui/ResultModal.jsx
+++ b/web_gui/ResultModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function ResultModal({ result, onClose }) {
+export default function ResultModal({ result, onClose, onCopyLog }) {
   if (!result) return null;
   const { scores, tenpai, reason } = result;
   return (
@@ -17,6 +17,11 @@ export default function ResultModal({ result, onClose }) {
                 </li>
               ))}
             </ul>
+          )}
+          {onCopyLog && (
+            <button className="button mt-2" onClick={onCopyLog}>
+              Copy Log
+            </button>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- keep full event history in MahjongEngine
- expose `/games/{id}/log` endpoint to fetch Tenhou JSON log
- allow copying the log from the ResultModal in the GUI
- test log endpoint and new API helper
- document feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a3a1f4f70832ab56354f2fcaaaf1a