### PR TITLE
Add win result modal to GUI and pause AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Future work will expand these components.
 - [x] ryukyoku detection
 - [x] Noten penalty scoring on draws
 - [x] Draw result modal in GUI
+- [x] Win result modal in GUI
 - [x] standard wall initialization
 - [x] dead wall & dora indicator tracking
 - [x] wanpai separation and yama remaining count

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -7,6 +7,21 @@ from .wall import Wall
 from .rules import RuleSet, StandardRuleSet, _tile_to_index
 from mahjong.shanten import Shanten
 from mahjong.hand_calculating.hand_response import HandResponse
+from dataclasses import asdict
+from typing import Any
+
+
+def _hand_response_dict(resp: HandResponse) -> dict[str, Any]:
+    """Return a JSON serializable representation of ``resp``."""
+    return {
+        "han": resp.han,
+        "fu": resp.fu,
+        "cost": resp.cost,
+        "yaku": [y.name for y in resp.yaku] if resp.yaku else None,
+        "fu_details": resp.fu_details,
+        "error": resp.error,
+        "is_open_hand": resp.is_open_hand,
+    }
 
 
 class MahjongEngine:
@@ -422,7 +437,9 @@ class MahjongEngine:
             "tsumo",
             {
                 "player_index": player_index,
-                "result": result,
+                "win_tile": win_tile,
+                "hand": asdict(player.hand),
+                "result": _hand_response_dict(result),
                 "scores": scores,
             },
         )
@@ -446,7 +463,13 @@ class MahjongEngine:
         scores = [p.score for p in self.state.players]
         self._emit(
             "ron",
-            {"player_index": player_index, "result": result, "scores": scores},
+            {
+                "player_index": player_index,
+                "win_tile": win_tile,
+                "hand": asdict(player.hand),
+                "result": _hand_response_dict(result),
+                "scores": scores,
+            },
         )
         self.state.waiting_for_claims = []
         self.advance_hand(player_index)

--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -84,3 +84,27 @@ def test_riichi_event_updates_score_and_sticks() -> None:
     )
     output = run_node(code)
     assert output == '24000:1:true'
+
+
+def test_tsumo_sets_result_and_scores() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {players:[{score:25000},{score:25000},{score:25000},{score:25000}]};\n"
+        "const evt = {name:'tsumo', payload:{player_index:0, scores:[26000,24000,24000,24000], result:{han:1,fu:30,cost:{total:1000}}, win_tile:{suit:'man',value:1}, hand:{tiles:[],melds:[]}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.result.type + ':' + newState.players[0].score);"
+    )
+    output = run_node(code)
+    assert output == 'tsumo:26000'
+
+
+def test_ron_sets_result_and_scores() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {players:[{score:25000},{score:25000},{score:25000},{score:25000}]};\n"
+        "const evt = {name:'ron', payload:{player_index:0, scores:[33000,17000,25000,25000], result:{han:2,fu:40,cost:{total:8000}}, win_tile:{suit:'pin',value:5}, hand:{tiles:[],melds:[]}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.result.type + ':' + newState.players[0].score);"
+    )
+    output = run_node(code)
+    assert output == 'ron:33000'

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -34,4 +34,19 @@ describe('GameBoard auto draw', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({ player_index: 0, action: 'auto', ai_type: 'simple' });
   });
