### PR TITLE
Implement chi selection modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Future work will expand these components.
 - [x] Event log modal with copy button
 - [x] Debug logging of GUI API calls
 - [x] Error modal shows server rejection
+- [x] Chi option modal when multiple chi choices are available
 - [x] Cancel in-flight allowed actions requests
 - [x] Download Tenhou log
 - [x] Download MJAI log

--- a/core/api.py
+++ b/core/api.py
@@ -236,6 +236,13 @@ def get_allowed_actions(player_index: int) -> list[str]:
     return _engine.get_allowed_actions(player_index)
 
 
+def get_chi_options(player_index: int) -> list[list[Tile]]:
+    """Return chi tile pairs available to ``player_index``."""
+
+    assert _engine is not None, "Game not started"
+    return _engine.get_chi_options(player_index)
+
+
 def get_all_allowed_actions() -> list[list[str]]:
     """Return allowed actions for all players."""
 

--- a/core/tests/test_chi_options.py
+++ b/core/tests/test_chi_options.py
@@ -1,0 +1,19 @@
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile
+
+
+def test_get_chi_options_multiple() -> None:
+    engine = MahjongEngine()
+    engine.state.last_discard = Tile("man", 5)
+    engine.state.last_discard_player = 0
+    engine.state.waiting_for_claims = [1, 2, 3]
+    player = engine.state.players[1]
+    player.hand.tiles = [
+        Tile("man", 3),
+        Tile("man", 4),
+        Tile("man", 6),
+        Tile("pin", 1),
+    ]
+    opts = engine.get_chi_options(1)
+    values = [[t.value for t in pair] for pair in opts]
+    assert sorted(values) == [[3, 4], [4, 6]]

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -37,6 +37,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `auto_play_turn`   | `player_index`, `ai_type`               | Draw and discard using the chosen AI. |
 | `end_game`         | none                                    | Terminate the current game. |
 | `get_state`        | none                                    | Retrieve the current `GameState`. |
+| `get_chi_options`  | `player_index`                          | List possible chi tile pairs for the last discard. |
 
 ## Events (Core -> GUI/CLI)
 

--- a/web/server.py
+++ b/web/server.py
@@ -170,6 +170,24 @@ def allowed_actions(game_id: int, player_index: int) -> dict:
     return {"actions": actions}
 
 
+@app.get("/games/{game_id}/chi-options/{player_index}")
+def chi_options(game_id: int, player_index: int) -> dict:
+    """Return chi tile pairs for ``player_index``."""
+
+    _ = game_id  # placeholder for future multi-game support
+    try:
+        options = api.get_chi_options(player_index)
+    except AssertionError:
+        raise HTTPException(status_code=404, detail="Game not started")
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Player not found")
+
+    def dump(pair: list[models.Tile]) -> list[dict]:
+        return [asdict(t) for t in pair]
+
+    return {"options": [dump(o) for o in options]}
+
+
 @app.get("/games/{game_id}/allowed-actions")
 def allowed_actions_all(game_id: int) -> dict:
     """Return allowed actions for all players."""

--- a/web_gui/ChiModal.jsx
+++ b/web_gui/ChiModal.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { tileToEmoji } from './tileUtils.js';
+
+export default function ChiModal({ options = [], discard = null, onSelect, onClose }) {
+  if (!options || options.length === 0) return null;
+  function renderMeld(pair) {
+    const meld = discard ? [...pair, discard] : pair.slice();
+    meld.sort((a, b) => a.value - b.value);
+    return meld.map((t, i) => (
+      <span key={i} className="mj-tile" aria-hidden="true">
+        {tileToEmoji(t)}
+      </span>
+    ));
+  }
+  return (
+    <div className="modal is-active">
+      <div className="modal-background" onClick={onClose}></div>
+      <div className="modal-content">
+        <div className="box">
+          <p>Choose Chi</p>
+          {options.map((opt, i) => (
+            <button
+              key={i}
+              className="button m-1"
+              aria-label={`chi option ${i}`}
+              onClick={() => onSelect?.(opt)}
+            >
+              {renderMeld(opt)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button className="modal-close is-large" aria-label="close" onClick={onClose}></button>
+    </div>
+  );
+}
+

--- a/web_gui/Controls.chi.test.jsx
+++ b/web_gui/Controls.chi.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import Controls from './Controls.jsx';
+
+function mockFetch() {
+  return vi.fn((url) => {
+    if (url.includes('/chi-options/')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ options: [[{ suit: 'man', value: 3 }, { suit: 'man', value: 4 }], [{ suit: 'man', value: 4 }, { suit: 'man', value: 6 }]] }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe('Controls chi modal', () => {
+  it('shows modal and sends action', async () => {
+    const fetchMock = mockFetch();
+    global.fetch = fetchMock;
+    render(
+      <Controls
+        server="http://s"
+        gameId="1"
+        playerIndex={0}
+        activePlayer={0}
+        allowedActions={['chi']}
+        waitingForClaims={[]}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Chi' }));
+    expect(fetchMock).toHaveBeenCalledWith('http://s/games/1/chi-options/0');
+    const opt = await screen.findByRole('button', { name: 'chi option 0' });
+    await userEvent.click(opt);
+    expect(fetchMock.mock.calls[1][0]).toBe('http://s/games/1/action');
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(body).toEqual({ player_index: 0, action: 'chi', tiles: [{ suit: 'man', value: 3 }, { suit: 'man', value: 4 }] });
+  });
+});
+

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -94,6 +94,7 @@ export default function PlayerPanel({
         waitingForClaims={waiting}
         aiActive={aiActive}
         allowedActions={actions}
+        lastDiscard={state?.last_discard}
         log={log}
         onError={setError}
       />

--- a/web_gui/chiOptions.js
+++ b/web_gui/chiOptions.js
@@ -1,0 +1,13 @@
+export async function getChiOptions(server, gameId, playerIndex, log = () => {}) {
+  try {
+    const url = `${server.replace(/\/$/, '')}/games/${gameId}/chi-options/${playerIndex}`;
+    log('debug', `GET ${url} - fetch chi options`);
+    const resp = await fetch(url);
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    return data.options || [];
+  } catch {
+    return [];
+  }
+}
+


### PR DESCRIPTION
## Summary
- provide `get_chi_options` helper in core API
- expose `/games/{id}/chi-options/{player}` endpoint
- add React modal to choose from multiple chi melds
- wire modal into player controls
- document the new capability and add tests

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx --no-install vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_686e4a387dac832aaabee11d73c3f02a