### PR TITLE
Fix auto draw when everyone passes

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -459,6 +459,12 @@ class MahjongEngine:
             if player_index in self.state.waiting_for_claims:
                 self.state.waiting_for_claims.remove(player_index)
                 self._emit("skip", {"player_index": player_index})
+                if not self.state.waiting_for_claims:
+                    # All players have passed on the discard; draw for next player
+                    next_player = self.state.current_player
+                    self.draw_tile(next_player)
+                    # draw_tile advances current_player; reset to drawer
+                    self.state.current_player = next_player
             return
         if player_index != self.state.current_player:
             return
@@ -466,6 +472,10 @@ class MahjongEngine:
             self.state.players
         )
         self._emit("skip", {"player_index": player_index})
+        new_player = self.state.current_player
+        self.draw_tile(new_player)
+        # draw_tile advances current_player; reset to drawer
+        self.state.current_player = new_player
 
     def advance_hand(self, winner_index: int | None = None) -> None:
         """Move to the next hand and handle dealer rotation."""

--- a/core/tests/test_skip_autodraw.py
+++ b/core/tests/test_skip_autodraw.py
@@ -1,0 +1,17 @@
+from core.mahjong_engine import MahjongEngine
+
+
+def test_auto_draw_after_all_players_skip() -> None:
+    engine = MahjongEngine()
+    discarder = engine.state.dealer
+    next_player = (discarder + 1) % 4
+    player = engine.state.players[discarder]
+    tile = player.hand.tiles[-1]
+    engine.discard_tile(discarder, tile)
+    # First player (next player) skips claim
+    engine.skip(next_player)
+    # Remaining players skip
+    engine.skip((discarder + 2) % 4)
+    engine.skip((discarder + 3) % 4)
+    assert len(engine.state.players[next_player].hand.tiles) == 14
+    assert engine.state.current_player == next_player


### PR DESCRIPTION
## Summary
- draw next tile when all players skip a discard
- ensure skipping your turn draws for the next player
- test auto draw after last skip

## Testing
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a49c09b50832abe76d313b8f4fd4c