### PR TITLE
Add GUI shanten check button

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Future work will expand these components.
 - [x] Basic draw control via REST API
 - [x] Automatic draw on turn start
 - [x] Discard tiles via GUI
+- [x] Display hand shanten count via GUI
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
 - [x] Simple tsumogiri AI for automated turns

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -239,3 +239,11 @@ def test_auto_action_endpoint() -> None:
     assert resp.status_code == 200
     tile = resp.json()
     assert "suit" in tile and "value" in tile
+
+
+def test_shanten_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    resp = client.get("/games/1/shanten/0")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "shanten" in data and isinstance(data["shanten"], int)

--- a/tests/web_gui/test_shanten_button.py
+++ b/tests/web_gui/test_shanten_button.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_controls_has_shanten_button() -> None:
+    text = Path('web_gui/Controls.jsx').read_text()
+    assert 'Shanten' in text
+    assert '/games/${gameId}/shanten' in text

--- a/web/server.py
+++ b/web/server.py
@@ -110,6 +110,23 @@ def shanten_quiz_check(req: QuizRequest) -> dict:
     return {"shanten": value}
 
 
+@app.get("/games/{game_id}/shanten/{player_index}")
+def shanten_number(game_id: int, player_index: int) -> dict:
+    """Return the shanten number for ``player_index`` in the current game."""
+
+    _ = game_id  # placeholder for future multi-game support
+    try:
+        state = api.get_state()
+    except AssertionError:
+        raise HTTPException(status_code=404, detail="Game not started")
+    try:
+        tiles = state.players[player_index].hand.tiles
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Player not found")
+    value = api.calculate_shanten(tiles)
+    return {"shanten": value}
+
+
 class ActionRequest(BaseModel):
     """Request body for game actions."""
 

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -25,6 +25,22 @@ export default function Controls({
     }
   }
 
+  async function shanten() {
+    try {
+      const resp = await fetch(
+        `${server.replace(/\/$/, '')}/games/${gameId}/shanten/${playerIndex}`
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        setMessage(`Shanten: ${data.shanten}`);
+      } else {
+        setMessage(`Error ${resp.status}`);
+      }
+    } catch {
+      setMessage('Server unreachable');
+    }
+  }
+
   function chi() {
     simple('chi', { tiles: [{ suit: 'man', value: 1 }, { suit: 'man', value: 2 }, { suit: 'man', value: 3 }] });
   }
@@ -65,6 +81,7 @@ export default function Controls({
       <Button onClick={tsumo} disabled={!isAllowed('tsumo')}>Tsumo</Button>
       <Button onClick={ron} disabled={!isAllowed('ron')}>Ron</Button>
       <Button onClick={skip} disabled={!isAllowed('skip')}>Skip</Button>
+      <Button onClick={shanten}>Shanten</Button>
       {message && <div className="message">{message}</div>}
     </div>
   );


### PR DESCRIPTION
## Summary
- add REST endpoint to fetch a player's shanten number
- show a Shanten button in the GUI controls
- document GUI shanten feature in README
- test new Controls button and endpoint

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a470900a0832ab19160d874833979