### PR TITLE
Add configurable AI delay for GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Future work will expand these components.
 - [x] Start round via API
 - [x] Simple shanten-based AI for automated turns (discards tiles that keep shanten and calls pon/chi when it improves the hand)
 - [x] Toggle AI per player from GUI
+- [x] Configurable AI delay in GUI
 - [x] AI type selection framework (currently only 'simple')
 - [x] Players 2-4 use AI by default in GUI
 - [x] Handle start_kyoku event in GUI

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -31,6 +31,9 @@ export default function App() {
   const [mode, setMode] = useState('game');
   const [peek, setPeek] = useState(false);
   const [sortHand, setSortHand] = useState(true);
+  const [aiDelay, setAiDelay] = useState(() =>
+    Number(localStorage.getItem('aiDelay') || 0),
+  );
   const [showSettings, setShowSettings] = useState(false);
   const [showLog, setShowLog] = useState(false);
   const wsRef = useRef(null);
@@ -42,6 +45,10 @@ export default function App() {
   useEffect(() => {
     if (gameId) localStorage.setItem('gameId', gameId);
   }, [gameId]);
+
+  useEffect(() => {
+    localStorage.setItem('aiDelay', String(aiDelay));
+  }, [aiDelay]);
 
   useEffect(() => {
     if (gameState?.result?.type === 'end_game') {
@@ -337,6 +344,17 @@ export default function App() {
               style={{ width: '20em' }}
             />
           </label>
+          <label className="label mr-2">
+            AI delay (ms):
+            <input
+              className="input"
+              type="number"
+              min="0"
+              value={aiDelay}
+              onChange={(e) => setAiDelay(Number(e.target.value))}
+              style={{ width: '6em' }}
+            />
+          </label>
           <div className="control">
             <Button onClick={startGame}>Start Game</Button>
           </div>
@@ -398,15 +416,16 @@ export default function App() {
         </div>
       )}
       {mode === 'game' ? (
-        <GameBoard
-          state={gameState}
-          server={server}
-          gameId={gameId}
-          peek={peek}
-          sortHand={sortHand}
-          log={log}
-          allowedActions={allowedActions}
-        />
+          <GameBoard
+            state={gameState}
+            server={server}
+            gameId={gameId}
+            peek={peek}
+            sortHand={sortHand}
+            log={log}
+            allowedActions={allowedActions}
+            aiDelay={aiDelay}
+          />
       ) : mode === 'practice' ? (
         <Practice server={server} sortHand={sortHand} log={log} />
       ) : (

--- a/web_gui/GameBoard.aiDelay.test.jsx
+++ b/web_gui/GameBoard.aiDelay.test.jsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState(playerIndex = 1) {
+  return {
+    current_player: playerIndex,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    waiting_for_claims: [],
+    last_discard: { suit: 'man', value: 1 },
+  };
+}
+
+describe('GameBoard aiDelay', () => {
+  it('delays AI requests', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = fetchMock;
+    const state = mockState(1);
+    render(<GameBoard state={state} server="http://s" gameId="1" aiDelay={500} />);
+    await Promise.resolve();
+    const before = fetchMock.mock.calls.filter(c => c[0].includes('/action'));
+    expect(before.length).toBe(0);
+    vi.advanceTimersByTime(500);
+    await Promise.resolve();
+    const after = fetchMock.mock.calls.filter(c => c[0].includes('/action'));
+    expect(after.length).toBe(1);
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- support adjustable AI delay in GameBoard via `aiDelay` prop
- persist delay setting and expose input in GUI options
- add regression tests for delayed AI actions
- document GUI AI delay feature

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `/root/.pyenv/versions/3.12.10/bin/flake8`
- `/root/.pyenv/versions/3.12.10/bin/mypy core web cli`
- `/root/.pyenv/versions/3.12.10/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686e7c37779c832a9aba498b7089b60a