### PR TITLE
Fix skip controls when waiting for claim

### DIFF
--- a/web_gui/Controls.disabled.test.jsx
+++ b/web_gui/Controls.disabled.test.jsx
@@ -15,6 +15,7 @@ describe('Controls disabled state', () => {
         playerIndex={0}
         activePlayer={1}
         allowedActions={['pon']}
+        waitingForClaims={[]}
       />,
     );
     expect(screen.getByRole('button', { name: 'Pon' }).disabled).toBe(true);
@@ -28,6 +29,7 @@ describe('Controls disabled state', () => {
         activePlayer={0}
         aiActive={true}
         allowedActions={['pon']}
+        waitingForClaims={[]}
       />,
     );
     expect(screen.getByRole('button', { name: 'Pon' }).disabled).toBe(true);
@@ -41,9 +43,25 @@ describe('Controls disabled state', () => {
         activePlayer={0}
         aiActive={false}
         allowedActions={['pon']}
+        waitingForClaims={[]}
       />,
     );
     expect(screen.getByRole('button', { name: 'Pon' }).disabled).toBe(false);
     expect(screen.getByRole('button', { name: 'Chi' }).disabled).toBe(true);
+  });
+
+  it('enables controls when waiting to claim', () => {
+    render(
+      <Controls
+        server="http://s"
+        gameId="1"
+        playerIndex={0}
+        activePlayer={1}
+        aiActive={false}
+        allowedActions={['skip']}
+        waitingForClaims={[0]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Skip' }).disabled).toBe(false);
   });
 });

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -8,6 +8,7 @@ export default function Controls({
   activePlayer = null,
   aiActive = false,
   allowedActions = [],
+  waitingForClaims = [],
   log = () => {},
 }) {
   const [message, setMessage] = useState('');
@@ -72,7 +73,9 @@ export default function Controls({
     simple('skip');
   }
 
-  const active = playerIndex === activePlayer && !aiActive;
+  const active =
+    (playerIndex === activePlayer || waitingForClaims.includes(playerIndex)) &&
+    !aiActive;
   const isAllowed = (action) => active && allowedActions.includes(action);
 
   return (

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -24,7 +24,8 @@ export default function PlayerPanel({
   state,
   log = () => {},
 }) {
-  const active = playerIndex === activePlayer;
+  const waiting = state?.waiting_for_claims ?? [];
+  const active = playerIndex === activePlayer || waiting.includes(playerIndex);
   const [allowedActions, setAllowedActions] = useState([]);
 
   useEffect(() => {
@@ -60,6 +61,7 @@ export default function PlayerPanel({
         gameId={gameId}
         playerIndex={playerIndex}
         activePlayer={activePlayer}
+        waitingForClaims={waiting}
         aiActive={aiActive}
         allowedActions={allowedActions}
         log={log}


### PR DESCRIPTION
## Summary
- enable controls for players in `waiting_for_claims`
- pass waiting players list to `Controls`
- test new skip behavior

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686cf2705978832aa941940820c2c70b