### PR TITLE
Handle ryukyoku events

### DIFF
--- a/cli/local_game.py
+++ b/cli/local_game.py
@@ -23,6 +23,11 @@ def run_game(players: list[str], *, max_rounds: int = 8) -> None:
         name = state.players[player_index].name
         tile = api.auto_play_turn()
         click.echo(f"{name} drew {tile.suit}{tile.value} and discarded it")
+        for ev in api.pop_events():
+            if ev.name == "ryukyoku":
+                reason = ev.payload.get("reason")
+                scores = ev.payload.get("scores")
+                click.echo(f"\u6d41\u5c40({reason}) \u2192 scores: {scores}")
     if not api.is_game_over():
         api.end_game()
     click.echo("Game ended")

--- a/core/tenhou_log.py
+++ b/core/tenhou_log.py
@@ -62,6 +62,11 @@ def events_to_tenhou_json(events: List[GameEvent]) -> str:
             kyoku.append(["和了", delta, []])
             log.append(kyoku)
             kyoku = None
+        elif ev.name == "ryukyoku" and kyoku is not None:
+            kyoku.extend(per_player)
+            kyoku.append(["流局"])
+            log.append(kyoku)
+            kyoku = None
 
     data = {
         "title": ["", ""],

--- a/tests/core/test_tenhou_log.py
+++ b/tests/core/test_tenhou_log.py
@@ -1,5 +1,6 @@
 from core.mahjong_engine import MahjongEngine
 from core.tenhou_log import events_to_tenhou_json, mjai_log_to_tenhou_json
+from core.models import Tile
 import json
 from dataclasses import asdict, is_dataclass
 
@@ -57,3 +58,13 @@ def test_mjai_log_conversion() -> None:
     tenhou_from_mjai = mjai_log_to_tenhou_json(lines)
 
     assert json.loads(tenhou_direct) == json.loads(tenhou_from_mjai)
+
+
+def test_events_to_tenhou_json_ryukyoku() -> None:
+    engine = MahjongEngine()
+    engine.state.wall.tiles = [Tile("pin", 1)]
+    engine.state.players[engine.state.current_player].hand.tiles.pop()
+    engine.draw_tile(engine.state.current_player)
+    data = json.loads(events_to_tenhou_json(engine.pop_events()))
+    kyoku = data["log"][0]
+    assert kyoku[-1][0] == "流局"

--- a/tests/web_gui/test_event_log.py
+++ b/tests/web_gui/test_event_log.py
@@ -75,3 +75,13 @@ def test_format_start_kyoku() -> None:
     )
     output = run_node(code)
     assert output.startswith('=====\u67711\u5c40 2\u672c\u5834')
+
+
+def test_format_ryukyoku() -> None:
+    code = (
+        "import { formatEvent } from './web_gui/eventLog.js';\n"
+        "const evt = {name:'ryukyoku', payload:{reason:'wall_empty', scores:[25000,25000,25000,25000]}};\n"
+        "console.log(formatEvent(evt));"
+    )
+    output = run_node(code)
+    assert output.startswith('\u6d41\u5c40（wall_empty）')

--- a/web_gui/eventLog.js
+++ b/web_gui/eventLog.js
@@ -35,7 +35,9 @@ export function formatEvent(evt) {
     case 'start_game':
       return 'Game started';
     case 'ryukyoku':
-      return `Ryukyoku: ${evt.payload.reason}`;
+      return `\u6d41\u5c40（${evt.payload.reason}）／点数: ${
+        Array.isArray(evt.payload.scores) ? evt.payload.scores.join(' / ') : ''
+      }`;
     case 'round_end':
       return 'Round ended';
     case 'end_game':


### PR DESCRIPTION
## Summary
- export ryukyoku rounds in Tenhou JSON logs
- show ryukyoku details in CLI local game
- show detailed ryukyoku message in GUI event log
- test Tenhou log draw handling
- test GUI formatter for ryukyoku events

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_68706cc772d0832a87e70685e21270a8