### PR TITLE
Update WebSocket event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Future work will expand these components.
 - [x] Allowed actions API
 - [x] Next actions API
 - [x] Next actions logged to event history
+- [x] GUI fetches next actions after every event
 - [x] GUI follows next actions from core
 - [x] Meld and win actions via GUI
 - [x] Start game via GUI

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -5,6 +5,7 @@ import ShantenQuiz from './ShantenQuiz.jsx';
 import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import { formatEvent, eventToMjaiJson } from './eventLog.js';
+import { logNextActions } from './eventFlow.js';
 import './style.css';
 import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle, FiSettings, FiCopy } from "react-icons/fi";
 
@@ -118,6 +119,11 @@ export default function App() {
         });
         return next;
       });
+      if (evt.name !== 'next_actions' && gameId) {
+        logNextActions(server, gameId, log, (line) =>
+          setEvents((evts) => [...evts.slice(-9), line]),
+        );
+      }
     } catch {
       // ignore parse errors
     }

--- a/web_gui/eventFlow.js
+++ b/web_gui/eventFlow.js
@@ -1,0 +1,10 @@
+import { formatEvent, eventToMjaiJson } from './eventLog.js';
+import { getNextActions } from './nextActions.js';
+
+export async function logNextActions(server, gameId, log = () => {}, addEvent) {
+  const data = await getNextActions(server, gameId, log);
+  if (!data) return;
+  const evt = { name: 'next_actions', payload: data };
+  log('info', formatEvent(evt));
+  addEvent(`${formatEvent(evt)} ${eventToMjaiJson(evt)}`);
+}

--- a/web_gui/eventFlow.test.js
+++ b/web_gui/eventFlow.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { logNextActions } from './eventFlow.js';
+
+describe('logNextActions', () => {
+  it('fetches and logs next actions', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ player_index: 1, actions: ['draw'] }) }),
+    );
+    global.fetch = fetchMock;
+    const events = [];
+    const log = vi.fn((l, m) => events.push(`[${l}] ${m}`));
+    await logNextActions('http://s', '1', log, (line) => events.push(line));
+    expect(fetchMock).toHaveBeenCalledWith('http://s/games/1/next-actions');
+    expect(events.pop()).toContain('next_actions');
+  });
+});


### PR DESCRIPTION
## Summary
- fetch next actions after each WebSocket message
- log the server's next_actions events
- add helper to fetch and log next actions
- test next action logging via Node
- document new behaviour

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686bd500817c832abee63e12fdbdad57