### PR TITLE
Allow calling chi without passing discard tile

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -53,8 +53,20 @@ def get_state() -> GameState:
 
 
 def call_chi(player_index: int, tiles: list[Tile]) -> None:
-    """Public wrapper for MahjongEngine.call_chi."""
+    """Public wrapper for MahjongEngine.call_chi.
+
+    ``tiles`` may contain either the full meld including the discarded tile or
+    just the two tiles from the caller's hand. When only two tiles are
+    provided the current discard is automatically inserted to form the meld.
+    """
     assert _engine is not None, "Game not started"
+
+    if len(tiles) == 2:
+        last_tile = _engine.state.last_discard
+        if last_tile is None:
+            raise ValueError("No discard available for chi")
+        tiles = sorted(tiles + [last_tile], key=lambda t: t.value)
+
     _engine.call_chi(player_index, tiles)
 
 

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -28,7 +28,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `start_game`       | list of player names                    | Begin a new hanchan. Returns `GameState`. |
 | `draw_tile`        | `player_index`                          | Draw the next tile for a player. |
 | `discard_tile`     | `player_index`, `Tile`                  | Discard a tile from the player's hand. |
-| `call_chi`         | `player_index`, `tiles`                 | Call `chi` using the given tiles. |
+| `call_chi`         | `player_index`, `tiles`                 | Call `chi` using the given tiles. When only two tiles are provided the current discard is automatically added. |
 | `call_pon`         | `player_index`, `tiles`                 | Call `pon` using the given tiles. |
 | `call_kan`         | `player_index`, `tiles`                 | Declare an open or closed `kan`. |
 | `declare_ron`      | `player_index`, `Tile`                  | Win on another player's discard. |

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -44,6 +44,19 @@ def test_call_pon() -> None:
     assert caller.hand.melds[0].type == "pon"
 
 
+def test_call_chi_missing_discard() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("man", 3)
+    discarder = state.players[0]
+    caller = state.players[1]
+    discarder.hand.tiles.append(tile)
+    api.discard_tile(0, tile)
+    caller.hand.tiles.extend([models.Tile("man", 1), models.Tile("man", 2)])
+    api.call_chi(1, [models.Tile("man", 1), models.Tile("man", 2)])
+    assert len(caller.hand.melds) == 1
+    assert caller.hand.melds[0].type == "chi"
+
+
 def test_end_game_creates_new_state() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     finished = api.end_game()


### PR DESCRIPTION
## Summary
- allow `core.api.call_chi` to accept two tiles and automatically add the current discard
- document chi behaviour
- test calling chi with only two tiles

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686a7db57168832aa97c70cd0aa93bff