### PR TITLE
Follow next core actions in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Future work will expand these components.
 - [x] Discard tiles via GUI
 - [x] Display hand shanten count via GUI
 - [x] Allowed actions API
+- [x] GUI follows next actions from core
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI
 - [x] Simple shanten-based AI for automated turns (discards tiles that keep shanten and calls pon/chi when it improves the hand)


### PR DESCRIPTION
## Summary
- make GameBoard respect waiting_for_claims from core
- auto skip or meld for AI players when claims are pending
- update unit tests for new behavior
- document feature in README

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a6058cf4c832a9adca71deb7e370b