### PR TITLE
Improve simple AI with shanten-based discard logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Future work will expand these components.
 - [x] Display hand shanten count via GUI
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
-- [x] Simple tsumogiri AI for automated turns
+- [x] Simple shanten-based AI for automated turns
 - [x] Toggle AI per player from GUI
 - [x] AI type selection framework (currently only 'simple')
 - [x] Players 2-4 use AI by default in GUI
@@ -149,8 +149,8 @@ Future work will expand these components.
  - [x] **10. Connect GUI state** – update React components to fetch the initial game,
   handle WebSocket events and send player actions.
  - [ ] **11. Provide a mock AI** – run a simple MJAI-compatible process through the
-  adapter with an interface that later swaps in a stronger engine. A minimal
-  tsumogiri AI exists for local automation.
+  adapter with an interface that later swaps in a stronger engine. A simple
+  shanten-based AI exists for local automation.
 - [ ] **12. Write end-to-end tests** – cover REST routes, WebSocket updates and basic
   GUI interactions.
  - [x] **13. Add `何切る問題` mode** – offer a practice scenario with a random seat wind

--- a/core/ai.py
+++ b/core/ai.py
@@ -6,10 +6,10 @@ from typing import Callable, Dict
 
 from .mahjong_engine import MahjongEngine
 from .models import Tile
-from .simple_ai import tsumogiri_turn
+from .simple_ai import smart_turn
 
 AI_REGISTRY: Dict[str, Callable[[MahjongEngine, int], Tile]] = {
-    "simple": tsumogiri_turn,
+    "simple": smart_turn,
 }
 
 

--- a/core/simple_ai.py
+++ b/core/simple_ai.py
@@ -1,24 +1,155 @@
-"""Very basic AI helpers."""
+"""Very basic AI helpers.
+
+This module currently provides a simple shanten based AI used by the
+``auto_play_turn`` API helper.  The AI tries to keep the hand close to
+tenpai by discarding tiles that do not increase the shanten number.  It
+also calls ``chi`` or ``pon`` when doing so will move the hand closer to
+tenpai.
+"""
 from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
 from .models import Tile
+from .rules import _tile_to_index
+from mahjong.shanten import Shanten
+import random
 
 
-def tsumogiri_turn(engine: MahjongEngine, player_index: int) -> Tile:
-    """Play a full turn by discarding the drawn tile.
+def _hand_shanten(tiles: list[Tile]) -> int:
+    """Return shanten number for ``tiles``."""
 
-    If the player has already drawn (hand size >= 14), simply discard the last
-    tile instead of drawing again. This allows enabling AI mid-turn.
-    """
+    counts = [0] * 34
+    for t in tiles:
+        counts[_tile_to_index(t)] += 1
+    return Shanten().calculate_shanten(counts)
 
-    player = engine.state.players[player_index]
-    if len(player.hand.tiles) >= 14:
-        tile = player.hand.tiles[-1]
-        engine.discard_tile(player_index, tile)
-        return tile
 
