### PR TITLE
Implement fetch cancellation for allowed actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Future work will expand these components.
 - [x] MJAI JSON shown alongside log entries
 - [x] Event log modal with copy button
 - [x] Debug logging of GUI API calls
+- [x] Cancel in-flight allowed actions requests
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FaUser, FaRobot } from 'react-icons/fa';
 import Hand from './Hand.jsx';
 import River from './River.jsx';
 import MeldArea from './MeldArea.jsx';
 import Controls from './Controls.jsx';
 import Button from './Button.jsx';
+import { getAllowedActions } from './allowedActions.js';
 
 export default function PlayerPanel({
   seat,
@@ -26,8 +27,27 @@ export default function PlayerPanel({
 }) {
   const waiting = state?.waiting_for_claims ?? [];
   const active = playerIndex === activePlayer || waiting.includes(playerIndex);
+  const [actions, setActions] = useState(allowedActions);
+  const controllerRef = useRef(null);
+
+  useEffect(() => {
+    setActions(allowedActions);
+  }, [allowedActions]);
+
+  useEffect(() => {
+    if (!server || !gameId) return;
+    const controller = new AbortController();
+    controllerRef.current?.abort();
+    controllerRef.current = controller;
+    getAllowedActions(server, gameId, playerIndex, log, { signal: controller.signal })
+      .then((acts) => {
+        if (Array.isArray(acts)) setActions(acts);
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [server, gameId, playerIndex]);
   return (
-    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}> 
+    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}>
       <div className="player-header">
         <span className="riichi-stick">{player?.riichi ? '|' : '\u00a0'}</span>
         <span className="player-name">{(player ? player.name : seat) + (player ? ` ${player.score}` : '')}</span>
@@ -54,7 +74,7 @@ export default function PlayerPanel({
         activePlayer={activePlayer}
         waitingForClaims={waiting}
         aiActive={aiActive}
-        allowedActions={allowedActions}
+        allowedActions={actions}
         log={log}
       />
     </div>

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import PlayerPanel from './PlayerPanel.jsx';
 
 function panel(aiActive) {
@@ -37,5 +37,41 @@ describe('PlayerPanel layout styles', () => {
     const hand = container.querySelector('.hand-with-melds');
     expect(river.style.marginBottom).toBe('calc(var(--tile-font-size) * 0.8)');
     expect(hand.style.zIndex).toBe('1');
+  });
+});
+
+describe('PlayerPanel fetch cancellation', () => {
+  it('aborts previous request when props change', async () => {
+    let aborted = false;
+    const fetchMock = vi.fn((url, opts) => {
+      opts.signal.addEventListener('abort', () => {
+        aborted = true;
+      });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) });
+    });
+    global.fetch = fetchMock;
+    function Panel({ server }) {
+      return (
+        <PlayerPanel
+          seat="east"
+          player={{}}
+          hand={[]}
+          melds={[]}
+          riverTiles={[]}
+          server={server}
+          gameId="1"
+          playerIndex={0}
+          activePlayer={0}
+          aiActive={false}
+          state={{}}
+          allowedActions={[]}
+        />
+      );
+    }
+    const { rerender } = render(<Panel server="http://s" />);
+    await Promise.resolve();
+    rerender(<Panel server="http://s2" />);
+    await Promise.resolve();
+    expect(aborted).toBe(true);
   });
 });

--- a/web_gui/allowedActions.js
+++ b/web_gui/allowedActions.js
@@ -1,25 +1,60 @@
-export async function getAllowedActions(server, gameId, playerIndex, log = () => {}) {
+const controllers = new Map();
+
+function prepareSignal(id, signal) {
+  if (signal) return signal;
+  if (!id) return undefined;
+  const prev = controllers.get(id);
+  if (prev) prev.abort();
+  const controller = new AbortController();
+  controllers.set(id, controller);
+  return controller.signal;
+}
+
+export async function getAllowedActions(
+  server,
+  gameId,
+  playerIndex,
+  log = () => {},
+  { signal, requestId } = {},
+) {
+  const finalSignal = prepareSignal(requestId, signal);
   try {
     const url = `${server.replace(/\/$/, '')}/games/${gameId}/allowed-actions/${playerIndex}`;
     log('debug', `GET ${url} - update allowed actions`);
-    const resp = await fetch(url);
+    const resp = await fetch(url, { signal: finalSignal });
     if (!resp.ok) return [];
     const data = await resp.json();
     return data.actions || [];
-  } catch {
+  } catch (err) {
+    if (err.name !== 'AbortError') {
+      /* ignore other errors */
+    }
     return [];
+  } finally {
+    if (requestId) controllers.delete(requestId);
   }
 }
 
-export async function getAllAllowedActions(server, gameId, log = () => {}) {
+export async function getAllAllowedActions(
+  server,
+  gameId,
+  log = () => {},
+  { signal, requestId } = {},
+) {
+  const finalSignal = prepareSignal(requestId, signal);
   try {
     const url = `${server.replace(/\/$/, '')}/games/${gameId}/allowed-actions`;
     log('debug', `GET ${url} - fetch allowed actions`);
-    const resp = await fetch(url);
+    const resp = await fetch(url, { signal: finalSignal });
     if (!resp.ok) return [];
     const data = await resp.json();
     return data.actions || [];
-  } catch {
+  } catch (err) {
+    if (err.name !== 'AbortError') {
+      /* ignore other errors */
+    }
     return [];
+  } finally {
+    if (requestId) controllers.delete(requestId);
   }
 }

--- a/web_gui/allowedActions.test.js
+++ b/web_gui/allowedActions.test.js
@@ -7,7 +7,7 @@ describe('getAllowedActions', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: ['pon'] }) })
     );
     global.fetch = fetchMock;
-    const actions = await getAllowedActions('http://s', '1', 0);
+    const actions = await getAllowedActions('http://s', '1', 0, undefined, { requestId: 'a' });
     expect(fetchMock).toHaveBeenCalled();
     expect(actions).toEqual(['pon']);
   });
