### PR TITLE
Implement allowed action caching

### DIFF
--- a/tests/core/test_allowed_actions_cache.py
+++ b/tests/core/test_allowed_actions_cache.py
@@ -1,0 +1,15 @@
+from core import api, models
+
+
+def test_allowed_actions_cache_invalidated_on_discard() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    _ = api.get_allowed_actions(0)
+
+    discard = models.Tile("man", 2)
+    state.players[0].hand.tiles = [discard]
+    api.discard_tile(0, discard)
+    state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 3)]
+
+    actions = api.get_allowed_actions(1)
+    assert "chi" in actions and "skip" in actions
+


### PR DESCRIPTION
## Summary
- cache allowed actions in `MahjongEngine`
- invalidate the cache when game state changes
- add regression test for cache invalidation

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686d110cdaf8832a8230681a78d26f3d