-    tile = engine.draw_tile(player_index)
-    if tile in player.hand.tiles:
-        engine.discard_tile(player_index, tile)
-    return tile
+def _choose_discard(tiles: list[Tile]) -> Tile:
+    """Return a tile to discard that keeps shanten minimal."""
+
+    counts = [0] * 34
+    for t in tiles:
+        counts[_tile_to_index(t)] += 1
+    base = Shanten().calculate_shanten(counts)
+    keep_shanten: list[Tile] = []
+    best_tiles: list[Tile] = []
+    best_value = 8
+
+    for tile in tiles:
+        idx = _tile_to_index(tile)
+        counts[idx] -= 1
+        value = Shanten().calculate_shanten(counts)
+        counts[idx] += 1
+        if value == base:
+            keep_shanten.append(tile)
+        if value < best_value:
+            best_value = value
+            best_tiles = [tile]
+        elif value == best_value:
+            best_tiles.append(tile)
+
+    if keep_shanten:
+        return random.choice(keep_shanten)
+    if best_tiles:
+        return random.choice(best_tiles)
+    return random.choice(tiles)
+
+
+def _maybe_call_meld(engine: MahjongEngine, player_index: int) -> bool:
+    """Attempt to chi/pon the last discard if it improves shanten."""
+
+    state = engine.state
+    if player_index not in state.waiting_for_claims:
+        return False
+
+    last_tile = state.last_discard
+    last_player = state.last_discard_player
+    if last_tile is None or last_player is None or player_index == last_player:
+        return False
+
+    player = state.players[player_index]
+    base = _hand_shanten(player.hand.tiles)
+    best_action: tuple[str, list[Tile]] | None = None
+    best_value = base
+
+    # Pon check
+    count = sum(
+        1 for t in player.hand.tiles if t.suit == last_tile.suit and t.value == last_tile.value
+    )
+    if count >= 2:
+        new_hand = player.hand.tiles.copy()
+        removed = 0
+        for i in range(len(new_hand) - 1, -1, -1):
+            t = new_hand[i]
+            if t.suit == last_tile.suit and t.value == last_tile.value:
+                new_hand.pop(i)
+                removed += 1
+                if removed == 2:
+                    break
+        shanten = _hand_shanten(new_hand)
+        if shanten < best_value:
+            best_value = shanten
+            tiles = [Tile(last_tile.suit, last_tile.value) for _ in range(3)]
+            best_action = ("pon", tiles)
+
+    # Chi check
+    if (
+        last_tile.suit in {"man", "pin", "sou"}
+        and (last_player + 1) % len(state.players) == player_index
+    ):
+        for offset in (-2, -1, 0):
+            start = last_tile.value + offset
+            seq = [start, start + 1, start + 2]
+            if min(seq) < 1 or max(seq) > 9:
+                continue
+            needed = [v for v in seq if v != last_tile.value]
+            if all(
+                any(t.suit == last_tile.suit and t.value == v for t in player.hand.tiles)
+                for v in needed
+            ):
+                new_hand = player.hand.tiles.copy()
+                for v in needed:
+                    for i, t in enumerate(new_hand):
+                        if t.suit == last_tile.suit and t.value == v:
+                            new_hand.pop(i)
+                            break
+                shanten = _hand_shanten(new_hand)
+                if shanten < best_value:
+                    best_value = shanten
+                    tiles = [Tile(last_tile.suit, x) for x in seq]
+                    best_action = ("chi", tiles)
+
+    if best_action is None:
+        return False
+
+    if best_action[0] == "pon":
+        engine.call_pon(player_index, best_action[1])
+    else:
+        engine.call_chi(player_index, best_action[1])
+    return True
+
+
+def smart_turn(engine: MahjongEngine, player_index: int) -> Tile:
+    """Play a full turn using a shanten based heuristic."""
+
+    state = engine.state
+
+    if player_index in state.waiting_for_claims:
+        if _maybe_call_meld(engine, player_index):
+            # After calling, the player must discard
+            player = state.players[player_index]
+            discard = _choose_discard(player.hand.tiles)
+            engine.discard_tile(player_index, discard)
+            return discard
+        engine.skip(player_index)
+        assert state.last_discard is not None
+        return state.last_discard
+
+    player = state.players[player_index]
+
+    if len(player.hand.tiles) < 14:
+        engine.draw_tile(player_index)
+
+    discard = _choose_discard(player.hand.tiles)
+    engine.discard_tile(player_index, discard)
+    return discard

--- a/core/tests/test_simple_ai.py
+++ b/core/tests/test_simple_ai.py
@@ -1,24 +1,45 @@
 from core.mahjong_engine import MahjongEngine
-from core.simple_ai import tsumogiri_turn
+from core.simple_ai import smart_turn
+from core.shanten_quiz import calculate_shanten
+from core.models import Tile
 
 
-def test_tsumogiri_turn_discards_when_already_drawn() -> None:
+HAND_14 = [
+    Tile("man", 1), Tile("man", 2), Tile("man", 3),
+    Tile("pin", 1), Tile("pin", 2), Tile("pin", 3),
+    Tile("sou", 1), Tile("sou", 2), Tile("sou", 3),
+    Tile("man", 7), Tile("man", 8), Tile("man", 9),
+    Tile("pin", 9), Tile("sou", 9),
+]
+
+HAND_13 = HAND_14[:-1]
+
+
+def test_smart_turn_discards_without_increasing_shanten() -> None:
     engine = MahjongEngine()
     dealer = engine.state.dealer
     player = engine.state.players[dealer]
-    assert len(player.hand.tiles) == 14
-    last_tile = player.hand.tiles[-1]
-    tsumogiri_turn(engine, dealer)
-    assert engine.state.current_player == (dealer + 1) % 4
-    assert player.river[-1] == last_tile
+    player.hand.tiles = HAND_14.copy()
+    before = calculate_shanten(player.hand.tiles)
+
+    discarded = smart_turn(engine, dealer)
+
+    after = calculate_shanten(player.hand.tiles)
+    assert after <= before
+    assert discarded == player.river[-1]
     assert len(player.hand.tiles) == 13
 
 
-def test_tsumogiri_turn_draws_when_needed() -> None:
+def test_smart_turn_draws_when_needed() -> None:
     engine = MahjongEngine()
-    player_index = (engine.state.dealer + 1) % 4
-    player = engine.state.players[player_index]
+    idx = (engine.state.dealer + 1) % 4
+    player = engine.state.players[idx]
+    player.hand.tiles = HAND_13.copy()
+    before = calculate_shanten(player.hand.tiles)
+
+    discarded = smart_turn(engine, idx)
+
+    after = calculate_shanten(player.hand.tiles)
+    assert after <= before
+    assert discarded == player.river[-1]
     assert len(player.hand.tiles) == 13
-    tsumogiri_turn(engine, player_index)
-    assert len(player.hand.tiles) == 13
-    assert len(player.river) == 1


### PR DESCRIPTION
## Summary
- enhance simple AI so it discards tiles that keep shanten value
- allow the AI to chi/pon when it reduces shanten
- register the new behaviour in AI registry
- test new smart_turn implementation and update API tests
- document improved AI in README

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a4a646f18832aa24b2d9d430904ca