### PR TITLE
Enable tile selection when declaring riichi

### DIFF
--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -15,6 +15,8 @@ export function Controls({
   lastDiscard = null,
   log = () => {},
   onError = () => {},
+  onRiichi = null,
+  selectingRiichi = false,
 }) {
   const [message, setMessage] = useState('');
   const [chiOptions, setChiOptions] = useState(null);
@@ -88,7 +90,11 @@ export function Controls({
   }
 
   function riichi() {
-    simple('riichi');
+    if (onRiichi) {
+      onRiichi();
+    } else {
+      simple('riichi');
+    }
   }
 
   function tsumo() {
@@ -115,6 +121,10 @@ export function Controls({
     active &&
     allowedActions.includes(action) &&
     (action !== 'skip' || waitingForClaims.length > 0);
+
+  if (selectingRiichi && playerIndex === activePlayer) {
+    return <div className="controls">Select tile for riichi</div>;
+  }
 
   if (waitingForRiichi && playerIndex === activePlayer) {
     return (

--- a/web_gui/GameBoard.riichi.test.jsx
+++ b/web_gui/GameBoard.riichi.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+import { tileDescription } from './tileUtils.js';
+
+function mockPlayers() {
+  return new Array(4).fill(0).map(() => ({
+    hand: { tiles: new Array(14).fill(0).map(() => ({ suit: 'man', value: 1 })), melds: [] },
+    river: [],
+  }));
+}
+
+describe('GameBoard riichi discard', () => {
+  it('sends riichi when selecting tile after button', async () => {
+    const fetchMock = vi.fn(url => {
+      if (url.includes('/allowed-actions/0')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ actions: ['riichi'] }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    global.fetch = fetchMock;
+    const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
+    render(
+      <GameBoard
+        state={state}
+        server="http://s"
+        gameId="1"
+        allowedActions={[['riichi'], [], [], []]}
+      />,
+    );
+    await Promise.resolve();
+    fetchMock.mockClear();
+    const controls = document.querySelector('.south .controls');
+    await userEvent.click(within(controls).getByRole('button', { name: 'Riichi' }));
+    await new Promise(r => setTimeout(r, 0));
+    const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;
+    const hand = document.querySelector('.south .hand');
+    const btn = within(hand).getAllByRole('button', { name: label })[0];
+    await userEvent.click(btn);
+    const actionCalls = fetchMock.mock.calls.filter(c => c[0].includes('/action'));
+    console.log('actions', actionCalls.map(c => ({url:c[0], body:c[1].body}))); 
+    const body = JSON.parse(actionCalls[actionCalls.length - 1][1].body);
+    expect(body).toEqual({
+      player_index: 0,
+      action: 'riichi',
+      tile: { suit: 'man', value: 1 },
+    });
+  });
+});

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -22,6 +22,7 @@ export default function PlayerPanel({
   melds,
   riverTiles,
   onDiscard,
+  onRiichi,
   drawn = false,
   server,
   gameId,
@@ -32,6 +33,7 @@ export default function PlayerPanel({
   state,
   log = () => {},
   allowedActions = [],
+  selectingRiichi = false,
 }) {
   const waiting = state?.waiting_for_claims ?? [];
   const isWaiting = waiting.includes(playerIndex);
@@ -130,6 +132,8 @@ export default function PlayerPanel({
         lastDiscard={state?.last_discard}
         log={log}
         onError={setError}
+        onRiichi={onRiichi}
+        selectingRiichi={selectingRiichi}
       />
       {error && (
         <ErrorModal message={error} onClose={() => setError(null)} />


### PR DESCRIPTION
## Summary
- allow GUI users to choose a tile when declaring riichi
- add state plumbing from GameBoard through PlayerPanel to Controls
- display simple message when waiting for riichi tile
- test riichi tile selection behaviour

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_686fa529aa40832a898e5bba7cb8968e