### PR TITLE
Add event log copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Future work will expand these components.
 - [x] Modal error display on failed discard actions
 - [x] Setup controls hidden after game start with modal access
 - [x] Detailed event log display
+- [x] Copy event log to clipboard
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -6,7 +6,7 @@ import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import { formatEvent } from './eventLog.js';
 import './style.css';
-import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle, FiSettings } from "react-icons/fi";
+import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle, FiSettings, FiCopy } from "react-icons/fi";
 
 export default function App() {
   const [server, setServer] = useState(
@@ -95,6 +95,14 @@ export default function App() {
       setGameState((s) => applyEvent(s, evt));
     } catch {
       // ignore parse errors
+    }
+  }
+
+  async function copyEvents() {
+    try {
+      await navigator.clipboard.writeText(events.join('\n'));
+    } catch {
+      /* ignore */
     }
   }
 
@@ -268,7 +276,12 @@ export default function App() {
       )}
       {mode === 'game' && (
         <div className="event-log">
-          <h2>Events</h2>
+          <div className="event-log-header">
+            <h2>Events</h2>
+            <Button aria-label="Copy events" onClick={copyEvents}>
+              <FiCopy />
+            </Button>
+          </div>
           <ul>
             {events.map((e, i) => (
               <li key={i}>{e}</li>

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -155,3 +155,13 @@ describe('App header', () => {
     expect(heading).toBeNull();
   });
 });
+
+describe('Event log copy', () => {
+  it('copies log text when button clicked', async () => {
+    global.fetch = mockFetch();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+    render(<App />);
+    await userEvent.click(screen.getByLabelText('Copy events'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('');
+  });
+});

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -84,6 +84,11 @@
   border: 1px solid #ccc;
   padding: 0.25rem;
 }
+.event-log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
 
 .controls {
   display: flex;


### PR DESCRIPTION
## Summary
- make events section copyable in GUI
- style event log header
- test event copy button
- document new feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686bb9d21664832a80dc0c0bcd216688