### PR TITLE
Implement riichi validation and tenpai helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Future work will expand these components.
 - [x] current player tracking
 - [x] Enforce tsumogiri after riichi
 - [x] Riichi event includes player score and stick count
-- [x] action dispatch helper
-- [x] seat wind tracking
+- [x] Validate closed-hand tenpai requirement for riichi
+ - [x] action dispatch helper
+  - [x] seat wind tracking
 
 ## Implementation plan progress
 

--- a/core/player.py
+++ b/core/player.py
@@ -34,6 +34,13 @@ class Player:
             self.hand.tiles.remove(tile)
         self.river.append(tile)
 
+    def has_open_melds(self) -> bool:
+        """Return ``True`` if the player has chi, pon or open kan melds."""
+        return any(
+            meld.type in {"chi", "pon", "kan", "added_kan"}
+            for meld in self.hand.melds
+        )
+
     def declare_riichi(self) -> None:
         """Declare riichi and pay the 1000 point stick."""
         if self.riichi:

--- a/core/shanten_quiz.py
+++ b/core/shanten_quiz.py
@@ -4,14 +4,27 @@ from __future__ import annotations
 
 from mahjong.shanten import Shanten
 
-from .mahjong_engine import MahjongEngine
-from .models import Tile
+from typing import Any, Type
+
+from .models import Meld, Tile
 from .rules import _tile_to_index
+
+# Optional override used by tests to substitute a dummy engine
+ENGINE_CLASS: Type[Any] | None = None
+
+
+def _get_engine() -> Type[Any]:
+    """Return the MahjongEngine class or test override."""
+    if ENGINE_CLASS is not None:
+        return ENGINE_CLASS
+    from .mahjong_engine import MahjongEngine
+    return MahjongEngine
 
 
 def generate_hand() -> list[Tile]:
     """Return a random 13-tile hand for the quiz."""
-    engine = MahjongEngine()
+    engine_class = _get_engine()
+    engine = engine_class()
     engine.pop_events()  # discard start event
     hand = engine.state.players[0].hand.tiles.copy()
     if len(hand) > 13:
@@ -30,3 +43,16 @@ def calculate_shanten(hand: list[Tile]) -> int:
     """Return the shanten number for ``hand``."""
     counts = _hand_counts(hand)
     return Shanten().calculate_shanten(counts)
+
+
+def is_tenpai(hand_tiles: list[Tile], melds: list[Meld]) -> bool:
+    """Return ``True`` if the combined tiles form a tenpai hand."""
+    counts = [0] * 34
+    for t in hand_tiles:
+        counts[_tile_to_index(t)] += 1
+    for meld in melds:
+        for t in meld.tiles:
+            counts[_tile_to_index(t)] += 1
+    if sum(counts) > 14 and hand_tiles:
+        counts[_tile_to_index(hand_tiles[-1])] -= 1
+    return Shanten().calculate_shanten(counts) == 0

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -55,6 +55,15 @@ def test_end_game_creates_new_state() -> None:
 def test_declare_riichi_api() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     player = state.players[0]
+    player.hand.tiles = [
+        models.Tile("man", 1), models.Tile("man", 1),
+        models.Tile("man", 2), models.Tile("man", 2),
+        models.Tile("man", 3), models.Tile("man", 3),
+        models.Tile("pin", 4), models.Tile("pin", 4),
+        models.Tile("pin", 5), models.Tile("pin", 5),
+        models.Tile("sou", 6), models.Tile("sou", 6),
+        models.Tile("sou", 7), models.Tile("sou", 8),
+    ]
     score = player.score
     api.declare_riichi(0)
     assert player.riichi

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -5,6 +5,18 @@ from core.rules import RuleSet
 from mahjong.hand_calculating.hand_response import HandResponse
 
 