@@ -15,8 +15,24 @@ describe('getAllowedActions', () => {
   it('handles fetch failure gracefully', async () => {
     const fetchMock = vi.fn(() => Promise.reject(new Error('x')));
     global.fetch = fetchMock;
-    const actions = await getAllowedActions('http://s', '1', 0);
+    const actions = await getAllowedActions('http://s', '1', 0, undefined, { requestId: 'b' });
     expect(actions).toEqual([]);
+  });
+
+  it('aborts previous request with same id', async () => {
+    let aborted = false;
+    const fetchMock = vi.fn((url, opts) => {
+      opts.signal.addEventListener('abort', () => {
+        aborted = true;
+      });
+      return new Promise(() => {});
+    });
+    global.fetch = fetchMock;
+    getAllowedActions('http://s', '1', 0, undefined, { requestId: 'x' });
+    await Promise.resolve();
+    getAllowedActions('http://s', '1', 0, undefined, { requestId: 'x' });
+    await Promise.resolve();
+    expect(aborted).toBe(true);
   });
 });
 
@@ -29,8 +45,24 @@ describe('getAllAllowedActions', () => {
       })
     );
     global.fetch = fetchMock;
-    const actions = await getAllAllowedActions('http://s', '1');
-    expect(fetchMock).toHaveBeenCalledWith('http://s/games/1/allowed-actions');
+    const actions = await getAllAllowedActions('http://s', '1', undefined, { requestId: 'all' });
+    expect(fetchMock.mock.calls[0][0]).toBe('http://s/games/1/allowed-actions');
     expect(actions).toEqual([['pon'], ['chi']]);
+  });
+
+  it('aborts previous request with same id', async () => {
+    let aborted = false;
+    const fetchMock = vi.fn((url, opts) => {
+      opts.signal.addEventListener('abort', () => {
+        aborted = true;
+      });
+      return new Promise(() => {});
+    });
+    global.fetch = fetchMock;
+    getAllAllowedActions('http://s', '1', undefined, { requestId: 'z' });
+    await Promise.resolve();
+    getAllAllowedActions('http://s', '1', undefined, { requestId: 'z' });
+    await Promise.resolve();
+    expect(aborted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- support request cancellation in `allowedActions.js`
- fetch player actions in `PlayerPanel` with AbortController
- test abort behaviour for allowed actions and `PlayerPanel`
- document request cancellation capability

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686d0958fdbc832a8f179516315070ea