### PR TITLE
Document and emit kan replacement draw

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -46,13 +46,21 @@ class MahjongEngine:
         """Clear cached allowed actions."""
         self._cached_allowed_actions = None
 
-    def _draw_replacement_tile(self, player: Player) -> None:
-        """Draw a replacement tile from the dead wall and reveal new dora."""
+    def _draw_replacement_tile(self, player: Player, player_index: int) -> None:
+        """Draw a replacement tile from the dead wall and reveal new dora.
+
+        A ``draw_tile`` event is emitted so front ends can display the
+        replacement tile. The payload includes ``source='dead_wall'``.
+        """
         assert self.state.wall is not None
         if not self.state.wall.dead_wall:
             return
         tile = self.state.wall.dead_wall.pop(0)
         player.draw(tile)
+        self._emit(
+            "draw_tile",
+            {"player_index": player_index, "tile": tile, "source": "dead_wall"},
+        )
         if self.state.dead_wall:
             self.state.dead_wall.pop(0)
         # Reveal next dora indicator if available
@@ -435,7 +443,7 @@ class MahjongEngine:
             self.state.last_discard_player = None
             self.state.waiting_for_claims = []
             self._close_claims()
-            self._draw_replacement_tile(player)
+            self._draw_replacement_tile(player, player_index)
             self.state.current_player = player_index
             self._emit("meld", {"player_index": player_index, "meld": meld})
             self.state.kan_count += 1
@@ -462,7 +470,7 @@ class MahjongEngine:
                 meld.type = "added_kan"
                 self.state.waiting_for_claims = []
                 self._close_claims()
-                self._draw_replacement_tile(player)
+                self._draw_replacement_tile(player, player_index)
                 self.state.current_player = player_index
                 self._emit("meld", {"player_index": player_index, "meld": meld})
                 self.state.kan_count += 1
@@ -487,7 +495,7 @@ class MahjongEngine:
         player.hand.melds.append(meld)
         self.state.waiting_for_claims = []
         self._close_claims()
-        self._draw_replacement_tile(player)
+        self._draw_replacement_tile(player, player_index)
         self.state.current_player = player_index
         self._emit("meld", {"player_index": player_index, "meld": meld})
         self.state.kan_count += 1

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -49,7 +49,7 @@ translate them directly.
 | ------------------ | --------------------------------------- | ----- |
 | `start_game`       | `GameState`                             | Sent once at the beginning. |
 | `start_kyoku`      | dealer seat and round number            | Signals the start of a hand. |
-| `draw_tile`        | `player_index`, `Tile`                  | Tile drawn from the wall. |
+| `draw_tile`        | `player_index`, `Tile`, `source`        | Tile drawn from the wall. When emitted after a kan, `source` will be `"dead_wall"`. |
 | `discard`          | `player_index`, `Tile`                  | Tile placed into the river. |
 | `meld`             | `player_index`, `Meld`                  | Meld call (chi/pon/kan). |
 | `claims_closed`    | none                                    | No player called the discard. |
@@ -59,6 +59,9 @@ translate them directly.
 | `ryukyoku`         | reason                                  | Hand ends in draw. |
 | `round_end`        | next dealer and round                   | Fired before the next hand begins. |
 | `end_game`         | final scores, reason                    | Sent after the last hand or when a player goes bankrupt. |
+
+The replacement tile drawn after any kan uses this `draw_tile` event so
+front ends always receive the tile and know it came from the dead wall.
 
 Front ends are expected to update their displays or AI processes whenever an
 event is received.  The low level transport (function call, WebSocket, etc.) is

--- a/docs/kyoku-flow.md
+++ b/docs/kyoku-flow.md
@@ -7,6 +7,7 @@ flowchart TD
     A[draw_tile()] --> B{declare_tsumo() / call_kan()?}
     B -- tsumo --> C[declare_tsumo()]
     B -- kan --> D[call_kan() and draw replacement]
+    D --> E1[emit draw_tile(source: dead_wall)]
     B -- none --> E{declare_riichi()?}
     E -- yes --> F[declare_riichi()]
     E -- no --> G[discard_tile()]
@@ -23,6 +24,7 @@ Each node corresponds to a method in `MahjongEngine`:
 
 - `draw_tile()` – draw a tile from the wall and advance `current_player`.
 - `call_kan()` – form a kan meld and draw a replacement tile.
+  The engine emits a `draw_tile` event immediately with `source: "dead_wall"`.
 - `declare_tsumo()` – self-drawn win; updates scores and ends the hand.
 - `declare_riichi()` – declare riichi and set `must_tsumogiri`.
 - `discard_tile()` – place a tile in the river and set `waiting_for_claims`.

--- a/docs/web-gui-architecture.md
+++ b/docs/web-gui-architecture.md
@@ -22,6 +22,9 @@ Each component receives only the data it needs so the interface remains simple a
 1. After the page loads, `App` fetches the current game state via `GET /games/{id}`.
 2. `App` opens a WebSocket to `/ws/{id}` and listens for events.
 3. Incoming events update the React state, which re-renders the `GameBoard`.
+   When the engine sends a `draw_tile` event with `source: "dead_wall"` (after a
+   kan), the tile is inserted into the acting player's hand before further
+   actions are offered.
 4. The GUI queries `/games/{id}/next-actions` to determine which player acts next
    and what actions are possible. The set of allowed actions for each player is
    pushed to the client via an `allowed_actions` WebSocket event, so no extra

--- a/tests/core/test_closed_added_kan.py
+++ b/tests/core/test_closed_added_kan.py
@@ -18,6 +18,19 @@ def test_call_closed_kan_draws_replacement_and_dora() -> None:
     assert len(engine.state.dora_indicators) == before_dora + 1
 
 
+def test_call_kan_emits_draw_event() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()
+    tiles = [Tile("man", 5) for _ in range(4)]
+    engine.state.players[0].hand.tiles = tiles.copy()
+    engine.call_kan(0, tiles)
+    last_two = engine.event_history[-2:]
+    assert last_two[0].name == "draw_tile"
+    assert last_two[0].payload["player_index"] == 0
+    assert last_two[0].payload.get("source") == "dead_wall"
+    assert last_two[1].name == "meld"
+
+
 def test_call_added_kan_upgrades_pon() -> None:
     engine = MahjongEngine()
     discarder = engine.state.players[0]


### PR DESCRIPTION
## Summary
- emit `draw_tile` event for kan replacement draws
- document the replacement draw flow in game docs
- describe GUI handling of `draw_tile` after kan
- test that the new event is emitted

## Testing
- `python -m build core`
- `python -m build cli`
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`

------
https://chatgpt.com/codex/tasks/task_e_686e66fc61f4832a92a552cd60963b95