### PR TITLE
Improve meld orientation with called tile tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Future work will expand these components.
 - [x] Display honba & riichi stick counts
 - [x] Meld display from game state
 - [x] Melds positioned to the right of the player's hand
+- [x] Called tile rotated within melds
 - [x] Tile image rendering in GUI with alt text
 - [x] Adjustable tile font size (default 1.5x)
 - [x] Peek at opponents' hands option

--- a/core/ai_adapter.py
+++ b/core/ai_adapter.py
@@ -52,7 +52,11 @@ def json_to_game_state(message: str) -> GameState:
         return Tile(**d)
 
     def decode_meld(d: dict[str, Any]) -> Meld:
-        return Meld(tiles=[decode_tile(t) for t in d["tiles"]], type=d["type"])
+        return Meld(
+            tiles=[decode_tile(t) for t in d["tiles"]],
+            type=d["type"],
+            called_index=d.get("called_index"),
+        )
 
     def decode_hand(d: dict[str, Any]) -> Hand:
         tiles = [decode_tile(t) for t in d.get("tiles", [])]

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -258,7 +258,10 @@ class MahjongEngine:
             raise ValueError("Discard mismatch")
         discarder.river.pop()
 
-        meld = Meld(tiles=tiles, type="chi")
+        called_index = None
+        if last_tile in tiles:
+            called_index = tiles.index(last_tile)
+        meld = Meld(tiles=tiles, type="chi", called_index=called_index)
         player.hand.melds.append(meld)
         self.state.last_discard = None
         self.state.last_discard_player = None
@@ -308,7 +311,10 @@ class MahjongEngine:
             raise ValueError("Discard mismatch")
         discarder.river.pop()
 
-        meld = Meld(tiles=tiles, type="pon")
+        called_index = None
+        if last_tile in tiles:
+            called_index = tiles.index(last_tile)
+        meld = Meld(tiles=tiles, type="pon", called_index=called_index)
         player.hand.melds.append(meld)
         self.state.last_discard = None
         self.state.last_discard_player = None
@@ -356,7 +362,8 @@ class MahjongEngine:
             if not discarder.river or discarder.river[-1] != last_tile:
                 raise ValueError("Discard mismatch")
             discarder.river.pop()
-            meld = Meld(tiles=meld_tiles, type="kan")
+            called_index = 0
+            meld = Meld(tiles=meld_tiles, type="kan", called_index=called_index)
             player.hand.melds.append(meld)
             self.state.last_discard = None
             self.state.last_discard_player = None

--- a/core/models.py
+++ b/core/models.py
@@ -27,6 +27,7 @@ class Meld:
     """Collection of tiles forming a meld (chi, pon, kan)."""
     tiles: List[Tile]
     type: str
+    called_index: int | None = None
 
 
 @dataclass

--- a/docs/board-layout.md
+++ b/docs/board-layout.md
@@ -13,9 +13,9 @@ This document outlines how the Mahjong board is arranged in the web UI. The desi
   Discard piles remain directly in front of the players.
 - Opponents occupy the top, left and right edges, surrounding a central area used for wall tiles or indicators.
 - Each opponent's concealed hand is drawn just outside their discard pile so the river remains visible.
-- Each seat's discard pile and meld area is rotated with CSS so tiles face the center.
+- Each seat's discard pile is rotated with CSS so tiles face the center.
   `.seat-east` rotates 90deg, `.seat-north` 180deg and `.seat-west` -90deg.
-- Melds are drawn in dedicated areas separate from discard piles so rivers remain intact.
+- Melds follow the hand orientation. The tile taken from another player is rotated 90 degrees within the meld. Melds are drawn in dedicated areas separate from discard piles so rivers remain intact.
 
 ### Player Panel Layout
 

--- a/tests/web_gui/test_called_tile.py
+++ b/tests/web_gui/test_called_tile.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_called_tile_css_present() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert '.called-tile' in css
+    start = css.index('.called-tile')
+    block = css[start:css.index('}', start)]
+    assert 'rotate(90deg)' in block
+
+
+def test_meld_area_not_rotated() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert 'east .meld-area' not in css
+    assert 'north .meld-area' not in css
+    assert 'west .meld-area' not in css

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -122,10 +122,26 @@ export default function GameBoard({
   const eastDrawn = hasDrawnTile(east, 3);
   const southDrawn = hasDrawnTile(south, 0);
 
-  const northMelds = north?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
-  const westMelds = west?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
-  const eastMelds = east?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
-  const southMelds = south?.hand?.melds.map((m) => m.tiles.map(tileLabel)) ?? [];
+  const northMelds =
+    north?.hand?.melds.map((m) => ({
+      tiles: m.tiles.map(tileLabel),
+      calledIndex: m.called_index ?? null,
+    })) ?? [];
+  const westMelds =
+    west?.hand?.melds.map((m) => ({
+      tiles: m.tiles.map(tileLabel),
+      calledIndex: m.called_index ?? null,
+    })) ?? [];
+  const eastMelds =
+    east?.hand?.melds.map((m) => ({
+      tiles: m.tiles.map(tileLabel),
+      calledIndex: m.called_index ?? null,
+    })) ?? [];
+  const southMelds =
+    south?.hand?.melds.map((m) => ({
+      tiles: m.tiles.map(tileLabel),
+      calledIndex: m.called_index ?? null,
+    })) ?? [];
 
   const remaining = state?.wall?.tiles?.length ?? 0;
   const dora = state?.wall?.tiles?.[0] ? [tileLabel(state.wall.tiles[0])] : [];

--- a/web_gui/MeldArea.jsx
+++ b/web_gui/MeldArea.jsx
@@ -5,8 +5,13 @@ export default function MeldArea({ melds = [] }) {
     <div className="meld-area">
       {melds.map((meld, mIdx) => (
         <div key={mIdx} className="meld">
-          {meld.map((t, i) => (
-            <span key={i} className="mj-tile">{t}</span>
+          {meld.tiles.map((t, i) => (
+            <span
+              key={i}
+              className={`mj-tile${meld.calledIndex === i ? ' called-tile' : ''}`}
+            >
+              {t}
+            </span>
           ))}
         </div>
       ))}

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -133,9 +133,13 @@
 .north .river { transform: rotate(180deg); }
 .west .river { transform: rotate(-90deg); }
 
-.east .meld-area { transform: rotate(90deg); }
-.north .meld-area { transform: rotate(180deg); }
-.west .meld-area { transform: rotate(-90deg); }
+.called-tile {
+  transform: rotate(90deg);
+}
+
+.called-tile:hover {
+  transform: rotate(90deg) translateY(-2px);
+}
 .flat-btn {
   background-color: #007bff;
   border: none;


### PR DESCRIPTION
## Summary
- track which tile came from another player's discard
- tilt the called tile in each meld
- stop rotating meld areas in CSS
- adjust board layout docs and README
- test CSS rules for called tiles

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `/root/.pyenv/versions/3.12.10/bin/flake8`
- `/root/.pyenv/versions/3.12.10/bin/mypy core web cli`
- `/root/.pyenv/versions/3.12.10/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a550f914c832a8f4b7797954bcda5