### PR TITLE
Fix allowed actions after results

### DIFF
--- a/tests/web_gui/test_clear_allowed_actions.py
+++ b/tests/web_gui/test_clear_allowed_actions.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_allowed_actions_cleared_on_tsumo() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'setAllowedActions([[], [], [], []])' in text
+    idx = text.index('setAllowedActions([[], [], [], []])')
+    snippet = text[max(0, idx - 100): idx + 100]
+    assert 'tsumo' in snippet
+    assert 'ron' in snippet
+    assert 'ryukyoku' in snippet

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -127,6 +127,14 @@ export default function App() {
         });
         return next;
       });
+      if (
+        evt.name === 'tsumo' ||
+        evt.name === 'ron' ||
+        evt.name === 'ryukyoku'
+      ) {
+        setAllowedActions([[], [], [], []]);
+        return;
+      }
       if (evt.name !== 'next_actions' && gameId) {
         logNextActions(server, gameId, log, (line) =>
           setEvents((evts) => [...evts.slice(-9), line]),


### PR DESCRIPTION
## Summary
- clear allowed actions state in App when round ends
- test that App clears actions on `tsumo` event

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686dde3b27f8832aacb4491e90f0b0f0