### PR TITLE
Fix riichi enable state and duplicate draw

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -591,7 +591,7 @@ class MahjongEngine:
             if counts[key] >= 4:
                 actions.add("kan")
 
-        if not player.riichi:
+        if not player.riichi and self._is_tenpai(player):
             actions.add("riichi")
 
         return sorted(actions)

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -119,3 +119,35 @@ def test_get_allowed_actions_api() -> None:
     state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 3)]
     actions = api.get_allowed_actions(1)
     assert "chi" in actions and "pon" not in actions and "skip" in actions
+
+
+TENPAI_TILES = [
+    models.Tile("man", 1), models.Tile("man", 1),
+    models.Tile("man", 2), models.Tile("man", 2),
+    models.Tile("man", 3), models.Tile("man", 3),
+    models.Tile("pin", 4), models.Tile("pin", 4),
+    models.Tile("pin", 5), models.Tile("pin", 5),
+    models.Tile("sou", 6), models.Tile("sou", 6),
+    models.Tile("sou", 7), models.Tile("sou", 8),
+]
+
+
+def test_allowed_actions_include_riichi_when_tenpai() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    state.players[0].hand.tiles = TENPAI_TILES.copy()
+    actions = api.get_allowed_actions(0)
+    assert "riichi" in actions
+
+
+def test_allowed_actions_exclude_riichi_when_not_tenpai() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tiles = [
+        models.Tile("man", 1), models.Tile("man", 1), models.Tile("man", 1),
+        models.Tile("man", 2), models.Tile("man", 3), models.Tile("man", 4),
+        models.Tile("man", 5), models.Tile("man", 6), models.Tile("man", 7),
+        models.Tile("pin", 1), models.Tile("pin", 2), models.Tile("sou", 3),
+        models.Tile("sou", 4), models.Tile("sou", 6),
+    ]
+    state.players[0].hand.tiles = tiles
+    actions = api.get_allowed_actions(0)
+    assert "riichi" not in actions

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -4,7 +4,6 @@ import PlayerPanel from './PlayerPanel.jsx';
 import { tileToEmoji, sortTiles, sortTilesExceptLast } from './tileUtils.js';
 import ErrorModal from './ErrorModal.jsx';
 import ResultModal from './ResultModal.jsx';
-import { getNextActions } from './nextActions.js';
 
 function tileLabel(tile) {
   return tileToEmoji(tile);
@@ -59,20 +58,6 @@ export default function GameBoard({
 
   useEffect(() => {
     if (!gameId || result || state?.result) return;
-    getNextActions(server, gameId).then((data) => {
-      if (!data || !Array.isArray(data.actions)) return;
-      const { player_index, actions } = data;
-      if (actions.length === 1 && actions[0] === 'draw') {
-        const ai = aiPlayers[player_index];
-        const body = { player_index, action: ai ? 'auto' : 'draw' };
-        if (ai) body.ai_type = aiTypes[player_index];
-        fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        }).catch(() => {});
-      }
-    });
     const waiting = state?.waiting_for_claims ?? [];
     if (waiting.length > 0) {
       if (JSON.stringify(waiting) !== JSON.stringify(prevWaiting.current)) {


### PR DESCRIPTION
## Summary
- prevent riichi action when not in tenpai
- remove redundant auto draw logic from GameBoard
- add tests for riichi allowed actions

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a707a7710832a98e3d23266b4bba7