### PR TITLE
Improve simple AI with shanten-based strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Future work will expand these components.
 - [x] Display hand shanten count via GUI
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
-- [x] Simple tsumogiri AI for automated turns
+- [x] Simple shanten-based AI for automated turns (discards tiles that keep shanten and calls pon/chi when it improves the hand)
 - [x] Toggle AI per player from GUI
 - [x] AI type selection framework (currently only 'simple')
 - [x] Players 2-4 use AI by default in GUI

--- a/core/ai.py
+++ b/core/ai.py
@@ -6,10 +6,10 @@ from typing import Callable, Dict
 
 from .mahjong_engine import MahjongEngine
 from .models import Tile
-from .simple_ai import tsumogiri_turn
+from .simple_ai import shanten_turn
 
 AI_REGISTRY: Dict[str, Callable[[MahjongEngine, int], Tile]] = {
-    "simple": tsumogiri_turn,
+    "simple": shanten_turn,
 }
 
 

--- a/core/api.py
+++ b/core/api.py
@@ -97,6 +97,11 @@ def auto_play_turn(player_index: int | None = None, ai_type: str = "simple") -> 
     if ai is None:
         raise ValueError(f"Unknown ai_type: {ai_type}")
     for p in list(_engine.state.waiting_for_claims):
+        if ai_type == "simple":
+            from .simple_ai import claim_meld
+
+            if claim_meld(_engine, p):
+                continue
         _engine.skip(p)
     return ai(_engine, idx)
 

--- a/core/shanten_quiz.py
+++ b/core/shanten_quiz.py
@@ -53,6 +53,9 @@ def is_tenpai(hand_tiles: list[Tile], melds: list[Meld]) -> bool:
     for meld in melds:
         for t in meld.tiles:
             counts[_tile_to_index(t)] += 1
-    if sum(counts) > 14 and hand_tiles:
-        counts[_tile_to_index(hand_tiles[-1])] -= 1
+    total = sum(counts)
+    if total > 14 and hand_tiles:
+        excess = total - 14
+        for _ in range(excess):
+            counts[_tile_to_index(hand_tiles[-1])] -= 1
     return Shanten().calculate_shanten(counts) == 0

--- a/core/simple_ai.py
+++ b/core/simple_ai.py
@@ -1,8 +1,14 @@
 """Very basic AI helpers."""
 from __future__ import annotations
 
+import random
+from typing import Iterable
+
+from mahjong.shanten import Shanten
+
 from .mahjong_engine import MahjongEngine
 from .models import Tile
+from .rules import _tile_to_index
 
 
 def tsumogiri_turn(engine: MahjongEngine, player_index: int) -> Tile:
@@ -22,3 +28,108 @@ def tsumogiri_turn(engine: MahjongEngine, player_index: int) -> Tile:
     if tile in player.hand.tiles:
         engine.discard_tile(player_index, tile)
     return tile
+
+
+def _hand_counts(hand: Iterable[Tile]) -> list[int]:
+    counts = [0] * 34
+    for tile in hand:
+        counts[_tile_to_index(tile)] += 1
+    return counts
+
+
+def suggest_discard(hand: list[Tile]) -> Tile:
+    """Return a discard that keeps the hand close to tenpai."""
+
+    counts = _hand_counts(hand)
+    shanten = Shanten()
+    best_tiles: list[Tile] = []
+    best_value = 8  # higher than any real shanten number
+
+    for tile in hand:
+        idx = _tile_to_index(tile)
+        counts[idx] -= 1
+        value = shanten.calculate_shanten(counts)
+        counts[idx] += 1
+        if value < best_value:
+            best_value = value
+            best_tiles = [tile]
+        elif value == best_value:
+            best_tiles.append(tile)
+
+    return random.choice(best_tiles) if best_tiles else random.choice(hand)
+
+
+def shanten_turn(engine: MahjongEngine, player_index: int) -> Tile:
+    """Play a turn by discarding a shanten-neutral tile."""
+
+    player = engine.state.players[player_index]
+    if len(player.hand.tiles) < 14:
+        engine.draw_tile(player_index)
+    tile = suggest_discard(player.hand.tiles)
+    engine.discard_tile(player_index, tile)
+    return tile
+
+
+def _calculate_shanten(tiles: Iterable[Tile]) -> int:
+    counts = _hand_counts(list(tiles))
+    return Shanten().calculate_shanten(counts)
+
+
+def claim_meld(engine: MahjongEngine, player_index: int) -> bool:
+    """Claim pon/chi if it improves shanten. Return True if meld was called."""
+
+    state = engine.state
+    last_tile = state.last_discard
+    last_player = state.last_discard_player
+    if last_tile is None or last_player is None:
+        return False
+
+    player = state.players[player_index]
+    current = _calculate_shanten(player.hand.tiles)
+    best_action: tuple[str, list[Tile]] | None = None
+    best_value = current
+
+    # Pon candidate
+    same = [t for t in player.hand.tiles if t.suit == last_tile.suit and t.value == last_tile.value]
+    if len(same) >= 2:
+        remaining = player.hand.tiles.copy()
+        remaining.remove(same[0])
+        remaining.remove(same[1])
+        value = _calculate_shanten(remaining)
+        if value < best_value:
+            best_value = value
+            best_action = ("pon", [same[0], same[1], last_tile])
+
+    # Chi candidate
+    if (last_player + 1) % len(state.players) == player_index and last_tile.suit in {"man", "pin", "sou"}:
+        for delta1, delta2 in [(-2, -1), (-1, 1), (1, 2)]:
+            v1 = last_tile.value + delta1
+            v2 = last_tile.value + delta2
+            if not (1 <= v1 <= 9 and 1 <= v2 <= 9):
+                continue
+            needed: list[Tile] = []
+            for v in (v1, v2):
+                found = next((t for t in player.hand.tiles if t.suit == last_tile.suit and t.value == v and t not in needed), None)
+                if found is None:
+                    needed = []
+                    break
+                needed.append(found)
+            if len(needed) == 2:
+                remaining = player.hand.tiles.copy()
+                remaining.remove(needed[0])
+                remaining.remove(needed[1])
+                value = _calculate_shanten(remaining)
+                if value < best_value:
+                    best_value = value
+                    meld_tiles = [*needed, last_tile]
+                    meld_tiles.sort(key=lambda t: t.value)
+                    best_action = ("chi", meld_tiles)
+
+    if best_action is None or best_value >= current:
+        return False
+
+    if best_action[0] == "pon":
+        engine.call_pon(player_index, best_action[1])
+    else:
+        engine.call_chi(player_index, best_action[1])
+    return True

