### PR TITLE
Add tsumo to allowed actions

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -760,6 +760,21 @@ class MahjongEngine:
         ):
             actions.add("riichi")
 
+        if (
+            player_index == state.current_player
+            and len(player.hand.tiles) % 3 == 2
+        ):
+            win_tile = player.hand.tiles[-1]
+            try:
+                result = self.calculate_score(player_index, win_tile)
+            except Exception:
+                result = None
+            if result and (
+                (result.cost and result.cost.get("total", 0) > 0)
+                or (result.han is not None and result.han > 0)
+            ):
+                actions.add("tsumo")
+
         return sorted(actions)
 
     def get_allowed_actions(self, player_index: int) -> list[str]:

--- a/tests/core/test_allowed_actions_tsumo.py
+++ b/tests/core/test_allowed_actions_tsumo.py
@@ -1,0 +1,25 @@
+from core.mahjong_engine import MahjongEngine
+from core.rules import RuleSet
+from mahjong.hand_calculating.hand_response import HandResponse
+
+
+class AlwaysWinRules(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=1, cost={"total": 8000})
+
+
+class NeverWinRules(RuleSet):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+        return HandResponse(han=0)
+
+
+def test_allowed_actions_include_tsumo_when_winning() -> None:
+    engine = MahjongEngine(ruleset=AlwaysWinRules())
+    actions = engine.get_allowed_actions(0)
+    assert "tsumo" in actions
+
+
+def test_allowed_actions_exclude_tsumo_when_not_winning() -> None:
+    engine = MahjongEngine(ruleset=NeverWinRules())
+    actions = engine.get_allowed_actions(0)
+    assert "tsumo" not in actions


### PR DESCRIPTION
## Summary
- allow `tsumo` action when a player draws a winning tile
- test that `tsumo` appears in allowed actions only when the hand wins

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686ef1906d2c832a9c43254525b69a0b