### PR TITLE
Fix skip action availability

### DIFF
--- a/web_gui/allowedActions.js
+++ b/web_gui/allowedActions.js
@@ -7,7 +7,12 @@ export function getAllowedActions(state, playerIndex) {
   const lastPlayer = state.last_discard_player;
   const numPlayers = state.players.length;
 
-  if (playerIndex === state.current_player) {
+  if (
+    playerIndex === state.current_player &&
+    last &&
+    lastPlayer !== null &&
+    lastPlayer !== playerIndex
+  ) {
     actions.add('skip');
   }
 

--- a/web_gui/allowedActions.test.js
+++ b/web_gui/allowedActions.test.js
@@ -25,4 +25,20 @@ describe('getAllowedActions', () => {
     const actions = getAllowedActions(mockState(), 2);
     expect(actions).not.toContain('pon');
   });
+
+  it('allows skip when responding to a discard', () => {
+    const state = mockState();
+    state.current_player = 2;
+    const actions = getAllowedActions(state, 2);
+    expect(actions).toContain('skip');
+  });
+
+  it('omits skip on own turn with no discard', () => {
+    const state = mockState();
+    state.last_discard = null;
+    state.last_discard_player = null;
+    state.current_player = 0;
+    const actions = getAllowedActions(state, 0);
+    expect(actions).not.toContain('skip');
+  });
 });


### PR DESCRIPTION
## Summary
- prevent `skip` on your own turn
- test skip availability rules

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a4646da78832a8dccf102c40a6fe3