### PR TITLE
Add kan event tests

### DIFF
--- a/tests/core/test_call_kan_events.py
+++ b/tests/core/test_call_kan_events.py
@@ -1,0 +1,57 @@
+import pytest
+from core.mahjong_engine import MahjongEngine
+from core.models import Tile
+
+
+def test_open_kan_events_order() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    discarder = engine.state.players[1]
+    caller = engine.state.players[0]
+    tile = Tile('man', 1)
+    discarder.hand.tiles.append(tile)
+    engine.state.current_player = 1
+    engine.discard_tile(1, tile)
+    engine.pop_events()
+    caller.hand.tiles.extend([Tile('man', 1) for _ in range(3)])
+    engine.call_kan(0, [Tile('man', 1)] * 4)
+    events = engine.pop_events()
+    names = [e.name for e in events]
+    assert names == ['claims_closed', 'meld']
+    meld = events[-1].payload['meld']
+    assert meld.type == 'kan'
+    assert len(meld.tiles) == 4
+    assert events[-1].payload['player_index'] == 0
+
+
+def test_closed_kan_event() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    engine.state.players[0].hand.tiles = [Tile('sou', 5)] * 4
+    engine.call_kan(0, [Tile('sou', 5)] * 4)
+    events = engine.pop_events()
+    assert [e.name for e in events] == ['meld']
+    meld = events[0].payload['meld']
+    assert meld.type == 'closed_kan'
+    assert len(meld.tiles) == 4
+
+
+def test_added_kan_event() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    discarder = engine.state.players[1]
+    caller = engine.state.players[0]
+    tile = Tile('pin', 2)
+    discarder.hand.tiles.append(tile)
+    engine.state.current_player = 1
+    engine.discard_tile(1, tile)
+    caller.hand.tiles.extend([Tile('pin', 2), Tile('pin', 2)])
+    engine.call_pon(0, [Tile('pin', 2), Tile('pin', 2), tile])
+    engine.pop_events()
+    caller.hand.tiles.append(Tile('pin', 2))
+    engine.call_kan(0, [Tile('pin', 2)] * 4)
+    events = engine.pop_events()
+    assert [e.name for e in events] == ['meld']
+    meld = events[0].payload['meld']
+    assert meld.type == 'added_kan'
+    assert len(meld.tiles) == 4

--- a/tests/web_gui/test_kan_action.py
+++ b/tests/web_gui/test_kan_action.py
@@ -1,0 +1,26 @@
+import subprocess
+
+
+def run_node(code: str) -> str:
+    result = subprocess.run([
+        'node',
+        '-e',
+        code,
+    ], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_apply_kan_updates_board_and_log() -> None:
+    code = (
+        "import { applyEvent } from './web_gui/applyEvent.js';\n"
+        "import { formatEvent } from './web_gui/eventLog.js';\n"
+        "const state = {last_discard:{suit:'man',value:1}, last_discard_player:1, current_player:1,\n"
+        "  players:[{hand:{tiles:[{suit:'man',value:1},{suit:'man',value:1},{suit:'man',value:1}], melds:[]}, river:[]},\n"
+        "           {hand:{tiles:[], melds:[]}, river:[{suit:'man',value:1}]}]};\n"
+        "const evt = {name:'meld', payload:{player_index:0, meld:{tiles:[{suit:'man',value:1},{suit:'man',value:1},{suit:'man',value:1},{suit:'man',value:1}], type:'kan', called_index:0}}};\n"
+        "const newState = applyEvent(state, evt);\n"
+        "console.log(newState.players[1].river.length + ':' + newState.players[0].hand.melds.length + ':' + newState.current_player + ':' + newState.last_discard + ':' + formatEvent(evt));"
+    )
+    output = run_node(code)
+    assert output == '0:1:0:null:Player 0 calls kan'


### PR DESCRIPTION
## Summary
- test order & contents of events emitted during `call_kan`
- test kan meld handling in the web GUI

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `npx --no-install vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686e66fc23e8832a93e4fc6644e6bcbe