### PR TITLE
Fix chi tile ordering

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -63,9 +63,19 @@ def call_chi(player_index: int, tiles: list[Tile]) -> None:
 
     if len(tiles) == 2:
         last_tile = _engine.state.last_discard
-        if last_tile is None:
+        last_player = _engine.state.last_discard_player
+        if last_tile is None or last_player is None:
             raise ValueError("No discard available for chi")
-        tiles = sorted(tiles + [last_tile], key=lambda t: t.value)
+
+        hand_tiles = sorted(tiles, key=lambda t: t.value)
+        called_from = (player_index - last_player) % len(_engine.state.players)
+
+        if called_from == 1:
+            tiles = [last_tile, *hand_tiles]
+        elif called_from == 3:
+            tiles = [*hand_tiles, last_tile]
+        else:
+            tiles = sorted([*hand_tiles, last_tile], key=lambda t: t.value)
 
     _engine.call_chi(player_index, tiles)
 

--- a/tests/core/test_meld_order.py
+++ b/tests/core/test_meld_order.py
@@ -1,0 +1,17 @@
+import pytest
+from core import api, models
+
+
+def test_call_chi_tile_order_from_left() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("man", 3)
+    discarder = state.players[1]
+    caller = state.players[2]
+    discarder.hand.tiles.append(tile)
+    state.current_player = 1
+    api.discard_tile(1, tile)
+    caller.hand.tiles.extend([models.Tile("man", 1), models.Tile("man", 2)])
+    api.call_chi(2, [models.Tile("man", 1), models.Tile("man", 2)])
+    meld = caller.hand.melds[0]
+    assert [t.value for t in meld.tiles] == [3, 1, 2]
+    assert meld.called_index == 0


### PR DESCRIPTION
## Summary
- fix tile order when API auto-inserts the discarded tile for chi
- add regression test for meld tile ordering

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e487fd268832aaebe3e60890baba1