### PR TITLE
Fix riichi availability rules

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -256,10 +256,12 @@ def get_allowed_actions(player_index: int) -> list[str]:
 
     # Only allow riichi immediately after the player discards.
     last = engine.state.last_discard_player
+    player = engine.state.players[player_index]
     if (
         last == player_index
-        and not engine.state.players[player_index].riichi
-        and engine._is_tenpai(engine.state.players[player_index])
+        and not player.riichi
+        and not player.has_open_melds()
+        and engine._is_tenpai(player)
     ):
         return ["riichi", "skip"]
 

--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -716,7 +716,13 @@ class MahjongEngine:
             if counts[key] >= 4:
                 actions.add("kan")
 
-        if not player.riichi and self._is_tenpai(player):
+        if (
+            self._claims_open
+            and last_player == player_index
+            and not player.riichi
+            and not player.has_open_melds()
+            and self._is_tenpai(player)
+        ):
             actions.add("riichi")
 
         return sorted(actions)

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -194,3 +194,26 @@ def test_allowed_actions_exclude_riichi_when_not_tenpai() -> None:
     api.discard_tile(0, discard)
     actions = api.get_allowed_actions(0)
     assert "riichi" not in actions
+
+
+def test_allowed_actions_exclude_riichi_with_open_meld() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    player = state.players[0]
+    player.hand.tiles = TENPAI_TILES.copy()
+    player.hand.melds.append(
+        models.Meld(tiles=[models.Tile("man", 1)] * 3, type="pon")
+    )
+    discard = player.hand.tiles[-1]
+    api.discard_tile(0, discard)
+    actions = api.get_allowed_actions(0)
+    assert "riichi" not in actions
+
+
+def test_allowed_actions_exclude_riichi_for_other_players() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    for p in state.players:
+        p.hand.tiles = TENPAI_TILES.copy()
+    discard = state.players[0].hand.tiles[-1]
+    api.discard_tile(0, discard)
+    actions = api.get_allowed_actions(1)
+    assert "riichi" not in actions


### PR DESCRIPTION
## Summary
- fix riichi availability to only allow declaration right after own discard
- disallow riichi when player has open melds
- add regression tests for API behaviour

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686ed7ab9c38832aad42edd7dfa5792e