### PR TITLE
Fix duplicate action events

### DIFF
--- a/docs/web-gui-architecture.md
+++ b/docs/web-gui-architecture.md
@@ -22,10 +22,9 @@ Each component receives only the data it needs so the interface remains simple a
 1. After the page loads, `App` fetches the current game state via `GET /games/{id}`.
 2. `App` opens a WebSocket to `/ws/{id}` and listens for events.
 3. Incoming events update the React state, which re-renders the `GameBoard`.
-4. The GUI queries `/games/{id}/next-actions` to determine which player acts next
-   and what actions are possible. The set of allowed actions for each player is
-   pushed to the client via an `allowed_actions` WebSocket event, so no extra
-   requests are needed when claims are possible.
+4. The server broadcasts `next_actions` events over the WebSocket whenever the
+   active player or their options change. This eliminates the need for HTTP
+   polling.
 5. If the only action is `draw`, the server performs it automatically and returns
    the subsequent player instead.
 6. Otherwise the GUI checks if that player is AI-controlled and either requests

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -102,6 +102,11 @@ def test_app_opens_websocket() -> None:
     assert '/ws/${' in text
 
 
+def test_app_no_longer_fetches_next_actions() -> None:
+    text = Path('web_gui/App.jsx').read_text()
+    assert 'logNextActions' not in text
+
+
 def test_controls_use_server_prop() -> None:
     text = Path('web_gui/Controls.jsx').read_text()
     assert 'server' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -6,7 +6,6 @@ import { applyEvent } from './applyEvent.js';
 import Button from './Button.jsx';
 import EventLogModal from './EventLogModal.jsx';
 import { formatEvent, eventToMjaiJson } from './eventLog.js';
-import { logNextActions } from './eventFlow.js';
 import './style.css';
 import { FiRefreshCw, FiEye, FiEyeOff, FiCheck, FiShuffle, FiSettings, FiCopy } from "react-icons/fi";
 
@@ -141,11 +140,6 @@ export default function App() {
       });
       if (evt.name === 'tsumo' || evt.name === 'ron' || evt.name === 'ryukyoku') {
         return;
-      }
-      if (evt.name !== 'next_actions' && gameId) {
-        logNextActions(server, gameId, log, (line) =>
-          setEvents((evts) => [...evts.slice(-9), line]),
-        );
       }
     } catch {
       // ignore parse errors

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -99,6 +99,7 @@ export default function GameBoard({
             body: JSON.stringify(body),
           }).catch(() => {});
         } else if (
+          waiting.includes(idx) &&
           allowedActions[idx]?.length === 1 &&
           allowedActions[idx][0] === "skip" &&
           !skipSent.current.has(idx)


### PR DESCRIPTION
## Summary
- clarify that next actions come from the websocket
- stop polling next actions in the GUI
- tighten skip logic in `GameBoard`
- add a regression test

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686e4e257814832a828deb7555606e8a