### PR TITLE
Fix chi call to use engine discard tile

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -61,23 +61,31 @@ def call_chi(player_index: int, tiles: list[Tile]) -> None:
     """
     assert _engine is not None, "Game not started"
 
-    if len(tiles) == 2:
-        last_tile = _engine.state.last_discard
-        last_player = _engine.state.last_discard_player
-        if last_tile is None or last_player is None:
-            raise ValueError("No discard available for chi")
+    last_tile = _engine.state.last_discard
+    last_player = _engine.state.last_discard_player
+    if last_tile is None or last_player is None:
+        raise ValueError("No discard available for chi")
 
-        hand_tiles = sorted(tiles, key=lambda t: t.value)
-        called_from = (player_index - last_player) % len(_engine.state.players)
+    # Remove any discard representation so the engine instance is used.
+    hand_tiles = [
+        t
+        for t in tiles
+        if not (t.suit == last_tile.suit and t.value == last_tile.value)
+    ]
+    if len(hand_tiles) != 2:
+        raise ValueError("Chi requires exactly two tiles from hand")
 
-        if called_from == 1:
-            tiles = [last_tile, *hand_tiles]
-        elif called_from == 3:
-            tiles = [*hand_tiles, last_tile]
-        else:
-            tiles = sorted([*hand_tiles, last_tile], key=lambda t: t.value)
+    hand_tiles = sorted(hand_tiles, key=lambda t: t.value)
+    called_from = (player_index - last_player) % len(_engine.state.players)
 
-    _engine.call_chi(player_index, tiles)
+    if called_from == 1:
+        meld_tiles = [last_tile, *hand_tiles]
+    elif called_from == 3:
+        meld_tiles = [*hand_tiles, last_tile]
+    else:
+        meld_tiles = sorted([*hand_tiles, last_tile], key=lambda t: t.value)
+
+    _engine.call_chi(player_index, meld_tiles)
 
 
 def call_pon(player_index: int, tiles: list[Tile]) -> None:

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -28,7 +28,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `start_game`       | list of player names, `max_rounds`=8    | Begin a new game with the specified round limit. Returns `GameState`. |
 | `draw_tile`        | `player_index`                          | Draw the next tile for a player. |
 | `discard_tile`     | `player_index`, `Tile`                  | Discard a tile from the player's hand. |
-| `call_chi`         | `player_index`, `tiles`                 | Call `chi` using the given tiles. When only two tiles are provided the current discard is automatically added. |
+| `call_chi`         | `player_index`, `tiles`                 | Call `chi` using the given tiles. Two hand tiles may be passed and the discard is automatically inserted, or a full meld may be provided. Any discard tile sent by the front end is replaced with the engine's instance. |
 | `call_pon`         | `player_index`, `tiles`                 | Call `pon` using the given tiles. |
 | `call_kan`         | `player_index`, `tiles`                 | Declare an open or closed `kan`. |
 | `declare_ron`      | `player_index`, `Tile`                  | Win on another player's discard. |

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -58,6 +58,23 @@ def test_call_chi_missing_discard() -> None:
     assert caller.hand.melds[0].type == "chi"
 
 
+def test_call_chi_replaces_discard_instance() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("man", 3)
+    discarder = state.players[0]
+    caller = state.players[1]
+    discarder.hand.tiles.append(tile)
+    api.discard_tile(0, tile)
+    discard_ref = discarder.river[-1]
+    caller.hand.tiles.extend([models.Tile("man", 1), models.Tile("man", 2)])
+    api.call_chi(
+        1,
+        [models.Tile("man", 1), models.Tile("man", 2), models.Tile("man", 3)],
+    )
+    meld = caller.hand.melds[0]
+    assert any(t is discard_ref for t in meld.tiles)
+
+
 def test_end_game_creates_new_state() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     finished = api.end_game()


### PR DESCRIPTION
## Summary
- ensure API `call_chi` replaces any client-sent discard tile with the engine's instance
- clarify chi call behaviour in API docs
- test that API uses the correct discard instance when forming melds

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e4b1b90c4832ab64c8715761497c8