### PR TITLE
Improve kan API

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -95,9 +95,33 @@ def call_pon(player_index: int, tiles: list[Tile]) -> None:
 
 
 def call_kan(player_index: int, tiles: list[Tile]) -> None:
-    """Public wrapper for MahjongEngine.call_kan."""
+    """Public wrapper for MahjongEngine.call_kan.
+
+    ``tiles`` may contain either the full meld including the discarded tile or
+    just the three tiles from the caller's hand. When only three tiles are
+    provided the current discard is automatically inserted and any matching
+    tile in ``tiles`` is replaced with the engine instance so object identity
+    checks succeed.
+    """
+
     assert _engine is not None, "Game not started"
-    _engine.call_kan(player_index, tiles)
+
+    meld_tiles = tiles
+    last_tile = _engine.state.last_discard
+    last_player = _engine.state.last_discard_player
+
+    if len(tiles) == 3:
+        if last_tile is None or last_player is None:
+            raise ValueError("No discard available for kan")
+        meld_tiles = [last_tile, *tiles]
+
+    if last_tile is not None:
+        meld_tiles = [
+            last_tile if t.suit == last_tile.suit and t.value == last_tile.value else t
+            for t in meld_tiles
+        ]
+
+    _engine.call_kan(player_index, meld_tiles)
 
 
 def declare_tsumo(player_index: int, tile: Tile) -> HandResponse:

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -31,7 +31,7 @@ The following classes defined in `core.models` are used throughout the API:
 | `riichi`           | `player_index`, `Tile`                  | Discard a tile and declare riichi in one step. |
 | `call_chi`         | `player_index`, `tiles`                 | Call `chi` using the given tiles. Two hand tiles may be passed and the discard is automatically inserted, or a full meld may be provided. Any discard tile sent by the front end is replaced with the engine's instance. |
 | `call_pon`         | `player_index`, `tiles`                 | Call `pon` using the given tiles. |
-| `call_kan`         | `player_index`, `tiles`                 | Declare an open or closed `kan`. |
+| `call_kan`         | `player_index`, `tiles`                 | Declare an open or closed `kan`. For an open kan, three hand tiles may be passed and the discard is inserted automatically. Any discard tile sent by the front end is replaced with the engine's instance. |
 | `declare_ron`      | `player_index`, `Tile`                  | Win on another player's discard. |
 | `declare_tsumo`    | `player_index`, `Tile`                  | Win on self-drawn tile. |
 | `skip`             | `player_index`                          | Pass on an action. |

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -76,6 +76,33 @@ def test_call_chi_replaces_discard_instance() -> None:
     assert any(t is discard_ref for t in meld.tiles)
 
 
+def test_call_kan_missing_discard() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("pin", 5)
+    discarder = state.players[0]
+    caller = state.players[1]
+    discarder.hand.tiles.append(tile)
+    api.discard_tile(0, tile)
+    caller.hand.tiles.extend([models.Tile("pin", 5) for _ in range(3)])
+    api.call_kan(1, [models.Tile("pin", 5)] * 3)
+    assert len(caller.hand.melds) == 1
+    assert caller.hand.melds[0].type == "kan"
+
+
+def test_call_kan_replaces_discard_instance() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    tile = models.Tile("sou", 2)
+    discarder = state.players[0]
+    caller = state.players[1]
+    discarder.hand.tiles.append(tile)
+    api.discard_tile(0, tile)
+    discard_ref = discarder.river[-1]
+    caller.hand.tiles.extend([models.Tile("sou", 2) for _ in range(3)])
+    api.call_kan(1, [models.Tile("sou", 2) for _ in range(4)])
+    meld = caller.hand.melds[0]
+    assert any(t is discard_ref for t in meld.tiles)
+
+
 def test_end_game_creates_new_state() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     finished = api.end_game()


### PR DESCRIPTION
## Summary
- allow calling kan with three tiles
- document automatic discard insertion for open kan
- test API call_kan convenience behavior

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686eea940e98832ab3f8b2422f140ad5