### PR TITLE
Fix allowed-actions fetch with AI

### DIFF
--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -36,8 +36,12 @@ export default function PlayerPanel({
 
   useEffect(() => {
     if (!server || !gameId) return;
-    const controller = new AbortController();
     controllerRef.current?.abort();
+    if (aiActive) {
+      controllerRef.current = null;
+      return;
+    }
+    const controller = new AbortController();
     controllerRef.current = controller;
     getAllowedActions(server, gameId, playerIndex, log, { signal: controller.signal })
       .then((acts) => {
@@ -45,7 +49,7 @@ export default function PlayerPanel({
       })
       .catch(() => {});
     return () => controller.abort();
-  }, [server, gameId, playerIndex]);
+  }, [server, gameId, playerIndex, aiActive]);
   return (
     <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}>
       <div className="player-header">

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -75,3 +75,30 @@ describe('PlayerPanel fetch cancellation', () => {
     expect(aborted).toBe(true);
   });
 });
+
+describe('PlayerPanel AI behaviour', () => {
+  it('does not fetch actions when aiActive is true', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) })
+    );
+    global.fetch = fetchMock;
+    render(
+      <PlayerPanel
+        seat="east"
+        player={{}}
+        hand={[]}
+        melds={[]}
+        riverTiles={[]}
+        server="http://s"
+        gameId="1"
+        playerIndex={0}
+        activePlayer={0}
+        aiActive={true}
+        state={{}}
+        allowedActions={[]}
+      />,
+    );
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- skip getAllowedActions fetch in `PlayerPanel` when the seat is AI controlled
- add test verifying that the fetch is skipped for AI players

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686d0b33ed48832aba7dd10de4df1e1b