### PR TITLE
Improve hand display spacing and sorting

### DIFF
--- a/tests/web_gui/test_hand_with_melds_gap.py
+++ b/tests/web_gui/test_hand_with_melds_gap.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_hand_with_melds_has_gap() -> None:
+    css = Path('web_gui/style.css').read_text()
+    start = css.index('.hand-with-melds')
+    block = css[start:css.index('}', start)]
+    assert 'gap:' in block

--- a/tests/web_gui/test_sort_after_discard.py
+++ b/tests/web_gui/test_sort_after_discard.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_game_board_resorts_hand() -> None:
+    text = Path('web_gui/GameBoard.jsx').read_text()
+    start = text.index('const southHand')
+    snippet = text[start:text.index(';', start)]
+    assert 'hasDrawnTile(south, 0)' in snippet
+    assert 'sortTilesExceptLast' in snippet
+    assert 'sortTiles(southTiles)' in snippet

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -206,7 +206,9 @@ export default function GameBoard({
   const southTiles = south?.hand?.tiles ?? null;
   const southHand = southTiles
     ? sortHand
-      ? sortTilesExceptLast(southTiles)
+      ? hasDrawnTile(south, 0)
+        ? sortTilesExceptLast(southTiles)
+        : sortTiles(southTiles)
       : southTiles
     : defaultHand;
 

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -39,6 +39,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .north { grid-area: north; }


### PR DESCRIPTION
## Summary
- adjust spacing between the hand and meld area
- re-sort player hand after discards so drawn tile isn't left on the edge
- test for new spacing rule
- test for south hand re-sorting logic

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `/root/.pyenv/versions/3.12.10/bin/flake8`
- `/root/.pyenv/versions/3.12.10/bin/mypy core web cli`
- `/root/.pyenv/versions/3.12.10/bin/pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686ed666d3c0832aa482d325b884381d