### PR TITLE
Add max_rounds game configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ remain to be built:
 - [x] Closed and added kan support with replacement draws and new dora
   indicators.
 - [x] Tracking honba and riichi sticks in `GameState`.
-- [x] Automatic round progression with dealer repeats and hanchan end
-  detection.
+- [x] Automatic round progression with dealer repeats and configurable round
+  limit (east-only or hanchan).
 - [x] Exhaustive draw conditions: four kans and nine terminals detection.
 - [ ] Chankan ron on kan declarations.
 - [ ] Exhaustive draw condition: four riichi.

--- a/cli/local_game.py
+++ b/cli/local_game.py
@@ -6,9 +6,9 @@ import click
 from core import api
 
 
-def run_game(players: list[str]) -> None:
+def run_game(players: list[str], *, max_rounds: int = 8) -> None:
     """Run an automated local game."""
-    state = api.start_game(players)
+    state = api.start_game(players, max_rounds=max_rounds)
     players_display = ', '.join(p.name for p in state.players)
     click.echo(f"Game started with players: {players_display}")
     start_round = state.round_number

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,16 +13,17 @@ def cli() -> None:
 @cli.command()
 @click.argument("players", nargs=-1)
 @click.option("--server", "server", "-s", help="Base URL of remote server")
-def start(players: tuple[str, ...], server: str | None) -> None:
+@click.option("--max-rounds", type=int, default=8, help="Number of rounds to play")
+def start(players: tuple[str, ...], server: str | None, max_rounds: int) -> None:
     """Start a game with the given PLAYERS."""
     if not players:
         players = ("You", "AI1", "AI2", "AI3")
     if server:
-        data = remote_game.create_game(server, list(players))
+        data = remote_game.create_game(server, list(players), max_rounds=max_rounds)
         names = ", ".join(p["name"] for p in data.get("players", []))
         click.echo(f"Remote game created with players: {names}")
         return
-    run_game(list(players))
+    run_game(list(players), max_rounds=max_rounds)
 
 
 @cli.command()

--- a/cli/remote_game.py
+++ b/cli/remote_game.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 import requests
 
 
-def create_game(server: str, players: list[str]) -> dict:
+def create_game(server: str, players: list[str], *, max_rounds: int | None = None) -> dict:
     """Create a remote game and return the JSON response."""
     url = f"{server.rstrip('/')}/games"
-    resp = requests.post(url, json={"players": players})
+    data: dict[str, object] = {"players": players}
+    if max_rounds is not None:
+        data["max_rounds"] = max_rounds
+    resp = requests.post(url, json=data)
     resp.raise_for_status()
     return resp.json()
 

--- a/core/api.py
+++ b/core/api.py
@@ -11,10 +11,10 @@ from mahjong.hand_calculating.hand_response import HandResponse
 _engine: MahjongEngine | None = None
 
 
-def start_game(player_names: list[str]) -> GameState:
+def start_game(player_names: list[str], *, max_rounds: int = 8) -> GameState:
     """Initialize a new game and return its state."""
     global _engine
-    _engine = MahjongEngine()
+    _engine = MahjongEngine(max_rounds=max_rounds)
     for i, name in enumerate(player_names):
         if i < len(_engine.state.players):
             _engine.state.players[i].name = name

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -27,9 +27,10 @@ def _hand_response_dict(resp: HandResponse) -> dict[str, Any]:
 class MahjongEngine:
     """Simplified engine that wraps the `mahjong` library."""
 
-    def __init__(self, ruleset: RuleSet | None = None) -> None:
+    def __init__(self, ruleset: RuleSet | None = None, *, max_rounds: int = 8) -> None:
         self.ruleset: RuleSet = ruleset or StandardRuleSet()
         self.state = GameState(wall=Wall())
+        self.state.max_rounds = max_rounds
         self.state.players = [Player(name=f"Player {i}") for i in range(4)]
         self.state.current_player = 0
         self.events: list[GameEvent] = []
@@ -573,7 +574,7 @@ class MahjongEngine:
             self.state.dealer = (self.state.dealer + 1) % len(self.state.players)
             self.state.round_number += 1
 
