### PR TITLE
Fix river updates for meld actions

### DIFF
--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -62,6 +62,22 @@ def test_discard_sets_waiting_for_claims() -> None:
     output = run_node(code)
     assert output == '3:true'
 
+
+def test_meld_removes_discard_from_river() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {last_discard:{suit:'man',value:1}, last_discard_player:0, \n"
+        "players:[\n"
+        "  {hand:{tiles:[], melds:[]}, river:[{suit:'man',value:1}]},\n"
+        "  {hand:{tiles:[{suit:'man',value:2},{suit:'man',value:3}], melds:[]}, river:[]}\n"
+        "]};\n"
+        "const evt = {name:'meld', payload:{player_index:1, meld:{tiles:[{suit:'man',value:1},{suit:'man',value:2},{suit:'man',value:3}], type:'chi', called_index:0}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.players[0].river.length + ':' + newState.players[1].hand.melds.length + ':' + newState.last_discard);"
+    )
+    output = run_node(code)
+    assert output == '0:1:null'
+
 def test_ryukyoku_sets_result_and_scores() -> None:
     code = (
         "import { applyEvent } from './web_gui/applyEvent.js';\n"

--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -8,6 +8,7 @@ function mockState(playerIndex = 0, waiting = []) {
     players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
     wall: { tiles: [] },
     waiting_for_claims: waiting,
+    last_discard: { suit: 'man', value: 1 },
   };
 }
 

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -85,7 +85,8 @@ export default function GameBoard({
     if (current == null || current === prevPlayer.current) return;
     prevPlayer.current = current;
     const tiles = state?.players?.[current]?.hand?.tiles ?? [];
-    if (tiles.length === 13) {
+    const last = state?.last_discard;
+    if (tiles.length === 13 && last) {
       const action = aiPlayers[current] ? 'auto' : 'draw';
       const body = { player_index: current, action };
       if (action === 'auto') body.ai_type = aiTypes[current];

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -43,6 +43,12 @@ export function applyEvent(state, event) {
         });
         p.hand.melds.push(event.payload.meld);
       }
+      if (typeof newState.last_discard_player === 'number') {
+        const d = newState.players[newState.last_discard_player];
+        if (d?.river?.length) d.river.pop();
+      }
+      newState.last_discard = null;
+      newState.last_discard_player = null;
       newState.current_player = event.payload.player_index;
       newState.waiting_for_claims = [];
       break;


### PR DESCRIPTION
## Summary
- update `applyEvent` to remove the claimed tile from the discarder and clear last discard data
- prevent automatic drawing after melds by checking `last_discard`
- update auto draw tests for new condition
- add regression test for meld event state update

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `./.venv/bin/python -m build core`
- `./.venv/bin/python -m build cli`
- `./.venv/bin/flake8`
- `./.venv/bin/mypy core web cli`
- `./.venv/bin/pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a7485e7e4832aaea2b292d00d4b6d