### PR TITLE
Fix repeated end_game calls

### DIFF
--- a/cli/local_game.py
+++ b/cli/local_game.py
@@ -23,5 +23,6 @@ def run_game(players: list[str]) -> None:
         name = state.players[player_index].name
         tile = api.auto_play_turn()
         click.echo(f"{name} drew {tile.suit}{tile.value} and discarded it")
-    api.end_game()
+    if not api.is_game_over():
+        api.end_game()
     click.echo("Game ended")

--- a/core/api.py
+++ b/core/api.py
@@ -153,6 +153,12 @@ def end_game() -> GameState:
     return _engine.end_game()
 
 
+def is_game_over() -> bool:
+    """Return True if the current game has ended."""
+    assert _engine is not None, "Game not started"
+    return _engine.is_game_over
+
+
 def pop_events() -> list[GameEvent]:
     """Retrieve and clear pending engine events."""
     assert _engine is not None, "Game not started"

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -66,6 +66,13 @@ def test_end_game_creates_new_state() -> None:
     assert new_state is not state
 
 
+def test_is_game_over() -> None:
+    api.start_game(["A", "B", "C", "D"])
+    assert not api.is_game_over()
+    api.end_game()
+    assert api.is_game_over()
+
+
 def test_declare_riichi_api() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     player = state.players[0]

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -102,6 +102,19 @@ def test_end_game_resets_state() -> None:
     assert engine.state.riichi_sticks == 0
 
 
+def test_end_game_ignored_on_subsequent_calls() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()  # clear start_game/start_kyoku
+    first = engine.end_game()
+    events = engine.pop_events()
+    assert events and events[-1].name == "end_game"
+    second = engine.end_game()
+    events = engine.pop_events()
+    assert not any(e.name == "end_game" for e in events)
+    assert first is second
+    assert engine.is_game_over
+
+
 def test_remaining_tiles_property() -> None:
     engine = MahjongEngine()
     remaining = engine.remaining_tiles


### PR DESCRIPTION
## Summary
- track end_game status in `MahjongEngine`
- expose `is_game_over` via API
- avoid calling `end_game` in CLI when already ended
- test repeated `end_game` calls and API flag

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e3b9246a0832aacbee0515f8ae973