### PR TITLE
Show draw results in GUI

### DIFF
--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -73,7 +73,9 @@ export default function GameBoard({
   }, [state?.current_player, gameId, server, state?.players, aiPlayers, aiTypes]);
 
   useEffect(() => {
-    setResult(state?.result ?? null);
+    if (state?.result) {
+      setResult(state.result);
+    }
   }, [state?.result]);
 
   async function copyLog() {

--- a/web_gui/GameBoard.resultModal.test.jsx
+++ b/web_gui/GameBoard.resultModal.test.jsx
@@ -1,0 +1,36 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function stateWithResult() {
+  return {
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: [], melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    result: {
+      type: 'ryukyoku',
+      reason: 'wall_empty',
+      scores: [25000, 25000, 25000, 25000],
+      tenpai: [false, false, false, false],
+    },
+  };
+}
+
+function blankState() {
+  return {
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: [], melds: [] }, river: [] })),
+    wall: { tiles: [] },
+  };
+}
+
+describe('GameBoard result modal', () => {
+  it('persists after state update until closed', () => {
+    const { rerender, getByText, getAllByLabelText, queryByText } = render(
+      <GameBoard state={stateWithResult()} server="" gameId="1" />,
+    );
+    expect(getByText('Exhaustive draw')).toBeTruthy();
+    rerender(<GameBoard state={blankState()} server="" gameId="1" />);
+    expect(getByText('Exhaustive draw')).toBeTruthy();
+    fireEvent.click(getAllByLabelText('close')[0]);
+    expect(queryByText('Exhaustive draw')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid clearing results when new hand starts
- test GameBoard result modal persistence

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a46dc7494832aba52b4272e70ba97