### PR TITLE
Implement wait-for-skip flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Future work will expand these components.
 - [x] configurable ruleset
 - [x] event log
 - [x] current player tracking
+- [x] Wait for all players to skip before next draw
 - [x] Enforce tsumogiri after riichi
 - [x] Riichi event includes player score and stick count
 - [x] action dispatch helper

--- a/core/api.py
+++ b/core/api.py
@@ -96,6 +96,8 @@ def auto_play_turn(player_index: int | None = None, ai_type: str = "simple") -> 
     ai = AI_REGISTRY.get(ai_type)
     if ai is None:
         raise ValueError(f"Unknown ai_type: {ai_type}")
+    for p in list(_engine.state.waiting_for_claims):
+        _engine.skip(p)
     return ai(_engine, idx)
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -53,6 +53,7 @@ class GameState:
     seat_winds: list[str] = field(default_factory=list)
     last_discard: Tile | None = None
     last_discard_player: int | None = None
+    waiting_for_claims: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -223,9 +223,24 @@ def test_skip_advances_turn_and_emits_event() -> None:
 def test_skip_ignored_if_not_players_turn() -> None:
     engine = MahjongEngine()
     engine.pop_events()
+    tile = engine.state.players[0].hand.tiles[0]
+    engine.discard_tile(0, tile)
+    engine.skip(0)
+    assert engine.state.current_player == 1
+    events = engine.pop_events()
+    assert not any(e.name == "skip" and e.payload["player_index"] == 0 for e in events)
+
+
+def test_draw_blocked_until_all_skip() -> None:
+    engine = MahjongEngine()
+    tile = engine.state.players[0].hand.tiles[0]
+    engine.discard_tile(0, tile)
+    with pytest.raises(ValueError):
+        engine.draw_tile(1)
     engine.skip(1)
-    assert engine.state.current_player == 0
-    assert not engine.pop_events()
+    engine.skip(2)
+    engine.skip(3)
+    engine.draw_tile(1)
 
 
 def test_start_kyoku_resets_state_and_emits_event() -> None:

--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -50,6 +50,18 @@ def test_discard_advances_turn_and_adds_river() -> None:
     output = run_node(code)
     assert output == '1:1'
 
+
+def test_discard_sets_waiting_for_claims() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {current_player:0, players:[{hand:{tiles:[]},river:[]},{hand:{tiles:[]},river:[]},{hand:{tiles:[]},river:[]},{hand:{tiles:[]},river:[]}]};\n"
+        "const evt = {name:'discard', payload:{player_index:0, tile:{suit:'pin', value:1}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.waiting_for_claims.length + ':' + newState.waiting_for_claims.includes(1));"
+    )
+    output = run_node(code)
+    assert output == '3:true'
+
 def test_ryukyoku_sets_result_and_scores() -> None:
     code = (
         "import { applyEvent } from './web_gui/applyEvent.js';\n"

--- a/web_gui/allowedActions.js
+++ b/web_gui/allowedActions.js
@@ -7,7 +7,7 @@ export function getAllowedActions(state, playerIndex) {
   const lastPlayer = state.last_discard_player;
   const numPlayers = state.players.length;
 
-  if (playerIndex === state.current_player) {
+  if (playerIndex === state.current_player || state.waiting_for_claims?.includes(playerIndex)) {
     actions.add('skip');
   }
 


### PR DESCRIPTION
## Summary
- add waiting_for_claims to engine state
- block drawing until all players skip after a discard
- update skip/chi/pon/kan/ron/tsumo flows
- expose skip when waiting via `allowedActions`
- track waiting list in `applyEvent`
- document new behavior in README
- adjust tests for new skip mechanics

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `npx --prefix web_gui vitest run` *(fails: React not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686a4483e9b8832a9b989c115fdb662e