### PR TITLE
Fix GUI startup action fetch

### DIFF
--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -41,7 +41,7 @@ export default function PlayerPanel({
   }, [allowedActionsMemo]);
 
   useEffect(() => {
-    if (!server || !gameId) return;
+    if (!server || !gameId || !state) return;
     controllerRef.current?.abort();
     if (aiActive) {
       controllerRef.current = null;

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -101,6 +101,31 @@ describe('PlayerPanel AI behaviour', () => {
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('does not fetch actions when state is null', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) })
+    );
+    global.fetch = fetchMock;
+    render(
+      <PlayerPanel
+        seat="east"
+        player={{}}
+        hand={[]}
+        melds={[]}
+        riverTiles={[]}
+        server="http://s"
+        gameId="1"
+        playerIndex={0}
+        activePlayer={0}
+        aiActive={false}
+        state={null}
+        allowedActions={[]}
+      />,
+    );
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('PlayerPanel error handling', () => {


### PR DESCRIPTION
## Summary
- avoid calling allowed-actions endpoint when no game state
- test PlayerPanel fetch suppression on null state

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_686d2274e5f8832abac2bfc1ff26fe36