### PR TITLE
Enable detailed 409 conflict messages in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Future work will expand these components.
 - [x] Round separator lines in event log
 - [x] Debug logging of GUI API calls
 - [x] Error modal shows server rejection
+- [x] Conflict detail logged and displayed on 409 errors
 - [x] Chi option modal when multiple chi choices are available
 - [x] Cancel in-flight allowed actions requests
 - [x] Cancel in-flight next actions requests

--- a/web_gui/GameBoard.discard.test.jsx
+++ b/web_gui/GameBoard.discard.test.jsx
@@ -49,4 +49,21 @@ describe('GameBoard discard', () => {
     const modal = await screen.findByText('Discard failed: 409');
     expect(modal).toBeTruthy();
   });
+  it('shows server detail on conflict', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ detail: 'Action not allowed' }),
+      })
+    );
+    global.fetch = fetchMock;
+    const state = { current_player: 0, players: mockPlayers(), wall: { tiles: [] } };
+    render(<GameBoard state={state} server="http://s" gameId="1" />);
+    const label = `Discard ${tileDescription({ suit: 'man', value: 1 })}`;
+    const btn = screen.getAllByRole('button', { name: label })[0];
+    await userEvent.click(btn);
+    const modal = await screen.findByText('Action not allowed');
+    expect(modal).toBeTruthy();
+  });
 });

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -41,12 +41,27 @@ export default function GameBoard({
 
   function sendAction(body, delay = false) {
     const url = `${server.replace(/\/$/, "")}/games/${gameId}/action`;
-    const fn = () =>
-      fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      }).catch(() => {});
+    const fn = async () => {
+      try {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+          let msg = `Action ${body.action} failed: ${resp.status}`;
+          try {
+            const data = await resp.json();
+            if (data.detail) msg = data.detail;
+          } catch {}
+          setError(msg);
+          log("warn", msg);
+        }
+      } catch {
+        setError("Failed to contact server");
+        log("warn", "Failed to contact server");
+      }
+    };
     if (delay && aiDelay > 0) {
       setTimeout(fn, aiDelay);
     } else {


### PR DESCRIPTION
## Summary
- show server-provided conflict detail in the GameBoard `sendAction` helper
- display the detail in the discard tests
- note 409 conflict detail feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_68706d2919f4832a96bb950c50fc89e2