### PR TITLE
Show spacing only for drawn tile

### DIFF
--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -92,6 +92,12 @@ export default function GameBoard({
 
   const defaultHand = Array(13).fill('🀫');
 
+  function hasDrawnTile(player, index) {
+    if (!player || state?.current_player !== index) return false;
+    const count = player.hand?.tiles?.length ?? 0;
+    return count % 3 === 2;
+  }
+
   function concealedHand(p) {
     const count = p?.hand?.tiles?.length ?? 13;
     return Array(count).fill('🀫');
@@ -109,6 +115,11 @@ export default function GameBoard({
       ? sortTilesExceptLast(southTiles)
       : southTiles
     : defaultHand;
+
+  const northDrawn = hasDrawnTile(north, 2);
+  const westDrawn = hasDrawnTile(west, 1);
+  const eastDrawn = hasDrawnTile(east, 3);
+  const southDrawn = hasDrawnTile(south, 0);
 
   const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
   const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
@@ -150,6 +161,7 @@ export default function GameBoard({
         seat="north"
         player={north}
         hand={northHand}
+        drawn={northDrawn}
         melds={northMelds}
         riverTiles={(north?.river ?? []).map(tileLabel)}
         state={state}
@@ -164,6 +176,7 @@ export default function GameBoard({
         seat="west"
         player={west}
         hand={westHand}
+        drawn={westDrawn}
         melds={westMelds}
         riverTiles={(west?.river ?? []).map(tileLabel)}
         state={state}
@@ -178,6 +191,7 @@ export default function GameBoard({
         seat="east"
         player={east}
         hand={eastHand}
+        drawn={eastDrawn}
         melds={eastMelds}
         riverTiles={(east?.river ?? []).map(tileLabel)}
         state={state}
@@ -192,6 +206,7 @@ export default function GameBoard({
         seat="south"
         player={south}
         hand={southHand}
+        drawn={southDrawn}
         melds={southMelds}
         riverTiles={(south?.river ?? []).map(tileLabel)}
         onDiscard={

--- a/web_gui/Hand.jsx
+++ b/web_gui/Hand.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { tileToEmoji, tileDescription } from './tileUtils.js';
 
-export default function Hand({ tiles = [], onDiscard }) {
+export default function Hand({ tiles = [], onDiscard, drawn = false }) {
   return (
     <div className="hand">
       {tiles.map((t, i) => {
         const label = typeof t === 'string' ? t : tileToEmoji(t);
         const alt = typeof t === 'string' ? t : tileDescription(t);
-        const cls = `mj-tile${i === tiles.length - 1 ? ' drawn-tile' : ''}`;
+        const cls = `mj-tile${drawn && i === tiles.length - 1 ? ' drawn-tile' : ''}`;
         return onDiscard ? (
           <button
             key={i}

--- a/web_gui/Hand.test.jsx
+++ b/web_gui/Hand.test.jsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Hand from './Hand.jsx';
+
+function renderTiles(drawn) {
+  const tiles = ['A', 'B', 'C'];
+  const { container } = render(<Hand tiles={tiles} drawn={drawn} />);
+  return container.querySelectorAll('.mj-tile');
+}
+
+describe('Hand drawn tile spacing', () => {
+  it('adds drawn-tile class when drawn is true', () => {
+    const tiles = renderTiles(true);
+    expect(tiles[tiles.length - 1].className).toContain('drawn-tile');
+  });
+
+  it('omits drawn-tile class when drawn is false', () => {
+    const tiles = renderTiles(false);
+    expect(tiles[tiles.length - 1].className).not.toContain('drawn-tile');
+  });
+});

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -14,6 +14,7 @@ export default function PlayerPanel({
   melds,
   riverTiles,
   onDiscard,
+  drawn = false,
   server,
   gameId,
   playerIndex,
@@ -42,7 +43,7 @@ export default function PlayerPanel({
         style={{ marginBottom: 'calc(var(--tile-font-size) * 0.8)' }}
       />
       <div className="hand-with-melds" style={{ position: 'relative', zIndex: 1 }}>
-        <Hand tiles={hand} onDiscard={onDiscard} />
+        <Hand tiles={hand} onDiscard={onDiscard} drawn={drawn} />
         <MeldArea melds={melds} />
       </div>
       <Controls

--- a/web_gui/Practice.jsx
+++ b/web_gui/Practice.jsx
@@ -46,12 +46,13 @@ export default function Practice({ server, sortHand = true }) {
   }
 
   const tiles = sortHand ? sortTilesExceptLast(problem.hand) : problem.hand;
+  const drawn = problem.hand.length % 3 === 2;
 
   return (
     <div className="practice">
       <div>Seat wind: {problem.seat_wind}</div>
       <div> Dora indicator: {tileToEmoji(problem.dora_indicator)} </div>
-      <Hand tiles={tiles} onDiscard={choose} />
+      <Hand tiles={tiles} onDiscard={choose} drawn={drawn} />
       {chosen && (
         <div>You discarded {tileToEmoji(chosen)}</div>
       )}


### PR DESCRIPTION
## Summary
- only show spacing after a player's hand when a tile has just been drawn
- pass drawn tile info through player and board components
- support drawn tile in practice view
- add unit tests for new `drawn` prop

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686a4b2bc774832aa47e3cd8eba3f56b