### PR TITLE
Allow log access from result modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Future work will expand these components.
 - [x] Cancel in-flight next actions requests
 - [x] Download Tenhou log
 - [x] Download MJAI log
+- [x] Log access from result modal
 - [x] 何切る問題 mode
   - [x] CLI practice command
   - [x] AI recommendation

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -200,6 +200,12 @@ def test_result_modal_has_copy_button() -> None:
     text = Path('web_gui/ResultModal.jsx').read_text()
     assert 'Copy Log' in text
 
+def test_result_modal_has_log_options() -> None:
+    text = Path('web_gui/ResultModal.jsx').read_text()
+    assert 'aria-label="Show log"' in text
+    assert 'aria-label="Download MJAI log"' in text
+    assert 'aria-label="Download Tenhou log"' in text
+
 
 def test_event_log_modal_component_exists() -> None:
     modal = Path('web_gui/EventLogModal.jsx')

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -430,6 +430,9 @@ export default function App() {
             log={log}
             allowedActions={allowedActions}
             aiDelay={aiDelay}
+            showLog={openLogModal}
+            downloadTenhou={downloadTenhou}
+            downloadMjai={downloadMjai}
           />
       ) : mode === 'practice' ? (
         <Practice server={server} sortHand={sortHand} log={log} />

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -17,6 +17,9 @@ export default function GameBoard({
   log = () => {},
   allowedActions = [[], [], [], []],
   aiDelay = 0,
+  showLog = null,
+  downloadTenhou = null,
+  downloadMjai = null,
 }) {
   const players = state?.players ?? [];
   const south = players[0];
@@ -355,6 +358,9 @@ export default function GameBoard({
         result={result}
         onClose={() => setResult(null)}
         onCopyLog={copyLog}
+        onShowLog={showLog}
+        onDownloadTenhou={downloadTenhou}
+        onDownloadMjai={downloadMjai}
       />
       <ErrorModal message={error} onClose={() => setError(null)} />
     </>

--- a/web_gui/ResultModal.jsx
+++ b/web_gui/ResultModal.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import Hand from './Hand.jsx';
 import { tileToEmoji } from './tileUtils.js';
+import Button from './Button.jsx';
 
-export default function ResultModal({ result, onClose, onCopyLog }) {
+export default function ResultModal({
+  result,
+  onClose,
+  onCopyLog,
+  onShowLog,
+  onDownloadTenhou,
+  onDownloadMjai,
+}) {
   if (!result) return null;
   const { type, scores } = result;
   return (
@@ -57,10 +65,35 @@ export default function ResultModal({ result, onClose, onCopyLog }) {
               )}
             </>
           )}
-          {onCopyLog && (
-            <button className="button mt-2" onClick={onCopyLog}>
-              Copy Log
-            </button>
+          {(onShowLog || onCopyLog || onDownloadMjai || onDownloadTenhou) && (
+            <div className="field is-grouped mt-2">
+              {onShowLog && (
+                <div className="control">
+                  <Button aria-label="Show log" onClick={onShowLog}>
+                    Log
+                  </Button>
+                </div>
+              )}
+              {onCopyLog && (
+                <div className="control">
+                  <Button onClick={onCopyLog}>Copy Log</Button>
+                </div>
+              )}
+              {onDownloadMjai && (
+                <div className="control">
+                  <Button aria-label="Download MJAI log" onClick={onDownloadMjai}>
+                    MJAI
+                  </Button>
+                </div>
+              )}
+              {onDownloadTenhou && (
+                <div className="control">
+                  <Button aria-label="Download Tenhou log" onClick={onDownloadTenhou}>
+                    Tenhou
+                  </Button>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add log buttons to the result modal and wire up to App
- expose log actions from GameBoard
- note feature in README
- test for new log buttons

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686f959c4330832a9683431f0434df0c