+
+  it('does not auto play when result is shown', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = { ...mockState(0), result: { type: 'ryukyoku' } };
+    const { rerender } = render(
+      <GameBoard state={state} server="http://s" gameId="1" />,
+    );
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+    state.result = null;
+    state.current_player = 1;
+    rerender(<GameBoard state={state} server="http://s" gameId="1" />);
+    await Promise.resolve();
+  });
 });

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -57,6 +57,7 @@ export default function GameBoard({
 
   useEffect(() => {
     const current = state?.current_player;
+    if (result || state?.result) return;
     if (!gameId || current == null || current === prevPlayer.current) return;
     prevPlayer.current = current;
     const tiles = state?.players?.[current]?.hand?.tiles ?? [];
@@ -70,7 +71,7 @@ export default function GameBoard({
         body: JSON.stringify(body),
       }).catch(() => {});
     }
-  }, [state?.current_player, gameId, server, state?.players, aiPlayers, aiTypes]);
+  }, [state?.current_player, gameId, server, state?.players, aiPlayers, aiTypes, result]);
 
   useEffect(() => {
     if (state?.result) {

--- a/web_gui/ResultModal.jsx
+++ b/web_gui/ResultModal.jsx
@@ -1,22 +1,50 @@
 import React from 'react';
+import Hand from './Hand.jsx';
+import { tileToEmoji } from './tileUtils.js';
 
 export default function ResultModal({ result, onClose, onCopyLog }) {
   if (!result) return null;
-  const { scores, tenpai, reason } = result;
+  const { type, scores } = result;
   return (
     <div className="modal is-active">
       <div className="modal-background" onClick={onClose}></div>
       <div className="modal-content">
         <div className="box">
-          <p>{reason === 'wall_empty' ? 'Exhaustive draw' : 'Draw'}</p>
-          {Array.isArray(scores) && (
-            <ul>
-              {scores.map((s, i) => (
-                <li key={i}>
-                  Player {i + 1}: {s} {tenpai?.[i] ? '(tenpai)' : ''}
-                </li>
-              ))}
-            </ul>
+          {type === 'ryukyoku' ? (
+            <>
+              <p>{result.reason === 'wall_empty' ? 'Exhaustive draw' : 'Draw'}</p>
+              {Array.isArray(scores) && (
+                <ul>
+                  {scores.map((s, i) => (
+                    <li key={i}>
+                      Player {i + 1}: {s} {result.tenpai?.[i] ? '(tenpai)' : ''}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : (
+            <>
+              <p>
+                Player {result.player_index + 1}{' '}
+                {type === 'tsumo' ? 'wins by tsumo' : 'wins by ron'}{' '}
+                {result.win_tile ? tileToEmoji(result.win_tile) : ''}
+              </p>
+              {result.hand && <Hand tiles={result.hand.tiles} />}
+              {result.result && (
+                <p>
+                  {result.result.han} han {result.result.fu} fu –{' '}
+                  {result.result.cost?.total ?? 0} points
+                </p>
+              )}
+              {Array.isArray(scores) && (
+                <ul>
+                  {scores.map((s, i) => (
+                    <li key={i}>Player {i + 1}: {s}</li>
+                  ))}
+                </ul>
+              )}
+            </>
           )}
           {onCopyLog && (
             <button className="button mt-2" onClick={onCopyLog}>
@@ -25,7 +53,11 @@ export default function ResultModal({ result, onClose, onCopyLog }) {
           )}
         </div>
       </div>
-      <button className="modal-close is-large" aria-label="close" onClick={onClose}></button>
+      <button
+        className="modal-close is-large"
+        aria-label="close"
+        onClick={onClose}
+      ></button>
     </div>
   );
 }

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -62,7 +62,12 @@ export function applyEvent(state, event) {
     }
     case 'tsumo':
     case 'ron': {
-      newState.result = event.payload;
+      if (Array.isArray(event.payload.scores)) {
+        newState.players.forEach((p, i) => {
+          if (p) p.score = event.payload.scores[i];
+        });
+      }
+      newState.result = { type: event.name, ...event.payload };
       newState.waiting_for_claims = [];
       break;
     }


### PR DESCRIPTION
## Summary
- show win results with scoring details in GUI
- stop AI auto turns while result modal is visible
- include winning hand data in tsumo/ron events
- handle tsumo/ron events in applyEvent
- update tests for new behavior

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `.venv/bin/python -m build core`
- `.venv/bin/python -m build cli`
- `.venv/bin/flake8`
- `.venv/bin/mypy core web cli`
- `.venv/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`

------
https://chatgpt.com/codex/tasks/task_e_686a4920a28c832aae1b3e35fdeeb950