### PR TITLE
Fix nondeterministic round progression test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import random
+import pytest
+
+@pytest.fixture(autouse=True)
+def _seed_random() -> None:
+    random.seed(0)


### PR DESCRIPTION
## Summary
- seed the global random module before each test to prevent sporadic failures when the new hand immediately triggers nine terminals

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686bd979d228832a8a0121e35010f2d8