### PR TITLE
Implement call skip waiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Future work will expand these components.
 - [x] declare_ron
 - [x] declare_riichi
 - [x] skip
+- [x] wait for calls until all players skip
 - [x] end_game
 - [x] start_kyoku
 - [x] ryukyoku detection

--- a/cli/local_game.py
+++ b/cli/local_game.py
@@ -23,5 +23,8 @@ def run_game(players: list[str]) -> None:
         name = state.players[player_index].name
         tile = api.auto_play_turn()
         click.echo(f"{name} drew {tile.suit}{tile.value} and discarded it")
+        # automatically pass on all calls so the loop can continue
+        for i in range(1, len(state.players)):
+            api.skip((player_index + i) % len(state.players))
     api.end_game()
     click.echo("Game ended")

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -187,6 +187,7 @@ def test_skip_advances_turn_and_emits_event() -> None:
     assert engine.state.current_player == 1
     events = engine.pop_events()
     assert events and events[0].name == "skip"
+    assert events[0].payload.get("next_player") == 1
 
 
 def test_skip_ignored_if_not_players_turn() -> None:
@@ -195,6 +196,18 @@ def test_skip_ignored_if_not_players_turn() -> None:
     engine.skip(1)
     assert engine.state.current_player == 0
     assert not engine.pop_events()
+
+
+def test_skip_after_discard_advances_when_all_pass() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    tile = Tile("pin", 5)
+    engine.state.players[0].hand.tiles = [tile]
+    engine.state.players[1].hand.tiles = [Tile("pin", 5), Tile("pin", 5)]
+    engine.discard_tile(0, tile)
+    assert engine.state.current_player == 0
+    engine.skip(1)
+    assert engine.state.current_player == 1
 
 
 def test_start_kyoku_resets_state_and_emits_event() -> None:

--- a/tests/core/test_turn_rotation.py
+++ b/tests/core/test_turn_rotation.py
@@ -1,4 +1,5 @@
 from core.mahjong_engine import MahjongEngine
+from core.models import Tile
 
 
 def test_draw_advances_turn() -> None:
@@ -12,5 +13,23 @@ def test_discard_advances_turn() -> None:
     engine = MahjongEngine()
     current = engine.state.current_player
     tile = engine.state.players[current].hand.tiles[0]
+    for i, p in enumerate(engine.state.players):
+        if i != current:
+            p.hand.tiles.clear()
     engine.discard_tile(current, tile)
     assert engine.state.current_player == (current + 1) % len(engine.state.players)
+
+
+def test_discard_waits_for_skip_when_call_possible() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    tile = Tile("man", 1)
+    engine.state.players[0].hand.tiles = [tile]
+    engine.state.players[1].hand.tiles = [Tile("man", 1), Tile("man", 1)]
+    for p in engine.state.players[2:]:
+        p.hand.tiles.clear()
+    engine.discard_tile(0, tile)
+    assert engine.state.current_player == 0
+    engine.skip(1)
+    assert engine.state.current_player == 1
+

--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -29,7 +29,7 @@ def test_skip_updates_current_player() -> None:
     code = (
         "import { applyEvent } from './web_gui/applyEvent.js';\n"
         "const state = {current_player: 0, players: [{}, {}]};\n"
-        "const evt = {name: 'skip', payload: {player_index: 0}};\n"
+        "const evt = {name: 'skip', payload: {player_index: 0, next_player: 1}};\n"
         "const newState = applyEvent(state, evt);\n"
         "console.log(newState.current_player);"
     )
@@ -48,7 +48,7 @@ def test_discard_advances_turn_and_adds_river() -> None:
         "console.log(newState.current_player + ':' + newState.players[0].river.length);"
     )
     output = run_node(code)
-    assert output == '1:1'
+    assert output == '0:1'
 
 def test_ryukyoku_sets_result_and_scores() -> None:
     code = (

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -22,10 +22,17 @@ export function applyEvent(state, event) {
         if (idx !== -1) p.hand.tiles.splice(idx, 1);
         p.river.push(tile);
       }
-      newState.current_player =
-        (event.payload.player_index + 1) % newState.players.length;
       newState.last_discard = event.payload.tile;
       newState.last_discard_player = event.payload.player_index;
+      break;
+    }
+    case 'skip': {
+      if (typeof event.payload.next_player === 'number') {
+        newState.current_player = event.payload.next_player;
+      } else if (event.payload.player_index === newState.current_player) {
+        const next = (event.payload.player_index + 1) % newState.players.length;
+        newState.current_player = next;
+      }
       break;
     }
     case 'meld': {
@@ -58,11 +65,6 @@ export function applyEvent(state, event) {
         });
       }
       newState.result = { type: 'ryukyoku', ...event.payload };
-      break;
-    }
-    case 'skip': {
-      const next = (event.payload.player_index + 1) % newState.players.length;
-      newState.current_player = next;
       break;
     }
     default:


### PR DESCRIPTION
## Summary
- wait for pending calls before advancing turn
- update local game loop to auto-skip
- adjust applyEvent logic for new skip payload
- document call waiting in README
- test updated turn flow and events

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a37c18f48832ab200eb371236ff3c