### PR TITLE
Enlarge event log modal

### DIFF
--- a/tests/web_gui/test_event_log_modal_size.py
+++ b/tests/web_gui/test_event_log_modal_size.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_event_log_modal_has_custom_class() -> None:
+    text = Path('web_gui/EventLogModal.jsx').read_text()
+    assert 'event-log-modal-content' in text
+
+
+def test_event_log_modal_css() -> None:
+    css = Path('web_gui/style.css').read_text()
+    assert '.event-log-modal-content' in css
+    assert '80vw' in css
+    assert '80vh' in css

--- a/web_gui/EventLogModal.jsx
+++ b/web_gui/EventLogModal.jsx
@@ -6,7 +6,7 @@ export default function EventLogModal({ events, onClose, onCopy }) {
   return (
     <div className="modal is-active">
       <div className="modal-background" onClick={onClose}></div>
-      <div className="modal-content">
+      <div className="modal-content event-log-modal-content">
         <div className="box event-log">
           <div className="event-log-header">
             <h2>Events</h2>

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -90,6 +90,17 @@
   align-items: center;
 }
 
+.event-log-modal-content {
+  width: 80vw;
+  height: 80vh;
+  max-width: 80vw;
+  max-height: 80vh;
+}
+
+.event-log-modal-content .event-log {
+  max-height: calc(80vh - 3rem);
+}
+
 .controls {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- expand EventLogModal to 80% viewport size
- style event-log modal content
- test the new modal class and styles

## Testing
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686cebefa038832aa02618d92dd4743e