### PR TITLE
Enforce turn order

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -134,6 +134,9 @@ def auto_play_turn(
         assert _engine.state.last_discard is not None
         return _engine.state.last_discard
 
+    if player_index is None:
+        idx = _engine.state.current_player
+
     return ai(_engine, idx)
 
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -165,6 +165,8 @@ class MahjongEngine:
         """Draw a tile for the specified player."""
         if self.state.waiting_for_claims:
             raise ValueError("Waiting for other players to claim discard")
+        if player_index != self.state.current_player:
+            raise ValueError("Not player's turn")
         assert self.state.wall is not None
         tile = self.state.wall.draw_tile()
         self.state.players[player_index].draw(tile)
@@ -174,12 +176,15 @@ class MahjongEngine:
             self._check_nine_terminals(player)
         if self.state.wall.remaining_tiles == 0:
             self._resolve_ryukyoku("wall_empty")
-        else:
-            self.state.current_player = (player_index + 1) % len(self.state.players)
+        # current_player will advance after the player discards
         return tile
 
     def discard_tile(self, player_index: int, tile: Tile) -> None:
         """Discard a tile from the specified player's hand."""
+        if self.state.waiting_for_claims:
+            raise ValueError("Waiting for other players to claim discard")
+        if player_index != self.state.current_player:
+            raise ValueError("Not player's turn")
         player = self.state.players[player_index]
         if player.must_tsumogiri and player.hand.tiles and player.hand.tiles[-1] is not tile:
             raise ValueError("Must discard the drawn tile after declaring riichi")

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -37,6 +37,7 @@ def test_call_pon() -> None:
     discarder = state.players[1]
     caller = state.players[0]
     discarder.hand.tiles.append(tile)
+    state.current_player = 1
     api.discard_tile(1, tile)
     caller.hand.tiles.extend([models.Tile("pin", 1), models.Tile("pin", 1)])
     api.call_pon(0, [models.Tile("pin", 1), models.Tile("pin", 1), tile])

--- a/tests/core/test_called_from.py
+++ b/tests/core/test_called_from.py
@@ -6,6 +6,7 @@ from core.models import Tile
 def _setup_discard(engine: MahjongEngine, discarder_idx: int, tile: Tile) -> None:
     discarder = engine.state.players[discarder_idx]
     discarder.hand.tiles.append(tile)
+    engine.state.current_player = discarder_idx
     engine.discard_tile(discarder_idx, tile)
 
 

--- a/tests/core/test_honba_scoring.py
+++ b/tests/core/test_honba_scoring.py
@@ -27,6 +27,7 @@ def test_ron_honba_bonus() -> None:
     engine.state.honba = 1
     tile = Tile("man", 2)
     engine.state.players[1].hand.tiles.append(tile)
+    engine.state.current_player = 1
     engine.discard_tile(1, tile)
     engine.state.players[0].hand.tiles.append(Tile("man", 2))
     start_scores = [p.score for p in engine.state.players]

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -48,6 +48,7 @@ def test_discard_tile_updates_state() -> None:
     tile = Tile(suit="pin", value=4)
     # Add tile to player's hand directly for simplicity
     engine.state.players[1].draw(tile)
+    engine.state.current_player = 1
     engine.discard_tile(1, tile)
     assert all(t is not tile for t in engine.state.players[1].hand.tiles)
     assert tile in engine.state.players[1].river
@@ -185,6 +186,7 @@ def test_ron_updates_scores_and_emits_event() -> None:
     _set_tenpai_hand(engine.state.players[2])
     engine.declare_riichi(2)
     engine.state.players[1].hand.tiles.append(Tile("man", 2))
+    engine.state.current_player = 1
     engine.discard_tile(1, engine.state.players[1].hand.tiles[-1])
     start_score = engine.state.players[0].score
     loser_start = engine.state.players[1].score

--- a/tests/core/test_turn_rotation.py
+++ b/tests/core/test_turn_rotation.py
@@ -1,3 +1,4 @@
+import pytest
 from core.mahjong_engine import MahjongEngine
 
 
@@ -5,7 +6,7 @@ def test_draw_advances_turn() -> None:
     engine = MahjongEngine()
     current = engine.state.current_player
     engine.draw_tile(current)
-    assert engine.state.current_player == (current + 1) % len(engine.state.players)
+    assert engine.state.current_player == current
 
 
 def test_discard_advances_turn() -> None:
@@ -14,3 +15,18 @@ def test_discard_advances_turn() -> None:
     tile = engine.state.players[current].hand.tiles[0]
     engine.discard_tile(current, tile)
     assert engine.state.current_player == (current + 1) % len(engine.state.players)
+
+
+def test_draw_out_of_turn_raises_error() -> None:
+    engine = MahjongEngine()
+    wrong_player = (engine.state.current_player + 1) % len(engine.state.players)
+    with pytest.raises(ValueError):
+        engine.draw_tile(wrong_player)
+
+
+def test_discard_out_of_turn_raises_error() -> None:
+    engine = MahjongEngine()
+    wrong_player = (engine.state.current_player + 1) % len(engine.state.players)
+    tile = engine.state.players[wrong_player].hand.tiles[0]
+    with pytest.raises(ValueError):
+        engine.discard_tile(wrong_player, tile)

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -53,9 +53,10 @@ def test_draw_action_endpoint() -> None:
 
 def test_discard_action_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    state = api.get_state()
     draw = client.post(
         "/games/1/action",
-        json={"player_index": 0, "action": "draw"},
+        json={"player_index": state.current_player, "action": "draw"},
     )
     tile = draw.json()
     resp = client.post(
@@ -146,21 +147,22 @@ def test_additional_action_endpoints() -> None:
     )
     assert resp.status_code == 409
 
+    state = api.get_state()
     draw = client.post(
         "/games/1/action",
-        json={"player_index": 0, "action": "draw"},
+        json={"player_index": state.current_player, "action": "draw"},
     )
     tile = draw.json()
 
     resp = client.post(
         "/games/1/action",
-        json={"player_index": 0, "action": "tsumo", "tile": tile},
+        json={"player_index": state.current_player, "action": "tsumo", "tile": tile},
     )
     assert resp.status_code == 200
 
     resp = client.post(
         "/games/1/action",
-        json={"player_index": 0, "action": "skip"},
+        json={"player_index": state.current_player, "action": "skip"},
     )
     assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary
- prevent drawing or discarding out of turn in `MahjongEngine`
- adjust AI helper to respect current player
- update tests for new turn validation
- test drawing/discarding out of turn

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686bd35169c0832aae7560a585641ea6