-        if self.state.round_number > 8:
+        if self.state.round_number > self.state.max_rounds:
             self.end_game()
         else:
             self.start_kyoku(self.state.dealer, self.state.round_number)

--- a/core/models.py
+++ b/core/models.py
@@ -49,6 +49,7 @@ class GameState:
     current_player: int = 0
     dealer: int = 0
     round_number: int = 1
+    max_rounds: int = 8
     honba: int = 0
     riichi_sticks: int = 0
     kan_count: int = 0

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -19,13 +19,13 @@ The following classes defined in `core.models` are used throughout the API:
 | `Meld`     | Collection of tiles forming a meld.   |
 | `Hand`     | Player hand consisting of tiles and melds. |
 | `Player`   | Seat information including hand and score. |
-| `GameState`| Aggregated state of an ongoing game.  |
+| `GameState`| Aggregated state of an ongoing game including `max_rounds`.  |
 
 ## Commands (GUI/CLI -> Core)
 
 | Command            | Arguments                               | Purpose |
 | ------------------ | --------------------------------------- | ------- |
-| `start_game`       | list of player names                    | Begin a new hanchan. Returns `GameState`. |
+| `start_game`       | list of player names, `max_rounds`=8    | Begin a new game with the specified round limit. Returns `GameState`. |
 | `draw_tile`        | `player_index`                          | Draw the next tile for a player. |
 | `discard_tile`     | `player_index`, `Tile`                  | Discard a tile from the player's hand. |
 | `call_chi`         | `player_index`, `tiles`                 | Call `chi` using the given tiles. When only two tiles are provided the current discard is automatically added. |

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -12,7 +12,7 @@ def test_start_command_runs() -> None:
 
 
 def test_start_command_remote(monkeypatch) -> None:
-    def fake_create(server: str, players: list[str]) -> dict:
+    def fake_create(server: str, players: list[str], *, max_rounds: int | None = None) -> dict:
         return {"players": [{"name": p} for p in players]}
 
     monkeypatch.setattr("cli.remote_game.create_game", fake_create)

--- a/tests/core/test_round_progression.py
+++ b/tests/core/test_round_progression.py
@@ -24,9 +24,20 @@ def test_honba_increments_on_draw() -> None:
 
 
 def test_hanchan_ends_after_south4() -> None:
-    engine = MahjongEngine()
+    engine = MahjongEngine(max_rounds=8)
     engine.pop_events()
     for _ in range(8):
+        winner = (engine.state.dealer + 1) % 4
+        tile = engine.state.players[winner].hand.tiles[0]
+        engine.declare_tsumo(winner, tile)
+    events = engine.pop_events()
+    assert events[-1].name == "end_game"
+
+
+def test_east_only_ends_after_east4() -> None:
+    engine = MahjongEngine(max_rounds=4)
+    engine.pop_events()
+    for _ in range(4):
         winner = (engine.state.dealer + 1) % 4
         tile = engine.state.players[winner].hand.tiles[0]
         engine.declare_tsumo(winner, tile)

--- a/web/server.py
+++ b/web/server.py
@@ -26,6 +26,7 @@ class CreateGameRequest(BaseModel):
     """Request body for creating a new game."""
 
     players: list[str]
+    max_rounds: int | None = None
 
 
 class SuggestRequest(BaseModel):
@@ -44,7 +45,10 @@ def health() -> dict[str, str]:
 def create_game(req: CreateGameRequest) -> dict:
     """Create a new game and return its id and state."""
     global _next_game_id
-    state = api.start_game(req.players)
+    if req.max_rounds is not None:
+        state = api.start_game(req.players, max_rounds=req.max_rounds)
+    else:
+        state = api.start_game(req.players)
     game_id = _next_game_id
     _next_game_id += 1
     return {"id": game_id, **asdict(state)}


### PR DESCRIPTION
## Summary
- add `max_rounds` field in `GameState`
- support passing round limit to `MahjongEngine` and API
- respect round limit when advancing hands
- expose option in CLI and server
- document new setting in README and API docs
- test east-only vs hanchan limits

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_686e3b87872c832a80d66fa134a04f67