### PR TITLE
Add debug-level API logging in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Future work will expand these components.
 - [x] Setup controls hidden after game start with modal access
 - [x] Detailed event log display
 - [x] Copy event log to clipboard
+- [x] Debug logging of GUI API calls
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/web_gui/App.apilog.test.jsx
+++ b/web_gui/App.apilog.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Server } from 'mock-socket';
+import { describe, it, expect, vi } from 'vitest';
+import App from './App.jsx';
+
+function mockFetch() {
+  return vi.fn((url) => {
+    if (url.endsWith('/health')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok' }) });
+    }
+    if (url.endsWith('/games')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({
+        id: 1,
+        players: new Array(4).fill(0).map(() => ({ name: '', hand: { tiles: [], melds: [] }, river: [] })),
+        wall: { tiles: [] }
+      }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe('App API logging', () => {
+  it('logs start game request', async () => {
+    global.fetch = mockFetch();
+    const server = new Server('ws://localhost:1235/ws/1');
+    render(<App />);
+    const input = screen.getByLabelText('Server:');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'http://localhost:1235');
+    await userEvent.click(screen.getByText('Start Game'));
+    const logItem = await screen.findByText(/\[debug\] POST \/games/);
+    expect(logItem).toBeTruthy();
+    server.stop();
+  });
+});

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -18,6 +18,9 @@ export default function App() {
   const [gameId, setGameId] = useState(() => localStorage.getItem('gameId') || '');
   const [gameState, setGameState] = useState(null);
   const [events, setEvents] = useState([]);
+  function log(level, message) {
+    setEvents((evts) => [...evts.slice(-19), `[${level}] ${message}`]);
+  }
   const [mode, setMode] = useState('game');
   const [peek, setPeek] = useState(false);
   const [sortHand, setSortHand] = useState(true);
@@ -53,6 +56,7 @@ export default function App() {
 
   async function startGame() {
     try {
+      log('debug', 'POST /games - user started a new game');
       const resp = await fetch(`${server.replace(/\/$/, '')}/games`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -76,6 +80,7 @@ export default function App() {
   async function fetchGameState(id = gameId) {
     try {
       if (!id) return;
+      log('debug', `GET /games/${id} - restoring game state`);
       const resp = await fetch(`${server.replace(/\/$/, '')}/games/${id}`);
       if (resp.ok) {
         setGameState(await resp.json());
@@ -91,7 +96,7 @@ export default function App() {
   function handleMessage(e) {
     try {
       const evt = JSON.parse(e.data);
-      setEvents((evts) => [...evts.slice(-9), formatEvent(evt)]);
+      log('info', formatEvent(evt));
       setGameState((s) => applyEvent(s, evt));
     } catch {
       // ignore parse errors
@@ -268,11 +273,12 @@ export default function App() {
           gameId={gameId}
           peek={peek}
           sortHand={sortHand}
+          log={log}
         />
       ) : mode === 'practice' ? (
-        <Practice server={server} sortHand={sortHand} />
+        <Practice server={server} sortHand={sortHand} log={log} />
       ) : (
-        <ShantenQuiz server={server} sortHand={sortHand} />
+        <ShantenQuiz server={server} sortHand={sortHand} log={log} />
       )}
       {mode === 'game' && (
         <div className="event-log">

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -8,12 +8,14 @@ export default function Controls({
   activePlayer = null,
   aiActive = false,
   allowedActions = [],
+  log = () => {},
 }) {
   const [message, setMessage] = useState('');
 
 
   async function simple(action, payload = {}) {
     try {
+      log('debug', `POST /games/${gameId}/action ${action} - control button`);
       await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -27,6 +29,7 @@ export default function Controls({
 
   async function shanten() {
     try {
+      log('debug', `GET /games/${gameId}/shanten/${playerIndex} - shanten button`);
       const resp = await fetch(
         `${server.replace(/\/$/, '')}/games/${gameId}/shanten/${playerIndex}`
       );

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -14,6 +14,7 @@ export default function GameBoard({
   gameId,
   peek = false,
   sortHand = false,
+  log = () => {},
 }) {
   const players = state?.players ?? [];
   const south = players[0];
@@ -44,6 +45,7 @@ export default function GameBoard({
     ) {
       const tiles = state.players[idx].hand.tiles;
       const tile = tiles[tiles.length - 1];
+      log('debug', `POST /games/${gameId}/action discard - enable AI autoplays`);
       fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -69,6 +71,7 @@ export default function GameBoard({
               action: 'auto',
               ai_type: aiTypes[idx],
             };
+            log('debug', `POST /games/${gameId}/action auto - resolve claims`);
             fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
@@ -90,6 +93,7 @@ export default function GameBoard({
       const action = aiPlayers[current] ? 'auto' : 'draw';
       const body = { player_index: current, action };
       if (action === 'auto') body.ai_type = aiTypes[current];
+      log('debug', `POST /games/${gameId}/action ${action} - next player action`);
       fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -107,6 +111,7 @@ export default function GameBoard({
   async function copyLog() {
     if (!gameId) return;
     try {
+      log('debug', `GET /games/${gameId}/log - user copied log`);
       const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/log`);
       if (!resp.ok) return;
       const data = await resp.json();
@@ -179,6 +184,7 @@ export default function GameBoard({
     try {
       if (!gameId) return;
       if (typeof tile === 'string') return;
+      log('debug', `POST /games/${gameId}/action discard - user clicked tile`);
       const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -22,6 +22,7 @@ export default function PlayerPanel({
   aiActive = false,
   toggleAI,
   state,
+  log = () => {},
 }) {
   const active = playerIndex === activePlayer;
   const [allowedActions, setAllowedActions] = useState([]);
@@ -31,7 +32,7 @@ export default function PlayerPanel({
       setAllowedActions([]);
       return;
     }
-    getAllowedActions(server, gameId, playerIndex).then(setAllowedActions);
+    getAllowedActions(server, gameId, playerIndex, log).then(setAllowedActions);
   }, [server, gameId, playerIndex, state]);
   return (
     <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}> 
@@ -61,6 +62,7 @@ export default function PlayerPanel({
         activePlayer={activePlayer}
         aiActive={aiActive}
         allowedActions={allowedActions}
+        log={log}
       />
     </div>
   );

--- a/web_gui/Practice.jsx
+++ b/web_gui/Practice.jsx
@@ -3,13 +3,14 @@ import Hand from './Hand.jsx';
 import Button from './Button.jsx';
 import { tileToEmoji, tileDescription, sortTilesExceptLast } from './tileUtils.js';
 
-export default function Practice({ server, sortHand = true }) {
+export default function Practice({ server, sortHand = true, log = () => {} }) {
   const [problem, setProblem] = useState(null);
   const [suggestion, setSuggestion] = useState(null);
   const [chosen, setChosen] = useState(null);
 
   async function loadProblem() {
     try {
+      log('debug', 'GET /practice - load new problem');
       const resp = await fetch(`${server.replace(/\/$/, '')}/practice`);
       if (resp.ok) {
         setProblem(await resp.json());
@@ -24,6 +25,7 @@ export default function Practice({ server, sortHand = true }) {
   async function choose(tile) {
     setChosen(tile);
     try {
+      log('debug', 'POST /practice/suggest - request AI suggestion');
       const resp = await fetch(`${server.replace(/\/$/, '')}/practice/suggest`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/web_gui/ShantenQuiz.jsx
+++ b/web_gui/ShantenQuiz.jsx
@@ -3,13 +3,14 @@ import Hand from './Hand.jsx';
 import Button from './Button.jsx';
 import { sortTiles } from './tileUtils.js';
 
-export default function ShantenQuiz({ server, sortHand = true }) {
+export default function ShantenQuiz({ server, sortHand = true, log = () => {} }) {
   const [hand, setHand] = useState(null);
   const [guess, setGuess] = useState('');
   const [answer, setAnswer] = useState(null);
 
   async function loadHand() {
     try {
+      log('debug', 'GET /shanten-quiz - new quiz hand');
       const resp = await fetch(`${server.replace(/\/$/, '')}/shanten-quiz`);
       if (resp.ok) {
         setHand(await resp.json());
@@ -23,6 +24,7 @@ export default function ShantenQuiz({ server, sortHand = true }) {
 
   async function check() {
     try {
+      log('debug', 'POST /shanten-quiz/check - submit answer');
       const resp = await fetch(
         `${server.replace(/\/$/, '')}/shanten-quiz/check`,
         {

--- a/web_gui/allowedActions.js
+++ b/web_gui/allowedActions.js
@@ -1,8 +1,8 @@
-export async function getAllowedActions(server, gameId, playerIndex) {
+export async function getAllowedActions(server, gameId, playerIndex, log = () => {}) {
   try {
-    const resp = await fetch(
-      `${server.replace(/\/$/, '')}/games/${gameId}/allowed-actions/${playerIndex}`
-    );
+    const url = `${server.replace(/\/$/, '')}/games/${gameId}/allowed-actions/${playerIndex}`;
+    log('debug', `GET ${url} - update allowed actions`);
+    const resp = await fetch(url);
     if (!resp.ok) return [];
     const data = await resp.json();
     return data.actions || [];

--- a/web_gui/nextActions.js
+++ b/web_gui/nextActions.js
@@ -1,8 +1,8 @@
-export async function getNextActions(server, gameId) {
+export async function getNextActions(server, gameId, log = () => {}) {
   try {
-    const resp = await fetch(
-      `${server.replace(/\/$/, '')}/games/${gameId}/next-actions`
-    );
+    const url = `${server.replace(/\/$/, '')}/games/${gameId}/next-actions`;
+    log('debug', `GET ${url} - fetch next actions`);
+    const resp = await fetch(url);
     if (!resp.ok) return null;
     return await resp.json();
   } catch {


### PR DESCRIPTION
## Summary
- log GUI API requests to the events list with `[debug]` level
- allow toggling by passing a logging function through components
- test that starting a game records a debug message
- document the new feature

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `python -m pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686bc8fd7e80832a882acee95d176b32