### PR TITLE
Fix ron detection

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -724,6 +724,25 @@ class MahjongEngine:
                 if has(last.value + 1) and has(last.value + 2):
                     actions.add("chi")
 
+            # Ron check - temporarily add discard to hand and evaluate
+            player.hand.tiles.append(last)
+            try:
+                result = self.ruleset.calculate_score(
+                    player.hand.tiles,
+                    player.hand.melds,
+                    last,
+                    is_tsumo=False,
+                )
+            except Exception:
+                result = None
+            finally:
+                player.hand.tiles.pop()
+            if result and (
+                (result.cost and result.cost.get("total", 0) > 0) or
+                (result.han is not None and result.han > 0)
+            ):
+                actions.add("ron")
+
         counts: dict[tuple[str, int], int] = {}
         for t in tiles:
             key = (t.suit, t.value)

--- a/tests/core/test_allowed_actions_ron.py
+++ b/tests/core/test_allowed_actions_ron.py
@@ -1,0 +1,32 @@
+from core.mahjong_engine import MahjongEngine
+from core.rules import RuleSet
+from core.models import Tile
+from mahjong.hand_calculating.hand_response import HandResponse
+
+
+class AlwaysWinRules(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=1, cost={"total": 8000})
+
+
+class NeverWinRules(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=0)
+
+
+def test_allowed_actions_include_ron_when_winning() -> None:
+    engine = MahjongEngine(ruleset=AlwaysWinRules())
+    tile = engine.state.players[0].hand.tiles[-1]
+    engine.discard_tile(0, tile)
+    engine.state.players[1].hand.tiles = [Tile("pin", 1)] * 13
+    actions = engine.get_allowed_actions(1)
+    assert "ron" in actions
+
+
+def test_allowed_actions_exclude_ron_when_not_winning() -> None:
+    engine = MahjongEngine(ruleset=NeverWinRules())
+    tile = engine.state.players[0].hand.tiles[-1]
+    engine.discard_tile(0, tile)
+    engine.state.players[1].hand.tiles = [Tile("pin", 1)] * 13
+    actions = engine.get_allowed_actions(1)
+    assert "ron" not in actions


### PR DESCRIPTION
## Summary
- allow ron claim on discard when winning
- test ron option presence in allowed actions

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686eedc3093c832a8d4ee50e90de58c9