--- a/core/tests/test_simple_ai.py
+++ b/core/tests/test_simple_ai.py
@@ -1,24 +1,41 @@
 from core.mahjong_engine import MahjongEngine
-from core.simple_ai import tsumogiri_turn
+from core.simple_ai import shanten_turn, claim_meld
+from core.models import Tile
+import random
 
 
-def test_tsumogiri_turn_discards_when_already_drawn() -> None:
+def test_shanten_turn_discards_best_tile(monkeypatch) -> None:
     engine = MahjongEngine()
     dealer = engine.state.dealer
     player = engine.state.players[dealer]
-    assert len(player.hand.tiles) == 14
-    last_tile = player.hand.tiles[-1]
-    tsumogiri_turn(engine, dealer)
-    assert engine.state.current_player == (dealer + 1) % 4
-    assert player.river[-1] == last_tile
+    player.hand.tiles = [
+        Tile("man", 1), Tile("man", 2), Tile("man", 3),
+        Tile("man", 4), Tile("man", 5), Tile("man", 6),
+        Tile("man", 7), Tile("man", 8), Tile("man", 9),
+        Tile("pin", 1), Tile("pin", 2), Tile("pin", 3),
+        Tile("sou", 7), Tile("sou", 9),
+    ]
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    discarded = shanten_turn(engine, dealer)
+    assert discarded.suit == "sou" and discarded.value == 7
     assert len(player.hand.tiles) == 13
+    assert player.river[-1] == discarded
 
 
-def test_tsumogiri_turn_draws_when_needed() -> None:
+def test_claim_meld_improves_shanten() -> None:
     engine = MahjongEngine()
-    player_index = (engine.state.dealer + 1) % 4
-    player = engine.state.players[player_index]
-    assert len(player.hand.tiles) == 13
-    tsumogiri_turn(engine, player_index)
-    assert len(player.hand.tiles) == 13
-    assert len(player.river) == 1
+    discarder = engine.state.players[0]
+    caller = engine.state.players[1]
+    tile = Tile("man", 1)
+    discarder.hand.tiles = [tile]
+    caller.hand.tiles = [
+        Tile("man", 1), Tile("man", 1), Tile("man", 2), Tile("man", 3),
+        Tile("man", 3), Tile("man", 4), Tile("man", 5), Tile("man", 5),
+        Tile("man", 6), Tile("man", 7), Tile("man", 7), Tile("pin", 9), Tile("pin", 9),
+    ]
+    engine.discard_tile(0, tile)
+    called = claim_meld(engine, 1)
+    assert called
+    assert len(caller.hand.melds) == 1
+    assert caller.hand.melds[0].type == "pon"
+    assert engine.state.current_player == 1

--- a/tests/core/test_simple_ai.py
+++ b/tests/core/test_simple_ai.py
@@ -1,18 +1,24 @@
 from core import api, models
+import random
 
 
-def test_auto_play_turn_discards_drawn_tile() -> None:
+def test_auto_play_turn_discards_best_tile(monkeypatch) -> None:
     state = api.start_game(["A", "B", "C", "D"])
-    assert state.wall is not None
-    tile = models.Tile(suit="man", value=9)
-    state.wall.tiles.append(tile)
     player = state.current_player
-    hand_len = len(state.players[player].hand.tiles)
+    actor = state.players[player]
+    actor.hand.tiles = [
+        models.Tile("man", 1), models.Tile("man", 2), models.Tile("man", 3),
+        models.Tile("man", 4), models.Tile("man", 5), models.Tile("man", 6),
+        models.Tile("man", 7), models.Tile("man", 8), models.Tile("man", 9),
+        models.Tile("pin", 1), models.Tile("pin", 2), models.Tile("pin", 3),
+        models.Tile("sou", 7), models.Tile("sou", 9),
+    ]
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
     discarded = api.auto_play_turn()
 
-    # With a full hand, the AI should discard without drawing
-    assert discarded == state.players[player].river[-1]
-    assert len(state.players[player].hand.tiles) == hand_len - 1
+    assert discarded.suit == "sou" and discarded.value == 7
+    assert discarded == actor.river[-1]
+    assert len(actor.hand.tiles) == 13
     assert state.current_player == (player + 1) % 4
 


### PR DESCRIPTION
## Summary
- enhance simple AI with shanten-based discard logic
- allow AI to call pon/chi when it improves shanten
- expose new AI behaviour in API
- handle meld claims safely in shanten check
- update README implementation status
- cover new behaviour with unit tests

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a4cf878dc832a9411d166b88807e0