### PR TITLE
Compact header layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Future work will expand these components.
 - [x] Icon buttons using react-icons
 - [x] Human/robot icons for AI toggle
 - [x] Icon tooltips for peek and sort toggles
+- [x] Compact header with gear options icon
 - [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
 - [x] 6x4 discard grid rendering

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -5,7 +5,7 @@ import ShantenQuiz from './ShantenQuiz.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import './style.css';
-import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle } from "react-icons/fi";
+import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle, FiSettings } from "react-icons/fi";
 
 export default function App() {
   const [server, setServer] = useState(
@@ -204,60 +204,61 @@ export default function App() {
 
   return (
     <>
-      <ServerModeFields />
-      {gameState ? (
-        <>
+      <div className="header-controls">
+        <ServerModeFields />
+        {gameState && (
           <div className="field">
-            <Button onClick={() => setShowSettings(true)}>Options</Button>
+            <Button aria-label="Options" onClick={() => setShowSettings(true)}>
+              <FiSettings />
+            </Button>
           </div>
-          {showSettings && (
-            <div className="modal is-active">
-              <div
-                className="modal-background"
-                onClick={() => setShowSettings(false)}
-              ></div>
-              <div className="modal-content">
-                <div className="box">
-                  <SetupFields />
-                </div>
-              </div>
-              <button
-                className="modal-close is-large"
-                aria-label="close"
-                onClick={() => setShowSettings(false)}
-              ></button>
+        )}
+        {mode === 'game' && (
+          <div className="field is-grouped is-align-items-flex-end">
+            <div className="control">
+              <Button
+                aria-label="Toggle peek"
+                title="Peek at opponents' hands"
+                className={peek ? 'active' : ''}
+                onClick={() => setPeek(!peek)}
+              >
+                {peek ? <FiEyeOff /> : <FiEye />}
+              </Button>
             </div>
-          )}
-        </>
-      ) : (
-        <SetupFields />
-      )}
-      {mode === 'game' && (
+          </div>
+        )}
         <div className="field is-grouped is-align-items-flex-end">
           <div className="control">
             <Button
-              aria-label="Toggle peek"
-              title="Peek at opponents' hands"
-              className={peek ? 'active' : ''}
-              onClick={() => setPeek(!peek)}
+              aria-label="Toggle sort"
+              title="Sort hand"
+              className={sortHand ? 'active' : ''}
+              onClick={() => setSortHand(!sortHand)}
             >
-              {peek ? <FiEyeOff /> : <FiEye />}
+              {sortHand ? <FiCheck /> : <FiShuffle />}
             </Button>
           </div>
         </div>
-      )}
-      <div className="field is-grouped is-align-items-flex-end">
-        <div className="control">
-          <Button
-            aria-label="Toggle sort"
-            title="Sort hand"
-            className={sortHand ? 'active' : ''}
-            onClick={() => setSortHand(!sortHand)}
-          >
-            {sortHand ? <FiCheck /> : <FiShuffle />}
-          </Button>
-        </div>
       </div>
+      {gameState ? null : <SetupFields />}
+      {showSettings && (
+        <div className="modal is-active">
+          <div
+            className="modal-background"
+            onClick={() => setShowSettings(false)}
+          ></div>
+          <div className="modal-content">
+            <div className="box">
+              <SetupFields />
+            </div>
+          </div>
+          <button
+            className="modal-close is-large"
+            aria-label="close"
+            onClick={() => setShowSettings(false)}
+          ></button>
+        </div>
+      )}
       {mode === 'game' ? (
         <GameBoard
           state={gameState}

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -34,7 +34,7 @@ describe('App websocket', () => {
     await userEvent.clear(input);
     await userEvent.type(input, 'http://localhost:1235');
     await userEvent.click(screen.getByText('Start Game'));
-    const optionsButton = await screen.findByText('Options');
+    const optionsButton = await screen.findByLabelText('Options');
     expect(optionsButton).toBeTruthy();
     server.stop();
   });
@@ -87,7 +87,7 @@ describe('App reload', () => {
     render(<App />);
     await screen.findByText('WebSocket connected');
     expect(screen.getByLabelText('Server:').value).toBe('http://localhost:5678');
-    await userEvent.click(screen.getByText('Options'));
+    await userEvent.click(screen.getByLabelText('Options'));
     expect(screen.getByLabelText('Game ID:').value).toBe('1');
     server.stop();
   });
@@ -129,7 +129,7 @@ describe('App settings modal', () => {
     await userEvent.clear(input);
     await userEvent.type(input, 'http://localhost:1234');
     await userEvent.click(screen.getByText('Start Game'));
-    const options = await screen.findByText('Options');
+    const options = await screen.findByLabelText('Options');
     expect(screen.queryByText('Start Game')).toBeNull();
     expect(options).toBeTruthy();
     await userEvent.click(options);

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -186,3 +186,11 @@
     grid-template-rows: repeat(4, auto);
   }
 }
+
+.header-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: flex-end;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- streamline GUI header controls by placing them in a single row
- replace Options text with a gear icon
- update tests for the new button label
- note compact header in README

## Testing
- `uv pip install -e ./core -e ./cli -e ./web --system`
- `uv pip install flake8 mypy pytest build --system`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a45e76d08832aa208c2705f2f816b