### PR TITLE
Add bankruptcy termination check

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Future work will expand these components.
 - [x] end_game
 - [x] start_kyoku
 - [x] ryukyoku detection
+- [x] Game ends on bankruptcy (score ≤ 0)
 - [x] Noten penalty scoring on draws
 - [x] Draw result modal in GUI
 - [x] Win result modal in GUI

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -56,7 +56,9 @@ translate them directly.
 | `tsumo`            | `player_index`, `HandResponse`, scores  | Self-drawn win. |
 | `ron`              | `player_index`, `HandResponse`, scores  | Win on discard. |
 | `ryukyoku`         | reason                                  | Hand ends in draw. |
-| `end_game`         | final scores                            | Sent after the last hand. |
+| `end_game`         | final scores, reason                    | Sent after the last hand or on bankruptcy. |
+
+If a player's score drops to zero or below, the reason will be `"bankruptcy"` and the game ends immediately.
 
 Front ends are expected to update their displays or AI processes whenever an
 event is received.  The low level transport (function call, WebSocket, etc.) is

--- a/tests/core/test_bankruptcy.py
+++ b/tests/core/test_bankruptcy.py
@@ -1,0 +1,21 @@
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile
+from core.rules import RuleSet
+from mahjong.hand_calculating.hand_response import HandResponse
+
+
+class BigScoreRuleSet(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=1, cost={"total": 40000})
+
+
+def test_end_game_on_bankruptcy() -> None:
+    engine = MahjongEngine(ruleset=BigScoreRuleSet())
+    engine.pop_events()
+    engine.state.players[1].score = 1000
+    tile = Tile("man", 1)
+    engine.state.players[0].hand.tiles.append(tile)
+    engine.declare_tsumo(0, tile)
+    events = engine.pop_events()
+    assert events[-1].name == "end_game"
+    assert events[-1].payload.get("reason") == "bankruptcy"


### PR DESCRIPTION
## Summary
- end game when any player goes bankrupt
- allow optional reason when ending game
- document new end condition and API update
- test bankruptcy detection

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e3a569134832a8be4980f33841890