+def _set_tenpai_hand(player) -> None:
+    player.hand.tiles = [
+        Tile("man", 1), Tile("man", 1),
+        Tile("man", 2), Tile("man", 2),
+        Tile("man", 3), Tile("man", 3),
+        Tile("pin", 4), Tile("pin", 4),
+        Tile("pin", 5), Tile("pin", 5),
+        Tile("sou", 6), Tile("sou", 6),
+        Tile("sou", 7), Tile("sou", 8),
+    ]
+
+
 def test_engine_initialization() -> None:
     engine = MahjongEngine()
     assert len(engine.state.players) == 4
@@ -106,6 +118,7 @@ def test_remaining_yama_tiles_property() -> None:
 def test_declare_riichi() -> None:
     engine = MahjongEngine()
     player = engine.state.players[0]
+    _set_tenpai_hand(player)
     start_score = player.score
     engine.declare_riichi(0)
     assert player.riichi
@@ -117,6 +130,7 @@ def test_riichi_event_includes_score_and_sticks() -> None:
     engine = MahjongEngine()
     engine.pop_events()  # clear start_game
     start_score = engine.state.players[0].score
+    _set_tenpai_hand(engine.state.players[0])
     engine.declare_riichi(0)
     events = engine.pop_events()
     riichi_evt = next(e for e in events if e.name == "riichi")
@@ -127,6 +141,7 @@ def test_riichi_event_includes_score_and_sticks() -> None:
 def test_discard_requires_tsumogiri_after_riichi() -> None:
     engine = MahjongEngine()
     player = engine.state.players[0]
+    _set_tenpai_hand(player)
     tile_to_discard = player.hand.tiles[0]
     engine.declare_riichi(0)
     with pytest.raises(ValueError):
@@ -136,6 +151,7 @@ def test_discard_requires_tsumogiri_after_riichi() -> None:
 def test_tsumogiri_allowed_after_riichi() -> None:
     engine = MahjongEngine()
     player = engine.state.players[0]
+    _set_tenpai_hand(player)
     drawn = player.hand.tiles[-1]
     engine.declare_riichi(0)
     engine.discard_tile(0, drawn)
@@ -148,6 +164,7 @@ def test_tsumo_updates_scores_and_emits_event() -> None:
     engine.pop_events()
     tile = Tile("man", 1)
     engine.state.players[0].hand.tiles.append(tile)
+    _set_tenpai_hand(engine.state.players[1])
     engine.declare_riichi(1)
     start_score = engine.state.players[0].score
     loser_start = engine.state.players[1].score
@@ -165,6 +182,7 @@ def test_ron_updates_scores_and_emits_event() -> None:
     engine.pop_events()
     tile = Tile("man", 2)
     engine.state.players[0].hand.tiles.append(tile)
+    _set_tenpai_hand(engine.state.players[2])
     engine.declare_riichi(2)
     engine.state.players[1].hand.tiles.append(Tile("man", 2))
     engine.discard_tile(1, engine.state.players[1].hand.tiles[-1])
@@ -196,6 +214,7 @@ def test_event_log() -> None:
     engine.state.wall.tiles.append(tile)
     drawn = engine.draw_tile(0)
     engine.discard_tile(0, drawn)
+    _set_tenpai_hand(engine.state.players[0])
     engine.declare_riichi(0)
     engine.declare_tsumo(0, drawn)
     engine.end_game()

--- a/tests/core/test_player.py
+++ b/tests/core/test_player.py
@@ -1,4 +1,5 @@
 from core.player import Player
+from core import models
 from core.models import Tile
 
 
@@ -40,3 +41,12 @@ def test_discard_removes_specific_instance() -> None:
 def test_player_has_seat_wind() -> None:
     player = Player(name="Test")
     assert player.seat_wind == "east"
+
+
+def test_has_open_melds() -> None:
+    player = Player(name="Test")
+    assert not player.has_open_melds()
+    player.hand.melds.append(
+        models.Meld(tiles=[models.Tile("man", 1)] * 3, type="pon")
+    )
+    assert player.has_open_melds()

