### PR TITLE
Fix dealer turn after ryukyoku

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -599,8 +599,6 @@ class MahjongEngine:
                     # All players have passed on the discard; draw for next player
                     next_player = self.state.current_player
                     self.draw_tile(next_player)
-                    # draw_tile advances current_player; reset to drawer
-                    self.state.current_player = next_player
             return
         if player_index != self.state.current_player:
             return


### PR DESCRIPTION
## Summary
- ensure skip() doesn't overwrite current_player after wall-end ryukyoku

## Testing
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686fa162b888832aba8205e94f247073