### PR TITLE
Add MJAI log download

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Future work will expand these components.
 - [x] Debug logging of GUI API calls
 - [x] Error modal shows server rejection
 - [x] Cancel in-flight allowed actions requests
+- [x] Download Tenhou log
+- [x] Download MJAI log
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/core/api.py
+++ b/core/api.py
@@ -168,6 +168,29 @@ def get_tenhou_log() -> str:
     return events_to_tenhou_json(history)
 
 
+def get_mjai_log() -> str:
+    """Return the accumulated event log in MJAI JSON format."""
+    assert _engine is not None, "Game not started"
+    import json
+    from dataclasses import asdict, is_dataclass
+
+    def encode(obj: object) -> object:
+        if is_dataclass(obj):
+            return {k: encode(v) for k, v in asdict(obj).items()}
+        if isinstance(obj, dict):
+            return {k: encode(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [encode(v) for v in obj]
+        return obj
+
+    history = _engine.get_event_history()
+    lines = []
+    for e in history:
+        payload = {"type": e.name, **encode(e.payload)}
+        lines.append(json.dumps(payload, ensure_ascii=False))
+    return "\n".join(lines)
+
+
 def get_event_history() -> list[GameEvent]:
     """Return the full event history."""
 

--- a/core/api.py
+++ b/core/api.py
@@ -173,9 +173,10 @@ def get_mjai_log() -> str:
     assert _engine is not None, "Game not started"
     import json
     from dataclasses import asdict, is_dataclass
+    from typing import Any, Mapping, cast
 
-    def encode(obj: object) -> object:
-        if is_dataclass(obj):
+    def encode(obj: Any) -> Any:
+        if is_dataclass(obj) and not isinstance(obj, type):
             return {k: encode(v) for k, v in asdict(obj).items()}
         if isinstance(obj, dict):
             return {k: encode(v) for k, v in obj.items()}
@@ -186,7 +187,10 @@ def get_mjai_log() -> str:
     history = _engine.get_event_history()
     lines = []
     for e in history:
-        payload = {"type": e.name, **encode(e.payload)}
+        payload = {
+            "type": e.name,
+            **cast(Mapping[str, Any], encode(e.payload)),
+        }
         lines.append(json.dumps(payload, ensure_ascii=False))
     return "\n".join(lines)
 

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -45,6 +45,14 @@ def test_get_log_endpoint() -> None:
     assert "log" in data and data["log"].startswith("{")
 
 
+def test_get_mjai_log_endpoint() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    resp = client.get("/games/1/mjai-log")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "log" in data and data["log"].startswith("{")
+
+
 def test_get_events_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     resp = client.get("/games/1/events")

--- a/web/server.py
+++ b/web/server.py
@@ -71,6 +71,18 @@ def get_log(game_id: int) -> dict:
     return {"log": data}
 
 
+@app.get("/games/{game_id}/mjai-log")
+def get_mjai_log(game_id: int) -> dict:
+    """Return the MJAI-format event log for the current game."""
+
+    _ = game_id  # placeholder for future multi-game support
+    try:
+        data = api.get_mjai_log()
+    except AssertionError:
+        raise HTTPException(status_code=404, detail="Game not started")
+    return {"log": data}
+
+
 @app.get("/games/{game_id}/events")
 def get_events(game_id: int) -> dict:
     """Return raw event history."""

--- a/web_gui/App.downloadlog.test.jsx
+++ b/web_gui/App.downloadlog.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Server } from 'mock-socket';
+import { describe, it, expect, vi } from 'vitest';
+import App from './App.jsx';
+
+function fetchWithLog() {
+  return vi.fn((url) => {
+    if (url.endsWith('/health')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok' }) });
+    }
+    if (url.endsWith('/games')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({
+        id: 1,
+        players: new Array(4).fill(0).map(() => ({ name: '', hand: { tiles: [], melds: [] }, river: [] })),
+        wall: { tiles: [] }
+      }) });
+    }
+    if (url.endsWith('/mjai-log')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ log: '{}' }) });
+    }
+    if (url.endsWith('/log')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ log: '{}' }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe('Log downloads', () => {
+  it('requests MJAI log when button clicked', async () => {
+    const fetchMock = fetchWithLog();
+    global.fetch = fetchMock;
+    Object.assign(URL, { createObjectURL: vi.fn(() => 'blob:url'), revokeObjectURL: vi.fn() });
+    const server = new Server('ws://localhost:1235/ws/1');
+    render(<App />);
+    const input = screen.getByLabelText('Server:');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'http://localhost:1235');
+    await userEvent.click(screen.getByText('Start Game'));
+    await screen.findByLabelText('Options');
+    const btn = await screen.findByLabelText('Download MJAI log');
+    await userEvent.click(btn);
+    const called = fetchMock.mock.calls.some(c => String(c[0]).includes('/mjai-log'));
+    expect(called).toBe(true);
+    server.stop();
+  });
+});

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -164,6 +164,42 @@ export default function App() {
     setShowLog(true);
   }
 
+  async function downloadLog(url, filename) {
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const blob = new Blob([data.log], { type: 'application/json' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      try {
+        link.click();
+      } catch {
+        /* ignore */
+      }
+      URL.revokeObjectURL(link.href);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function downloadTenhou() {
+    if (!gameId) return;
+    await downloadLog(
+      `${server.replace(/\/$/, '')}/games/${gameId}/log`,
+      `game_${gameId}_tenhou.json`,
+    );
+  }
+
+  async function downloadMjai() {
+    if (!gameId) return;
+    await downloadLog(
+      `${server.replace(/\/$/, '')}/games/${gameId}/mjai-log`,
+      `game_${gameId}_mjai.json`,
+    );
+  }
+
   function openWebSocket(id = gameId) {
     if (!id) return;
     const url = `${server.replace(/\/$/, '').replace('http', 'ws')}/ws/${id}`;
@@ -219,6 +255,16 @@ export default function App() {
             <div className="control ml-2">
               <Button aria-label="Show log" onClick={openLogModal}>
                 Log
+              </Button>
+            </div>
+            <div className="control ml-2">
+              <Button aria-label="Download MJAI log" onClick={downloadMjai}>
+                MJAI
+              </Button>
+            </div>
+            <div className="control ml-2">
+              <Button aria-label="Download Tenhou log" onClick={downloadTenhou}>
+                Tenhou
               </Button>
             </div>
           </>


### PR DESCRIPTION
## Summary
- enable MJAI-format log generation in core api
- expose new `/games/{id}/mjai-log` endpoint
- add download buttons for Tenhou and MJAI logs
- add vitest covering log download
- document new features in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686d97f609cc832a9c63005b31e9bb0d