--- a/tests/core/test_riichi_validation.py
+++ b/tests/core/test_riichi_validation.py
@@ -1,0 +1,40 @@
+import pytest
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile, Meld
+
+
+def _tenpai_tiles() -> list[Tile]:
+    return [
+        Tile("man", 1), Tile("man", 1),
+        Tile("man", 2), Tile("man", 2),
+        Tile("man", 3), Tile("man", 3),
+        Tile("pin", 4), Tile("pin", 4),
+        Tile("pin", 5), Tile("pin", 5),
+        Tile("sou", 6), Tile("sou", 6),
+        Tile("sou", 7), Tile("sou", 8),
+    ]
+
+
+def test_riichi_rejected_when_not_tenpai() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    base = [
+        Tile("man", 1), Tile("man", 1), Tile("man", 1),
+        Tile("man", 2), Tile("man", 3), Tile("man", 4),
+        Tile("man", 5), Tile("man", 6), Tile("man", 7),
+        Tile("pin", 1), Tile("pin", 2), Tile("sou", 3), Tile("sou", 4),
+    ]
+    player.hand.tiles = base + [Tile("sou", 6)]
+    with pytest.raises(ValueError):
+        engine.declare_riichi(0)
+
+
+def test_riichi_rejected_with_open_meld() -> None:
+    engine = MahjongEngine()
+    player = engine.state.players[0]
+    player.hand.tiles = _tenpai_tiles()
+    player.hand.melds.append(
+        Meld(tiles=[Tile("man", 1)] * 3, type="pon")
+    )
+    with pytest.raises(ValueError):
+        engine.declare_riichi(0)

--- a/tests/core/test_shanten_quiz.py
+++ b/tests/core/test_shanten_quiz.py
@@ -17,7 +17,7 @@ def test_generate_hand(monkeypatch):
         def pop_events(self) -> None:
             pass
 
-    monkeypatch.setattr(shanten_quiz, "MahjongEngine", DummyEngine)
+    monkeypatch.setattr(shanten_quiz, "ENGINE_CLASS", DummyEngine)
     hand = shanten_quiz.generate_hand()
     assert len(hand) == 13
 
@@ -35,3 +35,15 @@ def test_calculate_shanten(monkeypatch):
     value = shanten_quiz.calculate_shanten(hand)
     assert value == 2
     assert called["counts"][0] == 13
+
+
+def test_is_tenpai_helper(monkeypatch) -> None:
+    class DummyShanten:
+        def calculate_shanten(self, counts: list[int]) -> int:
+            # Return 0 when a specific count is passed to simulate tenpai
+            return 0 if counts[0] == 14 else 1
+
+    monkeypatch.setattr(shanten_quiz, "Shanten", DummyShanten)
+    tiles = [models.Tile("man", 1) for _ in range(14)]
+    assert shanten_quiz.is_tenpai(tiles, [])
+    assert not shanten_quiz.is_tenpai(tiles[:-1], [])

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -144,7 +144,7 @@ def test_additional_action_endpoints() -> None:
         "/games/1/action",
         json={"player_index": 0, "action": "riichi"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 409
 
     draw = client.post(
         "/games/1/action",

--- a/web/server.py
+++ b/web/server.py
@@ -147,7 +147,10 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
         api.call_kan(req.player_index, tiles)
         return {"status": "ok"}
     if req.action == "riichi":
-        api.declare_riichi(req.player_index)
+        try:
+            api.declare_riichi(req.player_index)
+        except ValueError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         return {"status": "ok"}
     if req.action == "tsumo" and req.tile:
         tile = models.Tile(**req.tile)


### PR DESCRIPTION
## Summary
- add `is_tenpai` helper to `shanten_quiz`
- expose `Player.has_open_melds`
- validate riichi declaration using new helper
- update REST server to return error when riichi fails
- add tests for riichi validation and update existing tests
- document riichi requirement in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a44acc8f8832a9a5e310543705535