### PR TITLE
Fix pon action in GUI and enhance logs

### DIFF
--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -22,7 +22,10 @@ export function Controls({
 
   async function simple(action, payload = {}) {
     try {
-      log('debug', `POST /games/${gameId}/action ${action} - control button`);
+      log(
+        'debug',
+        `POST /games/${gameId}/action ${action} ${JSON.stringify(payload)} - control button`,
+      );
       const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -75,7 +78,9 @@ export function Controls({
   }
 
   function pon() {
-    simple('pon', { tiles: [{ suit: 'pin', value: 1 }, { suit: 'pin', value: 1 }, { suit: 'pin', value: 1 }] });
+    if (!lastDiscard) return;
+    const tile = { suit: lastDiscard.suit, value: lastDiscard.value };
+    simple('pon', { tiles: [tile, tile, tile] });
   }
 
   function kan() {

--- a/web_gui/Controls.pon.test.jsx
+++ b/web_gui/Controls.pon.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import Controls from './Controls.jsx';
+
+function mockFetch() {
+  return vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+}
+
+describe('Controls pon action', () => {
+  it('uses lastDiscard tile when calling pon', async () => {
+    const fetchMock = mockFetch();
+    global.fetch = fetchMock;
+    const last = { suit: 'dragon', value: 3 };
+    render(
+      <Controls
+        server="http://s"
+        gameId="1"
+        playerIndex={0}
+        activePlayer={0}
+        allowedActions={['pon']}
+        waitingForClaims={[]}
+        lastDiscard={last}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Pon' }));
+    expect(fetchMock).toHaveBeenCalledWith('http://s/games/1/action', expect.objectContaining({ method: 'POST' }));
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({
+      player_index: 0,
+      action: 'pon',
+      tiles: [last, last, last],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- log payload details for GUI actions
- send correct tiles for pon using the last discard
- test pon button behaviour

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_686e82a167a4832aa035abb385728d6c