### PR TITLE
Add allowed action API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Future work will expand these components.
 - [x] Riipai (sort hand) button in GUI (enabled by default and used in Practice and Shanten Quiz)
 - [x] Accessible tile buttons with aria-labels
 - [x] Basic draw control via REST API
+- [x] Allowed actions API and GUI integration
 - [x] Automatic draw on turn start
 - [x] Discard tiles via GUI
 - [x] Display hand shanten count via GUI
@@ -108,6 +109,7 @@ Future work will expand these components.
 - [x] declare_ron
 - [x] declare_riichi
 - [x] skip
+- [x] get_allowed_actions
 - [x] end_game
 - [x] start_kyoku
 - [x] ryukyoku detection

--- a/core/api.py
+++ b/core/api.py
@@ -88,6 +88,13 @@ def skip(player_index: int) -> None:
     _engine.skip(player_index)
 
 
+def get_allowed_actions(player_index: int) -> list[str]:
+    """Return allowed actions for ``player_index`` in the current game."""
+
+    assert _engine is not None, "Game not started"
+    return _engine.get_allowed_actions(player_index)
+
+
 def auto_play_turn(player_index: int | None = None, ai_type: str = "simple") -> Tile:
     """Have the specified AI draw and discard for ``player_index``."""
 

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -107,3 +107,21 @@ def test_get_tenhou_log_api() -> None:
     api.start_game(["A", "B", "C", "D"])
     log = api.get_tenhou_log()
     assert log.startswith("{") and "name" in log
