### PR TITLE
Fix skip race condition in web GUI

### DIFF
--- a/tests/web_gui/test_apply_event.py
+++ b/tests/web_gui/test_apply_event.py
@@ -28,7 +28,7 @@ tile: {suit: 'pin', value: 1}}};\n"
 def test_skip_updates_current_player() -> None:
     code = (
         "import { applyEvent } from './web_gui/applyEvent.js';\n"
-        "const state = {current_player: 0, players: [{}, {}]};\n"
+        "const state = {current_player: 0, players: [{}, {}], waiting_for_claims:[0]};\n"
         "const evt = {name: 'skip', payload: {player_index: 0}};\n"
         "const newState = applyEvent(state, evt);\n"
         "console.log(newState.current_player);"
@@ -136,3 +136,15 @@ def test_claims_closed_clears_waiting_for_claims() -> None:
     )
     output = run_node(code)
     assert output == '0'
+
+
+def test_skip_ignored_when_not_waiting() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "const state = {current_player:0, players:[{}, {}], waiting_for_claims:[]};\n"
+        "const evt = {name:'skip', payload:{player_index:0}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.current_player + ':' + newState.waiting_for_claims.length);"
+    )
+    output = run_node(code)
+    assert output == '0:0'

--- a/web_gui/Controls.disabled.test.jsx
+++ b/web_gui/Controls.disabled.test.jsx
@@ -64,4 +64,19 @@ describe('Controls disabled state', () => {
     );
     expect(screen.getByRole('button', { name: 'Skip' }).disabled).toBe(false);
   });
+
+  it('disables skip when claim window closed', () => {
+    render(
+      <Controls
+        server="http://s"
+        gameId="1"
+        playerIndex={0}
+        activePlayer={1}
+        aiActive={false}
+        allowedActions={['skip']}
+        waitingForClaims={[]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Skip' }).disabled).toBe(true);
+  });
 });

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -86,7 +86,10 @@ export function Controls({
   const active =
     (playerIndex === activePlayer || waitingForClaims.includes(playerIndex)) &&
     !aiActive;
-  const isAllowed = (action) => active && allowedActions.includes(action);
+  const isAllowed = (action) =>
+    active &&
+    allowedActions.includes(action) &&
+    (action !== 'skip' || waitingForClaims.length > 0);
 
   return (
     <div className="controls">

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -90,6 +90,9 @@ export function applyEvent(state, event) {
       newState.waiting_for_claims = [];
       break;
     case 'skip': {
+      if (!Array.isArray(state.waiting_for_claims) || state.waiting_for_claims.length === 0) {
+        break;
+      }
       newState.waiting_for_claims = newState.waiting_for_claims.filter(
         (i) => i !== event.payload.player_index,
       );


### PR DESCRIPTION
## Summary
- ignore stale `skip` events when claim window already closed
- disable Skip button once claims close
- adjust unit tests for updated skip behavior

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686d273935e0832ab05d062c69d61129