### PR TITLE
Fix chi button after draw

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -612,10 +612,17 @@ class MahjongEngine:
         last = state.last_discard
         last_player = state.last_discard_player
 
+        claims_open = self._claims_open and player_index in state.waiting_for_claims
+
         if player_index in state.waiting_for_claims:
             actions.add("skip")
 
-        if last is not None and last_player is not None and last_player != player_index:
+        if (
+            claims_open
+            and last is not None
+            and last_player is not None
+            and last_player != player_index
+        ):
             same = [t for t in tiles if t.suit == last.suit and t.value == last.value]
             if len(same) >= 2:
                 actions.add("pon")

--- a/tests/core/test_claim_window.py
+++ b/tests/core/test_claim_window.py
@@ -1,0 +1,17 @@
+from core import api, models
+
+
+def test_claim_options_removed_after_draw() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    discard = models.Tile("man", 3)
+    state.players[0].hand.tiles = [discard]
+    api.discard_tile(0, discard)
+    state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 2)]
+    actions = api.get_allowed_actions(1)
+    assert "chi" in actions
+    api.skip(1)
+    api.skip(2)
+    api.skip(3)
+    actions_after = api.get_allowed_actions(1)
+    assert "chi" not in actions_after
+    assert "pon" not in actions_after


### PR DESCRIPTION
## Summary
- disallow claiming previous discard once claim window closes
- test that chi/pon options disappear after all players skip

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686d285b426c832aa14eee74107c81bf