### PR TITLE
Fix extra draw after melds

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -209,12 +209,14 @@ class MahjongEngine:
             raise ValueError("Waiting for other players to claim discard")
         if player_index != self.state.current_player:
             raise ValueError("Not player's turn")
+        player = self.state.players[player_index]
+        if len(player.hand.tiles) % 3 != 1:
+            raise ValueError("Cannot draw before discarding")
         self._check_four_winds()
         assert self.state.wall is not None
         tile = self.state.wall.draw_tile()
-        self.state.players[player_index].draw(tile)
+        player.draw(tile)
         self._emit("draw_tile", {"player_index": player_index, "tile": tile})
-        player = self.state.players[player_index]
         if len(player.river) == 0 and not player.hand.melds:
             self._check_nine_terminals(player)
         if self.state.wall.remaining_tiles == 0:

--- a/core/simple_ai.py
+++ b/core/simple_ai.py
@@ -14,19 +14,17 @@ from .rules import _tile_to_index
 def tsumogiri_turn(engine: MahjongEngine, player_index: int) -> Tile:
     """Play a full turn by discarding the drawn tile.
 
-    If the player has already drawn (hand size >= 14), simply discard the last
-    tile instead of drawing again. This allows enabling AI mid-turn.
+    The AI only draws when the player has just discarded (hand size modulo 3
+    equals 1). After calling melds the hand size will not satisfy this
+    condition so no extra draw occurs.
     """
 
     player = engine.state.players[player_index]
-    if len(player.hand.tiles) >= 14:
+    if len(player.hand.tiles) % 3 == 1:
+        tile = engine.draw_tile(player_index)
+    else:
         tile = player.hand.tiles[-1]
-        engine.discard_tile(player_index, tile)
-        return tile
-
-    tile = engine.draw_tile(player_index)
-    if tile in player.hand.tiles:
-        engine.discard_tile(player_index, tile)
+    engine.discard_tile(player_index, tile)
     return tile
 
 
@@ -63,7 +61,7 @@ def shanten_turn(engine: MahjongEngine, player_index: int) -> Tile:
     """Play a turn by discarding a shanten-neutral tile."""
 
     player = engine.state.players[player_index]
-    if len(player.hand.tiles) < 14:
+    if len(player.hand.tiles) % 3 == 1:
         engine.draw_tile(player_index)
     tile = suggest_discard(player.hand.tiles)
     engine.discard_tile(player_index, tile)

--- a/core/tests/test_imports.py
+++ b/core/tests/test_imports.py
@@ -15,5 +15,6 @@ def test_basic_classes() -> None:
     tile = models.Tile(suit="man", value=1)
     assert engine.state.wall is not None
     engine.state.wall.tiles.append(tile)
+    engine.state.players[0].hand.tiles.pop()
     drawn = engine.draw_tile(0)
     assert drawn == tile

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -20,6 +20,7 @@ def test_draw_and_discard() -> None:
     assert state.wall is not None
     tile = models.Tile(suit="sou", value=9)
     state.wall.tiles.append(tile)
+    state.players[0].hand.tiles.pop()
     drawn = api.draw_tile(0)
     assert drawn == tile
     api.discard_tile(0, tile)

--- a/tests/core/test_apply_action.py
+++ b/tests/core/test_apply_action.py
@@ -7,6 +7,7 @@ def test_apply_action_draw_discard() -> None:
     assert state.wall is not None
     tile = models.Tile(suit="sou", value=9)
     state.wall.tiles.append(tile)
+    state.players[0].hand.tiles.pop()
     draw = models.GameAction(type="draw", player_index=0)
     result = api.apply_action(draw)
     assert result == tile

--- a/tests/core/test_claim_window.py
+++ b/tests/core/test_claim_window.py
@@ -6,7 +6,7 @@ def test_claim_options_removed_after_draw() -> None:
     discard = models.Tile("man", 3)
     state.players[0].hand.tiles = [discard]
     api.discard_tile(0, discard)
-    state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 2)]
+    state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 2)] + [models.Tile("pin", 1)] * 11
     actions = api.get_allowed_actions(1)
     assert "chi" in actions
     api.skip(1)

--- a/tests/core/test_exhaustive_draw.py
+++ b/tests/core/test_exhaustive_draw.py
@@ -81,28 +81,24 @@ def test_four_winds_triggers_ryukyoku() -> None:
     engine.skip(1)
     engine.skip(2)
     engine.skip(3)
-    engine.draw_tile(1)
     engine.state.players[1].hand.tiles[-1] = Tile("wind", 1)
     east1 = engine.state.players[1].hand.tiles[-1]
     engine.discard_tile(1, east1)
     engine.skip(2)
     engine.skip(3)
     engine.skip(0)
-    engine.draw_tile(2)
     engine.state.players[2].hand.tiles[-1] = Tile("wind", 1)
     east2 = engine.state.players[2].hand.tiles[-1]
     engine.discard_tile(2, east2)
     engine.skip(3)
     engine.skip(0)
     engine.skip(1)
-    engine.draw_tile(3)
     engine.state.players[3].hand.tiles[-1] = Tile("wind", 1)
     east3 = engine.state.players[3].hand.tiles[-1]
     engine.discard_tile(3, east3)
     engine.skip(0)
     engine.skip(1)
     engine.skip(2)
