### PR TITLE
Hide setup fields outside game mode

### DIFF
--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -91,6 +91,12 @@ def test_app_has_game_id_input() -> None:
     assert 'localStorage' in text
 
 
+def test_setup_fields_only_in_game_mode() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    import re
+    assert re.search(r"mode === 'game' &&[\s\S]*?SetupFields", text)
+
+
 def test_app_opens_websocket() -> None:
     text = Path('web_gui/App.jsx').read_text()
     assert '/ws/${' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -205,33 +205,34 @@ export default function App() {
   return (
     <>
       <ServerModeFields />
-      {gameState ? (
-        <>
-          <div className="field">
-            <Button onClick={() => setShowSettings(true)}>Options</Button>
-          </div>
-          {showSettings && (
-            <div className="modal is-active">
-              <div
-                className="modal-background"
-                onClick={() => setShowSettings(false)}
-              ></div>
-              <div className="modal-content">
-                <div className="box">
-                  <SetupFields />
-                </div>
-              </div>
-              <button
-                className="modal-close is-large"
-                aria-label="close"
-                onClick={() => setShowSettings(false)}
-              ></button>
+      {mode === 'game' &&
+        (gameState ? (
+          <>
+            <div className="field">
+              <Button onClick={() => setShowSettings(true)}>Options</Button>
             </div>
-          )}
-        </>
-      ) : (
-        <SetupFields />
-      )}
+            {showSettings && (
+              <div className="modal is-active">
+                <div
+                  className="modal-background"
+                  onClick={() => setShowSettings(false)}
+                ></div>
+                <div className="modal-content">
+                  <div className="box">
+                    <SetupFields />
+                  </div>
+                </div>
+                <button
+                  className="modal-close is-large"
+                  aria-label="close"
+                  onClick={() => setShowSettings(false)}
+                ></button>
+              </div>
+            )}
+          </>
+        ) : (
+          <SetupFields />
+        ))}
       {mode === 'game' && (
         <div className="field is-grouped is-align-items-flex-end">
           <div className="control">


### PR DESCRIPTION
## Summary
- show the `Players` and `Game ID` controls only when in game mode
- test that the fields are conditional

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a458de138832aa3703aa2f820adf2