### PR TITLE
Batch websocket state updates

### DIFF
--- a/tests/web_gui/test_clear_allowed_actions.py
+++ b/tests/web_gui/test_clear_allowed_actions.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 def test_allowed_actions_cleared_on_tsumo() -> None:
     text = Path('web_gui/App.jsx').read_text()
-    assert 'setAllowedActions([[], [], [], []])' in text
-    idx = text.index('setAllowedActions([[], [], [], []])')
+    assert 'next.allowed = [[], [], [], []]' in text
+    idx = text.index('next.allowed = [[], [], [], []]')
     snippet = text[max(0, idx - 100): idx + 100]
     assert 'tsumo' in snippet
     assert 'ron' in snippet

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -18,9 +18,13 @@ export default function App() {
   const [connectionStatus, setConnectionStatus] = useState(null);
   const [players, setPlayers] = useState('A,B,C,D');
   const [gameId, setGameId] = useState(() => localStorage.getItem('gameId') || '');
-  const [gameState, setGameState] = useState(null);
+  const [gameData, setGameData] = useState({
+    state: null,
+    allowed: [[], [], [], []],
+  });
+  const gameState = gameData.state;
+  const allowedActions = gameData.allowed;
   const [events, setEvents] = useState([]);
-  const [allowedActions, setAllowedActions] = useState([[], [], [], []]);
   function log(level, message) {
     setEvents((evts) => [...evts.slice(-19), `[${level}] ${message}`]);
   }
@@ -68,7 +72,7 @@ export default function App() {
       });
       if (resp.ok) {
         const data = await resp.json();
-        setGameState(data);
+        setGameData((d) => ({ ...d, state: data }));
         setGameId(String(data.id));
         localStorage.setItem('gameId', String(data.id));
         setStatus('Game started');
@@ -85,10 +89,11 @@ export default function App() {
     try {
       if (!id) return;
       log('debug', `GET /games/${id} - restoring game state`);
-      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${id}`);
-      if (resp.ok) {
-        setGameState(await resp.json());
-      }
+        const resp = await fetch(`${server.replace(/\/$/, '')}/games/${id}`);
+        if (resp.ok) {
+          const data = await resp.json();
+          setGameData((d) => ({ ...d, state: data }));
+        }
     } catch {
       // ignore
     }
@@ -102,15 +107,19 @@ export default function App() {
       const evt = JSON.parse(e.data);
       log('info', formatEvent(evt));
       if (evt.name === 'allowed_actions') {
-        setAllowedActions(evt.payload?.actions || [[], [], [], []]);
+        setGameData((d) => ({ ...d, allowed: evt.payload?.actions || [[], [], [], []] }));
         setEvents((evts) => {
           const line = `${formatEvent(evt)} ${eventToMjaiJson(evt)}`;
           return [...evts.slice(-9), line];
         });
         return;
       }
-      setGameState((prev) => {
-        const next = applyEvent(prev, evt);
+      setGameData((prev) => {
+        const nextState = applyEvent(prev.state, evt);
+        const next = { ...prev, state: nextState };
+        if (evt.name === 'tsumo' || evt.name === 'ron' || evt.name === 'ryukyoku') {
+          next.allowed = [[], [], [], []];
+        }
         setEvents((evts) => {
           const lines = [];
           if (evt.name === 'draw_tile') {
@@ -127,12 +136,7 @@ export default function App() {
         });
         return next;
       });
-      if (
-        evt.name === 'tsumo' ||
-        evt.name === 'ron' ||
-        evt.name === 'ryukyoku'
-      ) {
-        setAllowedActions([[], [], [], []]);
+      if (evt.name === 'tsumo' || evt.name === 'ron' || evt.name === 'ryukyoku') {
         return;
       }
       if (evt.name !== 'next_actions' && gameId) {

--- a/web_gui/GameBoard.resultActions.test.jsx
+++ b/web_gui/GameBoard.resultActions.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function stateWithResult() {
+  return {
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: [], melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    result: {
+      type: 'tsumo',
+      player_index: 0,
+      scores: [25000, 25000, 25000, 25000],
+    },
+  };
+}
+
+describe('GameBoard actions cleared on result', () => {
+  it('disables action buttons when result displayed', () => {
+    render(<GameBoard state={stateWithResult()} server="" gameId="1" allowedActions={[['ron'], [], [], []]} />);
+    const ronBtns = screen.getAllByRole('button', { name: 'Ron' });
+    expect(ronBtns.every(b => b.disabled)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- consolidate game state and allowed actions into single object in `App.jsx`
- batch updates in `handleMessage`
- adjust string-based test to reflect new implementation
- add regression test ensuring action buttons are disabled when a result is shown

## Testing
- `pytest -q`
- `npx --no-install vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686e4098ae20832a85448ea1294a074b