### PR TITLE
Add round separators to event log

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Future work will expand these components.
 - [x] Copy event log to clipboard
 - [x] MJAI JSON shown alongside log entries
 - [x] Event log modal with copy button
+- [x] Round separator lines in event log
 - [x] Debug logging of GUI API calls
 - [x] Error modal shows server rejection
 - [x] Chi option modal when multiple chi choices are available

--- a/tests/web_gui/test_event_log.py
+++ b/tests/web_gui/test_event_log.py
@@ -65,3 +65,13 @@ def test_format_round_end() -> None:
     )
     output = run_node(code)
     assert output == 'Round ended'
+
+
+def test_format_start_kyoku() -> None:
+    code = (
+        "import { formatEvent } from './web_gui/eventLog.js';\n"
+        "const evt = {name:'start_kyoku', payload:{round:1, state:{honba:2}}};\n"
+        "console.log(formatEvent(evt));"
+    )
+    output = run_node(code)
+    assert output.startswith('=====\u67711\u5c40 2\u672c\u5834')

--- a/web_gui/eventLog.js
+++ b/web_gui/eventLog.js
@@ -24,8 +24,14 @@ export function formatEvent(evt) {
       return `Turn start for player ${p}`;
     case 'next_actions':
       return `Next actions for player ${p}: ${evt.payload.actions.join(', ')}`;
-    case 'start_kyoku':
-      return `Start hand ${evt.payload.round}`;
+    case 'start_kyoku': {
+      const round = evt.payload?.round ?? 1;
+      const honba = evt.payload?.state?.honba ?? 0;
+      const winds = ['\u6771', '\u5357', '\u897f', '\u5317'];
+      const wind = winds[Math.floor((round - 1) / 4)] || winds[0];
+      const hand = ((round - 1) % 4) + 1;
+      return `=====${wind}${hand}\u5c40 ${honba}\u672c\u5834=================`;
+    }
     case 'start_game':
       return 'Game started';
     case 'ryukyoku':


### PR DESCRIPTION
## Summary
- show separator line at start of each hand
- document the new log feature
- test start_kyoku log formatting

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686f988d2c20832aa3d187c797cc3276