+
+
+def test_get_allowed_actions_api() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("man", 2)
+    state.players[1].hand.tiles.append(tile)
+    api.discard_tile(1, tile)
+    state.players[2].hand.tiles = [models.Tile("man", 1), models.Tile("man", 3)]
+    acts = api.get_allowed_actions(2)
+    assert "chi" in acts
+    assert "pon" not in acts
+    state.current_player = 2
+    acts = api.get_allowed_actions(2)
+    assert "skip" in acts
+    state.last_discard = None
+    state.last_discard_player = None
+    state.current_player = 0
+    assert "skip" not in api.get_allowed_actions(0)

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -247,3 +247,19 @@ def test_shanten_endpoint() -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert "shanten" in data and isinstance(data["shanten"], int)
+
+
+def test_allowed_actions_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    state = api.get_state()
+    tile = models.Tile("man", 2)
+    state.players[1].hand.tiles.append(tile)
+    client.post(
+        "/games/1/action",
+        json={"player_index": 1, "action": "discard", "tile": {"suit": "man", "value": 2}},
+    )
+    state.players[2].hand.tiles = [models.Tile("man", 1), models.Tile("man", 3)]
+    resp = client.get("/games/1/allowed-actions/2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "chi" in data.get("actions", [])

--- a/web/server.py
+++ b/web/server.py
@@ -127,6 +127,20 @@ def shanten_number(game_id: int, player_index: int) -> dict:
     return {"shanten": value}
 
 
+@app.get("/games/{game_id}/allowed-actions/{player_index}")
+def allowed_actions(game_id: int, player_index: int) -> dict:
+    """Return allowed actions for ``player_index``."""
+
+    _ = game_id  # placeholder for future multi-game support
+    try:
+        actions = api.get_allowed_actions(player_index)
+    except AssertionError:
+        raise HTTPException(status_code=404, detail="Game not started")
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Player not found")
+    return {"actions": actions}
+
+
 class ActionRequest(BaseModel):
     """Request body for game actions."""
 

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -2,6 +2,17 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import GameBoard from './GameBoard.jsx';
 
+function setupFetch() {
+  const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+  global.fetch = (url, options) => {
+    if (String(url).includes('allowed-actions')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) });
+    }
+    return fetchMock(url, options);
+  };
+  return fetchMock;
+}
+
 function mockState(playerIndex = 0) {
   return {
     current_player: playerIndex,
@@ -12,8 +23,7 @@ function mockState(playerIndex = 0) {
 
 describe('GameBoard auto draw', () => {
   it('requests draw or auto when current_player changes', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
-    global.fetch = fetchMock;
+    const fetchMock = setupFetch();
     const state = mockState(0);
     const { rerender, getAllByLabelText } = render(
       <GameBoard state={state} server="http://s" gameId="1" />,
@@ -36,8 +46,7 @@ describe('GameBoard auto draw', () => {
   });
 
   it('does not auto play when result is shown', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
-    global.fetch = fetchMock;
+    const fetchMock = setupFetch();
     const state = { ...mockState(0), result: { type: 'ryukyoku' } };
     const { rerender } = render(
       <GameBoard state={state} server="http://s" gameId="1" />,

--- a/web_gui/GameBoard.discard.test.jsx
+++ b/web_gui/GameBoard.discard.test.jsx
@@ -4,6 +4,17 @@ import { describe, it, expect, vi } from 'vitest';
 import GameBoard from './GameBoard.jsx';
 import { tileDescription } from './tileUtils.js';
 
+function setupFetch() {
+  const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+  global.fetch = (url, options) => {
+    if (String(url).includes('allowed-actions')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) });
+    }
+    return fetchMock(url, options);
+  };
+  return fetchMock;
+}
+
 function mockPlayers() {
   return new Array(4).fill(0).map(() => ({
     hand: { tiles: [{ suit: 'man', value: 1 }], melds: [] },
@@ -13,8 +24,7 @@ function mockPlayers() {
 
 describe('GameBoard discard', () => {
   it('sends discard when clicking tile on turn', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
-    global.fetch = fetchMock;
+    const fetchMock = setupFetch();
     const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
     render(<GameBoard state={state} server="http://s" gameId="1" />);
     const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;
@@ -25,8 +35,7 @@ describe('GameBoard discard', () => {
   });
 
   it('ignores click when not your turn', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
-    global.fetch = fetchMock;
+    const fetchMock = setupFetch();
     const state = { current_player: 1, players: mockPlayers(), wall: { tiles: [] } };
     const { container } = render(<GameBoard state={state} server="http://s" gameId="1" />);
     const btn = container.querySelector('.south .hand button');
@@ -35,8 +44,8 @@ describe('GameBoard discard', () => {
   });
 
   it('shows modal on server error', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, status: 409 }));
-    global.fetch = fetchMock;
+    const fetchMock = setupFetch();
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 409 });
     const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
     render(<GameBoard state={state} server="http://s" gameId="1" />);
     const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;

--- a/web_gui/GameBoard.toggleAI.test.jsx
+++ b/web_gui/GameBoard.toggleAI.test.jsx
@@ -2,6 +2,17 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import GameBoard from './GameBoard.jsx';
 
+function setupFetch() {
+  const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+  global.fetch = (url, options) => {
+    if (String(url).includes('allowed-actions')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) });
+    }
+    return fetchMock(url, options);
+  };
+  return fetchMock;
+}
+
 function mockState() {
   // player 0 has already drawn a tile (14 tiles total)
   const tiles = Array(14).fill({ suit: 'man', value: 1 });
@@ -19,8 +30,7 @@ function mockState() {
 
 describe('GameBoard AI toggle mid-turn', () => {
   it('discards immediately when enabling AI', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
-    global.fetch = fetchMock;
+    const fetchMock = setupFetch();
     const state = mockState();
     const { getAllByLabelText } = render(
       <GameBoard state={state} server="http://s" gameId="1" />,

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { FaUser, FaRobot } from 'react-icons/fa';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
@@ -24,7 +24,17 @@ export default function PlayerPanel({
   state,
 }) {
   const active = playerIndex === activePlayer;
-  const allowedActions = getAllowedActions(state, playerIndex);
+  const [allowedActions, setAllowedActions] = useState([]);
+
+  useEffect(() => {
+    let ignore = false;
+    getAllowedActions(server, gameId, playerIndex).then((acts) => {
+      if (!ignore) setAllowedActions(acts);
+    });
+    return () => {
+      ignore = true;
+    };
+  }, [server, gameId, playerIndex, state]);
   return (
     <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}> 
       <div className="player-header">

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -1,6 +1,9 @@
 import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import PlayerPanel from './PlayerPanel.jsx';
+
+// Prevent fetch errors in useEffect
+global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ actions: [] }) });
 
 function panel(aiActive) {
   return (

--- a/web_gui/allowedActions.js
+++ b/web_gui/allowedActions.js
@@ -1,48 +1,14 @@
-export function getAllowedActions(state, playerIndex) {
-  const actions = new Set();
-  if (!state || !state.players || !state.players[playerIndex]) return [];
-  const player = state.players[playerIndex];
-  const tiles = player.hand?.tiles || [];
-  const last = state.last_discard;
-  const lastPlayer = state.last_discard_player;
-  const numPlayers = state.players.length;
-
-  if (
-    playerIndex === state.current_player &&
-    last &&
-    lastPlayer !== null &&
-    lastPlayer !== playerIndex
-  ) {
-    actions.add('skip');
-  }
-
-  if (last && lastPlayer !== null && lastPlayer !== playerIndex) {
-    const match = (t) => t.suit === last.suit && t.value === last.value;
-    const count = tiles.filter(match).length;
-    if (count >= 2) actions.add('pon');
-    if (count >= 3) actions.add('kan');
-    if (
-      (lastPlayer + 1) % numPlayers === playerIndex &&
-      ['man', 'pin', 'sou'].includes(last.suit)
-    ) {
-      const has = (v) =>
-        tiles.some((t) => t.suit === last.suit && t.value === v);
-      if (has(last.value - 2) && has(last.value - 1)) actions.add('chi');
-      if (has(last.value - 1) && has(last.value + 1)) actions.add('chi');
-      if (has(last.value + 1) && has(last.value + 2)) actions.add('chi');
+export async function getAllowedActions(server, gameId, playerIndex) {
+  try {
+    const resp = await fetch(
+      `${server.replace(/\/$/, '')}/games/${gameId}/allowed-actions/${playerIndex}`
+    );
+    if (resp.ok) {
+      const data = await resp.json();
+      return Array.isArray(data.actions) ? data.actions : [];
     }
-    // Ron detection not implemented
+  } catch {
+    /* ignore fetch errors */
   }
-
-  const counts = {};
-  for (const t of tiles) {
-    if (!t) continue;
-    const key = `${t.suit}-${t.value}`;
-    counts[key] = (counts[key] || 0) + 1;
-    if (counts[key] >= 4) actions.add('kan');
-  }
-
-  if (!player.riichi) actions.add('riichi');
-
-  return Array.from(actions);
+  return [];
 }

--- a/web_gui/allowedActions.test.js
+++ b/web_gui/allowedActions.test.js
@@ -1,44 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getAllowedActions } from './allowedActions.js';
 
-function mockState() {
-  return {
-    current_player: 0,
-    last_discard: { suit: 'man', value: 2 },
-    last_discard_player: 1,
-    players: [
-      {},
-      {},
-      { hand: { tiles: [{ suit: 'man', value: 1 }, { suit: 'man', value: 3 }] } },
-      {},
-    ],
-  };
-}
+// Minimal fetch mocking
 
 describe('getAllowedActions', () => {
-  it('allows chi when sequence exists', () => {
-    const actions = getAllowedActions(mockState(), 2);
-    expect(actions).toContain('chi');
-  });
-
-  it('omits pon when tiles missing', () => {
-    const actions = getAllowedActions(mockState(), 2);
-    expect(actions).not.toContain('pon');
-  });
-
-  it('allows skip when responding to a discard', () => {
-    const state = mockState();
-    state.current_player = 2;
-    const actions = getAllowedActions(state, 2);
-    expect(actions).toContain('skip');
-  });
-
-  it('omits skip on own turn with no discard', () => {
-    const state = mockState();
-    state.last_discard = null;
-    state.last_discard_player = null;
-    state.current_player = 0;
-    const actions = getAllowedActions(state, 0);
-    expect(actions).not.toContain('skip');
+  it('returns actions from server', async () => {
+    const fake = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ actions: ['chi'] }),
+    });
+    global.fetch = fake;
+    const actions = await getAllowedActions('http://s', '1', 0);
+    expect(fake).toHaveBeenCalled();
+    expect(actions).toEqual(['chi']);
   });
 });


### PR DESCRIPTION
## Summary
- calculate allowed actions in MahjongEngine
- expose new function in core.api
- serve them from FastAPI `/games/{id}/allowed-actions/{player_index}`
- fetch allowed actions in the GUI instead of computing them locally
- update docs and tests

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a530ab720832a97e04932234d2a71