### PR TITLE
Enhance event log with MJAI JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Future work will expand these components.
 - [x] Setup controls hidden after game start with modal access
 - [x] Detailed event log display
 - [x] Copy event log to clipboard
+- [x] MJAI JSON shown alongside log entries
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation
@@ -282,6 +283,13 @@ cd web_gui
 npm install
 npx vite --open
 ```
+
+#### Event log
+
+Each message from the server appears in the Events sidebar with a short
+description followed by the exact MJAI JSON for that event. When all
+players pass on a discard, the log shows "捨て牌に対するアクションはありませんでした"
+to indicate the claim window closed without a call.
 
 ### Start both together
 

--- a/tests/web_gui/test_event_log.py
+++ b/tests/web_gui/test_event_log.py
@@ -36,3 +36,23 @@ def test_format_next_actions_event() -> None:
     )
     output = run_node(code)
     assert output.startswith('Next actions for player 2')
+
+
+def test_event_to_mjai_json() -> None:
+    code = (
+        "import { eventToMjaiJson } from './web_gui/eventLog.js';\n"
+        "const evt = {name:'discard', payload:{player_index:1, tile:{suit:'pin', value:3}}};\n"
+        "console.log(eventToMjaiJson(evt));"
+    )
+    output = run_node(code)
+    assert '"type":"discard"' in output
+    assert '"player_index":1' in output
+
+
+def test_format_claims_closed() -> None:
+    code = (
+        "import { formatEvent } from './web_gui/eventLog.js';\n"
+        "console.log(formatEvent({name:'claims_closed'}));"
+    )
+    output = run_node(code)
+    assert output.startswith('捨て牌に対するアクションはありませんでした')

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -4,7 +4,7 @@ import Practice from './Practice.jsx';
 import ShantenQuiz from './ShantenQuiz.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
-import { formatEvent } from './eventLog.js';
+import { formatEvent, eventToMjaiJson } from './eventLog.js';
 import './style.css';
 import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle, FiSettings, FiCopy } from "react-icons/fi";
 
@@ -91,8 +91,27 @@ export default function App() {
   function handleMessage(e) {
     try {
       const evt = JSON.parse(e.data);
-      setEvents((evts) => [...evts.slice(-9), formatEvent(evt)]);
-      setGameState((s) => applyEvent(s, evt));
+      setGameState((prev) => {
+        const next = applyEvent(prev, evt);
+        setEvents((evts) => {
+          const lines = [];
+          if (evt.name === 'draw_tile') {
+            lines.push(formatEvent({ name: 'turn_start', payload: { player_index: evt.payload.player_index } }));
+            lines.push(formatEvent(evt));
+          } else if (evt.name === 'discard' || evt.name === 'meld' || evt.name === 'riichi' || evt.name === 'ron' || evt.name === 'tsumo' || evt.name === 'ryukyoku' || evt.name === 'start_kyoku' || evt.name === 'start_game' || evt.name === 'end_game' || evt.name === 'next_actions' || evt.name === 'skip') {
+            lines.push(formatEvent(evt));
+          } else {
+            lines.push(formatEvent(evt));
+          }
+          if (evt.name === 'skip' && prev?.waiting_for_claims?.length && next.waiting_for_claims.length === 0) {
+            lines.push(formatEvent({ name: 'claims_closed' }));
+          }
+          const json = eventToMjaiJson(evt);
+          const withJson = lines.map((l) => `${l} ${json}`);
+          return [...evts.slice(-10 + withJson.length), ...withJson];
+        });
+        return next;
+      });
     } catch {
       // ignore parse errors
     }

--- a/web_gui/eventLog.js
+++ b/web_gui/eventLog.js
@@ -18,6 +18,10 @@ export function formatEvent(evt) {
       return `Player ${p} wins by ron`;
     case 'skip':
       return `Player ${p} skips`;
+    case 'claims_closed':
+      return '捨て牌に対するアクションはありませんでした';
+    case 'turn_start':
+      return `Turn start for player ${p}`;
     case 'next_actions':
       return `Next actions for player ${p}: ${evt.payload.actions.join(', ')}`;
     case 'start_kyoku':
@@ -31,5 +35,11 @@ export function formatEvent(evt) {
     default:
       return evt.name;
   }
+}
+
+export function eventToMjaiJson(evt) {
+  if (!evt || !evt.name) return '';
+  const payload = { type: evt.name, ...(evt.payload || {}) };
+  return JSON.stringify(payload);
 }
 


### PR DESCRIPTION
## Summary
- add `eventToMjaiJson` helper mirroring core function
- support `turn_start` and `claims_closed` messages in `formatEvent`
- show human-readable messages and MJAI JSON in the GUI
- document the new behavior
- test JSON serialization and new formatter

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686bd15785b8832aad969028198ccfbd