### PR TITLE
Show round and seat winds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Future work will expand these components.
 - [x] Meld area component
 - [x] Center display (dora & wall count)
 - [x] Display honba & riichi stick counts
+- [x] Show current round (e.g. 東1局) next to honba count
 - [x] Meld display from game state
 - [x] Melds positioned to the right of the player's hand
 - [x] Called tile rotated within melds
@@ -155,6 +156,7 @@ Future work will expand these components.
 - [x] Validate closed-hand tenpai requirement for riichi
  - [x] action dispatch helper
   - [x] seat wind tracking
+  - [x] Seat wind shown beside each player name in the GUI
 
 ## Game mode turn flow
 

--- a/web_gui/CenterDisplay.jsx
+++ b/web_gui/CenterDisplay.jsx
@@ -5,13 +5,18 @@ export default function CenterDisplay({
   dora = [],
   honba = 0,
   riichiSticks = 0,
+  round = 1,
 }) {
+  const winds = ['\u6771', '\u5357', '\u897f', '\u5317'];
+  const wind = winds[Math.floor((round - 1) / 4)] || winds[0];
+  const hand = ((round - 1) % 4) + 1;
+  const roundLabel = `${wind}${hand}\u5c40`;
   return (
     <div className="center-display">
       <div className="remaining">Remaining: {remaining}</div>
       <div className="dora">Dora: {dora.join(' ')}</div>
       <div className="counts">
-        Honba: {honba} | Riichi: {riichiSticks}
+        {roundLabel} | Honba: {honba} | Riichi: {riichiSticks}
       </div>
     </div>
   );

--- a/web_gui/CenterDisplay.test.jsx
+++ b/web_gui/CenterDisplay.test.jsx
@@ -3,9 +3,18 @@ import { describe, it, expect } from 'vitest';
 import CenterDisplay from './CenterDisplay.jsx';
 
 describe('CenterDisplay', () => {
-  it('shows honba and riichi stick counts', () => {
-    render(<CenterDisplay remaining={10} dora={[]} honba={3} riichiSticks={2} />);
+  it('shows round, honba and riichi stick counts', () => {
+    render(
+      <CenterDisplay
+        remaining={10}
+        dora={[]}
+        honba={3}
+        riichiSticks={2}
+        round={5}
+      />,
+    );
     expect(screen.getByText('Remaining: 10')).toBeTruthy();
+    expect(screen.getByText(/南1局/)).toBeTruthy();
     expect(screen.getByText(/Honba: 3/)).toBeTruthy();
     expect(screen.getByText(/Riichi: 2/)).toBeTruthy();
   });

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -280,6 +280,7 @@ export default function GameBoard({
         dora={dora}
         honba={state?.honba ?? 0}
         riichiSticks={state?.riichi_sticks ?? 0}
+        round={state?.round_number ?? 1}
       />
       <div className={boardClass}>
         <PlayerPanel

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -8,6 +8,13 @@ import Button from './Button.jsx';
 import { getAllowedActions } from './allowedActions.js';
 import ErrorModal from './ErrorModal.jsx';
 
+const windChars = {
+  east: '\u6771',
+  south: '\u5357',
+  west: '\u897f',
+  north: '\u5317',
+};
+
 export default function PlayerPanel({
   seat,
   player,
@@ -90,7 +97,11 @@ export default function PlayerPanel({
     <div className={`${seat} seat player-panel${active ? ' active-player' : ''}${!active && isWaiting ? ' waiting-player' : ''}`}>
       <div className="player-header">
         <span className="riichi-stick">{player?.riichi ? '|' : '\u00a0'}</span>
-        <span className="player-name">{(player ? player.name : seat) + (player ? ` ${player.score}` : '')}</span>
+        <span className="player-name">
+          {(player ? player.name : seat)}
+          {player?.seat_wind ? ` (${windChars[player.seat_wind]})` : ''}
+          {player ? ` ${player.score}` : ''}
+        </span>
         <Button
           aria-label={aiActive ? 'Disable AI' : 'Enable AI'}
           className={`ai-btn${aiActive ? ' active' : ''}`}

--- a/web_gui/PlayerPanel.test.jsx
+++ b/web_gui/PlayerPanel.test.jsx
@@ -40,6 +40,28 @@ describe('PlayerPanel layout styles', () => {
   });
 });
 
+describe('PlayerPanel seat wind display', () => {
+  it('shows seat wind next to player name', () => {
+    const { getByText } = render(
+      <PlayerPanel
+        seat="east"
+        player={{ name: 'A', score: 25000, seat_wind: 'east' }}
+        hand={[]}
+        melds={[]}
+        riverTiles={[]}
+        server=""
+        gameId="1"
+        playerIndex={0}
+        activePlayer={0}
+        aiActive={false}
+        state={{ players: [] }}
+        allowedActions={[]}
+      />,
+    );
+    expect(getByText(/A \(東\)/)).toBeTruthy();
+  });
+});
+
 describe('PlayerPanel fetch cancellation', () => {
   it('aborts previous request when props change', async () => {
     let aborted = false;


### PR DESCRIPTION
## Summary
- add round display to center counts
- show each player's seat wind next to their name
- document new GUI features
- update tests for CenterDisplay and PlayerPanel

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686ed99acc8c832a8c9a2776ae7f09d0