-    engine.draw_tile(0)
     events = engine.pop_events()
     assert any(
         e.name == "ryukyoku" and e.payload.get("reason") == "four_winds"

--- a/tests/core/test_round_end_event.py
+++ b/tests/core/test_round_end_event.py
@@ -15,6 +15,7 @@ def test_round_end_after_draw() -> None:
     engine = MahjongEngine()
     engine.pop_events()
     engine.state.wall.tiles = [Tile("pin", 1)]
+    engine.state.players[engine.state.current_player].hand.tiles.pop()
     engine.draw_tile(engine.state.current_player)
     names = [e.name for e in engine.pop_events()]
     assert names == ["draw_tile", "ryukyoku", "round_end", "start_kyoku"]

--- a/tests/core/test_round_progression.py
+++ b/tests/core/test_round_progression.py
@@ -17,6 +17,7 @@ def test_honba_increments_on_draw() -> None:
     engine.pop_events()
     assert engine.state.wall is not None
     engine.state.wall.tiles = [Tile("pin", 1)]
+    engine.state.players[engine.state.current_player].hand.tiles.pop()
     engine.draw_tile(engine.state.current_player)
     assert engine.state.honba == 1
     assert engine.state.round_number == 1

--- a/tests/core/test_ryukyoku_penalty.py
+++ b/tests/core/test_ryukyoku_penalty.py
@@ -13,6 +13,7 @@ def test_ryukyoku_noten_penalty() -> None:
     engine._is_tenpai = fake_is_tenpai  # type: ignore
     assert engine.state.wall is not None
     engine.state.wall.tiles = [Tile("man", 1)]
+    engine.state.players[engine.state.current_player].hand.tiles.pop()
     engine.draw_tile(engine.state.current_player)
     events = engine.pop_events()
     ryukyoku = next(e for e in events if e.name == "ryukyoku")

--- a/tests/core/test_simple_ai.py
+++ b/tests/core/test_simple_ai.py
@@ -22,3 +22,70 @@ def test_auto_play_turn_discards_best_tile(monkeypatch) -> None:
     assert len(actor.hand.tiles) == 13
     assert state.current_player == (player + 1) % 4
 
+
+def test_auto_play_turn_after_chi_no_draw() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    engine = api._engine
+    assert engine is not None
+    engine.pop_events()
+    discarder = 0
+    caller = 1
+    chi_tile = models.Tile("man", 1)
+    engine.state.players[discarder].hand.tiles = [chi_tile] * 14
+    engine.state.current_player = discarder
+    api.discard_tile(discarder, chi_tile)
+    engine.pop_events()
+    engine.state.players[caller].hand.tiles = [
+        models.Tile("man", 2),
+        models.Tile("man", 3),
+        *([models.Tile("pin", 1)] * 11),
+    ]
+    api.call_chi(caller, [models.Tile("man", 2), models.Tile("man", 3)])
+    engine.pop_events()
+    api.auto_play_turn(caller)
+    events = engine.pop_events()
+    assert [e.name for e in events] == ["discard"]
+    assert len(engine.state.players[caller].hand.tiles) == 10
+
+
+def test_auto_play_turn_after_pon_no_draw() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    engine = api._engine
+    assert engine is not None
+    engine.pop_events()
+    discarder = 0
+    caller = 2
+    pon_tile = models.Tile("pin", 5)
+    engine.state.players[discarder].hand.tiles = [pon_tile] * 14
+    engine.state.current_player = discarder
+    api.discard_tile(discarder, pon_tile)
+    engine.pop_events()
+    engine.state.players[caller].hand.tiles = [
+        pon_tile,
+        pon_tile,
+        *([models.Tile("sou", 1)] * 11),
+    ]
+    api.call_pon(caller, [pon_tile, pon_tile, pon_tile])
+    engine.pop_events()
+    api.auto_play_turn(caller)
+    events = engine.pop_events()
+    assert [e.name for e in events] == ["discard"]
+    assert len(engine.state.players[caller].hand.tiles) == 10
+
+
+def test_auto_play_turn_after_kan_no_extra_draw() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    engine = api._engine
+    assert engine is not None
+    engine.pop_events()
+    caller = 0
+    kan_tile = models.Tile("sou", 5)
+    engine.state.players[caller].hand.tiles = [kan_tile] * 4 + [models.Tile("man", 1)] * 10
+    api.call_kan(caller, [kan_tile] * 4)
+    # events: draw_tile from dead wall then meld
+    engine.pop_events()
+    api.auto_play_turn(caller)
+    events = engine.pop_events()
+    assert [e.name for e in events] == ["discard"]
+    assert len(engine.state.players[caller].hand.tiles) == 10
+

--- a/tests/core/test_turn_rotation.py
+++ b/tests/core/test_turn_rotation.py
@@ -5,6 +5,7 @@ from core.mahjong_engine import MahjongEngine
 def test_draw_advances_turn() -> None:
     engine = MahjongEngine()
     current = engine.state.current_player
+    engine.state.players[current].hand.tiles.pop()
     engine.draw_tile(current)
     assert engine.state.current_player == current
 


### PR DESCRIPTION
## Summary
- prevent drawing when hand size is not in a drawable state
- adjust tests to respect new draw rules
- verify that players can't draw again after chi, pon, or kan

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx --no-install vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_686e7fea9478832a87d9a368e100b1c1