### PR TITLE
Refactor GameBoard effect deps

### DIFF
--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -62,4 +62,19 @@ describe('GameBoard auto draw', () => {
     rerender(<GameBoard state={state} server="http://s" gameId="1" />);
     await Promise.resolve();
   });
+
+  it('ignores score changes', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = mockState(0);
+    const { rerender } = render(
+      <GameBoard state={state} server="http://s" gameId="1" />,
+    );
+    await Promise.resolve();
+    fetchMock.mockClear();
+    state.players[0].score = 26000;
+    rerender(<GameBoard state={state} server="http://s" gameId="1" />);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -122,10 +122,9 @@ export default function GameBoard({
     }
   }, [
     state?.current_player,
-    state?.waiting_for_claims,
+    state?.waiting_for_claims?.length ?? 0,
     gameId,
     server,
-    state?.players,
     aiPlayers,
     aiTypes,
     result,


### PR DESCRIPTION
## Summary
- watch only primitive flags for AI auto-play effect
- ignore score updates in GameBoard tests

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686d1d7511f4832a83fce9c47bf42cbf