### PR TITLE
fix auto play claim handling

### DIFF
--- a/tests/core/test_auto_play_claim_players.py
+++ b/tests/core/test_auto_play_claim_players.py
@@ -1,0 +1,12 @@
+from core import api, models
+
+
+def test_auto_play_turn_respects_claim_players() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    discarder = 0
+    tile = state.players[discarder].hand.tiles[-1]
+    api.discard_tile(discarder, tile)
+    assert state.waiting_for_claims == [1, 2, 3]
+
+    api.auto_play_turn(1, claim_players=[1])
+    assert state.waiting_for_claims == [2, 3]

--- a/web/server.py
+++ b/web/server.py
@@ -208,7 +208,11 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
         return {"status": "ok"}
     if req.action == "auto":
         ai_type = req.ai_type or "simple"
-        tile = api.auto_play_turn(req.player_index, ai_type=ai_type)
+        tile = api.auto_play_turn(
+            req.player_index,
+            ai_type=ai_type,
+            claim_players=[req.player_index],
+        )
         return asdict(tile)
     raise HTTPException(status_code=400, detail="Unknown action")
 


### PR DESCRIPTION
## Summary
- ensure auto_play_turn only processes specified claim_players
- call auto_play_turn with claim_players in FastAPI endpoint
- add regression test

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686a775c2544832a802b354d77459277