### PR TITLE
Fix kan event tests

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -447,6 +447,7 @@ class MahjongEngine:
             self.state.last_discard_player = None
             self.state.waiting_for_claims = []
             self._close_claims()
+            # TODO: support chankan (槍槓) before drawing replacement tile
             self._draw_replacement_tile(player, player_index)
             self.state.current_player = player_index
             self._emit("meld", {"player_index": player_index, "meld": meld})
@@ -474,6 +475,7 @@ class MahjongEngine:
                 meld.type = "added_kan"
                 self.state.waiting_for_claims = []
                 self._close_claims()
+                # TODO: support chankan (槍槓) before drawing replacement tile
                 self._draw_replacement_tile(player, player_index)
                 self.state.current_player = player_index
                 self._emit("meld", {"player_index": player_index, "meld": meld})
@@ -499,6 +501,7 @@ class MahjongEngine:
         player.hand.melds.append(meld)
         self.state.waiting_for_claims = []
         self._close_claims()
+        # TODO: support chankan (槍槓) before drawing replacement tile
         self._draw_replacement_tile(player, player_index)
         self.state.current_player = player_index
         self._emit("meld", {"player_index": player_index, "meld": meld})

--- a/tests/core/test_call_kan_events.py
+++ b/tests/core/test_call_kan_events.py
@@ -17,7 +17,7 @@ def test_open_kan_events_order() -> None:
     engine.call_kan(0, [Tile('man', 1)] * 4)
     events = engine.pop_events()
     names = [e.name for e in events]
-    assert names == ['claims_closed', 'meld']
+    assert names == ['claims_closed', 'draw_tile', 'meld']
     meld = events[-1].payload['meld']
     assert meld.type == 'kan'
     assert len(meld.tiles) == 4
@@ -30,8 +30,8 @@ def test_closed_kan_event() -> None:
     engine.state.players[0].hand.tiles = [Tile('sou', 5)] * 4
     engine.call_kan(0, [Tile('sou', 5)] * 4)
     events = engine.pop_events()
-    assert [e.name for e in events] == ['meld']
-    meld = events[0].payload['meld']
+    assert [e.name for e in events] == ['draw_tile', 'meld']
+    meld = events[1].payload['meld']
     assert meld.type == 'closed_kan'
     assert len(meld.tiles) == 4
 
@@ -51,7 +51,7 @@ def test_added_kan_event() -> None:
     caller.hand.tiles.append(Tile('pin', 2))
     engine.call_kan(0, [Tile('pin', 2)] * 4)
     events = engine.pop_events()
-    assert [e.name for e in events] == ['meld']
-    meld = events[0].payload['meld']
+    assert [e.name for e in events] == ['draw_tile', 'meld']
+    meld = events[1].payload['meld']
     assert meld.type == 'added_kan'
     assert len(meld.tiles) == 4


### PR DESCRIPTION
## Summary
- fix expectations for kan event ordering
- leave TODO for chankan support

## Testing
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e70f82884832a8cdaf296158ec354