### PR TITLE
Fix AI claim handling for human players

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Future work will expand these components.
 - [x] Start game via GUI
 - [x] Simple shanten-based AI for automated turns (discards tiles that keep shanten and calls pon/chi when it improves the hand)
 - [x] Toggle AI per player from GUI
+- [x] Only AI-designated players automatically claim or skip melds
 - [x] AI type selection framework (currently only 'simple')
 - [x] Players 2-4 use AI by default in GUI
 - [x] Handle start_kyoku event in GUI

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -34,7 +34,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `declare_ron`      | `player_index`, `Tile`                  | Win on another player's discard. |
 | `declare_tsumo`    | `player_index`, `Tile`                  | Win on self-drawn tile. |
 | `skip`             | `player_index`                          | Pass on an action. |
-| `auto_play_turn`   | `player_index`, `ai_type`               | Draw and discard using the chosen AI. |
+| `auto_play_turn`   | `player_index`, `ai_type`, `ai_players` | Draw and discard using the chosen AI. Only players listed in `ai_players` automatically claim or skip melds. |
 | `end_game`         | none                                    | Terminate the current game. |
 | `get_state`        | none                                    | Retrieve the current `GameState`. |
 

--- a/tests/core/test_auto_play_turn_ai_players.py
+++ b/tests/core/test_auto_play_turn_ai_players.py
@@ -1,0 +1,16 @@
+from core import api, models
+import pytest
+
+
+def test_auto_play_turn_respects_ai_players() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("man", 1)
+    # give player 0 a simple hand with the discard tile last
+    state.players[0].hand.tiles = [models.Tile("sou", 1)] * 13 + [tile]
+    for p in state.players[1:]:
+        p.hand.tiles = [models.Tile("pin", (i % 9) + 1) for i in range(13)]
+    api.discard_tile(0, tile)
+    assert state.waiting_for_claims
+    with pytest.raises(ValueError):
+        api.auto_play_turn(1, ai_players=[1, 3])
+    assert state.waiting_for_claims == [2]

--- a/web/server.py
+++ b/web/server.py
@@ -149,6 +149,7 @@ class ActionRequest(BaseModel):
     tile: dict | None = None
     tiles: list[dict] | None = None
     ai_type: str | None = None
+    ai_players: list[int] | None = None
 
 
 @app.post("/games/{game_id}/action")
@@ -196,7 +197,12 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
         return {"status": "ok"}
     if req.action == "auto":
         ai_type = req.ai_type or "simple"
-        tile = api.auto_play_turn(req.player_index, ai_type=ai_type)
+        try:
+            tile = api.auto_play_turn(
+                req.player_index, ai_type=ai_type, ai_players=req.ai_players
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         return asdict(tile)
     raise HTTPException(status_code=400, detail="Unknown action")
 

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -26,7 +26,12 @@ describe('GameBoard auto draw', () => {
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);
     await Promise.resolve();
     const autoCall = fetchMock.mock.calls.find(c => c[0].includes('/action'));
-    expect(JSON.parse(autoCall[1].body)).toEqual({ player_index: 1, action: 'auto', ai_type: 'simple' });
+    expect(JSON.parse(autoCall[1].body)).toEqual({
+      player_index: 1,
+      action: 'auto',
+      ai_type: 'simple',
+      ai_players: [1, 2, 3],
+    });
     fetchMock.mockClear();
     fireEvent.click(getAllByLabelText('Enable AI')[0]);
     await Promise.resolve();
@@ -34,7 +39,12 @@ describe('GameBoard auto draw', () => {
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);
     await Promise.resolve();
     const autoCall2 = fetchMock.mock.calls.find(c => c[0].includes('/action'));
-    expect(JSON.parse(autoCall2[1].body)).toEqual({ player_index: 0, action: 'auto', ai_type: 'simple' });
+    expect(JSON.parse(autoCall2[1].body)).toEqual({
+      player_index: 0,
+      action: 'auto',
+      ai_type: 'simple',
+      ai_players: [0, 1, 2, 3],
+    });
   });
 
   it('does not auto play when result is shown', async () => {

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -64,7 +64,12 @@ export default function GameBoard({
     if (tiles.length === 13) {
       const action = aiPlayers[current] ? 'auto' : 'draw';
       const body = { player_index: current, action };
-      if (action === 'auto') body.ai_type = aiTypes[current];
+      if (action === 'auto') {
+        body.ai_type = aiTypes[current];
+        body.ai_players = aiPlayers
+          .map((v, i) => (v ? i : null))
+          .filter((v) => v !== null);
+      }
       fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- prevent auto_play_turn from claiming melds for human players
- send active AI list from GUI
- update API docs and README
- test new optional ai_players parameter
- update vitest expectations

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`
- `python -m build core`
- `python -m build cli`


------
https://chatgpt.com/codex/tasks/task_e_686a62bbad8c832abc9c308580b8d61f