### PR TITLE
Highlight waiting discard tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Future work will expand these components.
 - [x] Icon tooltips for peek and sort toggles
 - [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
-- [x] Different color when waiting on calls
+- [x] Latest discard glows when waiting on calls
 - [x] 6x4 discard grid rendering
 - [x] Modal error display on failed discard actions
 - [x] Server-side action validation

--- a/tests/web_gui/test_waiting_player.py
+++ b/tests/web_gui/test_waiting_player.py
@@ -1,15 +1,14 @@
 from pathlib import Path
 
 
-def test_waiting_player_css() -> None:
+def test_waiting_discard_css() -> None:
     css = Path('web_gui/style.css').read_text()
-    assert '.waiting-player' in css
-    start = css.index('.waiting-player')
+    assert '.waiting-discard' in css
+    start = css.index('.waiting-discard')
     block = css[start:css.index('}', start)]
-    assert 'background-color' in block
-    assert '#fff4ce' not in block
+    assert 'box-shadow' in block
 
 
-def test_player_panel_waiting_class() -> None:
-    jsx = Path('web_gui/PlayerPanel.jsx').read_text()
-    assert 'waiting-player' in jsx
+def test_waiting_discard_usage() -> None:
+    jsx = Path('web_gui/River.jsx').read_text()
+    assert 'waiting-discard' in jsx

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -36,8 +36,9 @@ export default function PlayerPanel({
   selectingRiichi = false,
 }) {
   const waiting = state?.waiting_for_claims ?? [];
-  const isWaiting = waiting.includes(playerIndex);
   const active = playerIndex === activePlayer;
+  const highlightDiscard =
+    waiting.length > 0 && state?.last_discard_player === playerIndex;
   const allowedActionsMemo = useMemo(
     () => allowedActions,
     [allowedActions.join(',')]
@@ -96,7 +97,7 @@ export default function PlayerPanel({
     return () => controller.abort();
   }, [server, gameId, playerIndex, aiActive]);
   return (
-    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}${!active && isWaiting ? ' waiting-player' : ''}`}>
+    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}>
       <div className="player-header">
         <span className="riichi-stick">{player?.riichi ? '|' : '\u00a0'}</span>
         <span className="player-name">
@@ -115,6 +116,7 @@ export default function PlayerPanel({
       <River
         tiles={riverTiles}
         style={{ marginBottom: 'calc(var(--tile-font-size) * 0.8)' }}
+        highlightIndex={highlightDiscard ? riverTiles.length - 1 : -1}
       />
       <div className="hand-with-melds" style={{ position: 'relative', zIndex: 1 }}>
         <Hand tiles={hand} onDiscard={onDiscard} drawn={drawn} />

--- a/web_gui/PlayerPanel.waiting.test.jsx
+++ b/web_gui/PlayerPanel.waiting.test.jsx
@@ -9,22 +9,27 @@ function Panel(waiting) {
       player={{}}
       hand={[]}
       melds={[]}
-      riverTiles={[]}
+      riverTiles={["A"]}
       server=""
       gameId="1"
       playerIndex={1}
       activePlayer={0}
       aiActive={false}
-      state={{ waiting_for_claims: waiting, players: [{}, {}, {}, {}] }}
+      state={{
+        waiting_for_claims: waiting,
+        last_discard_player: 1,
+        last_discard: { suit: 'man', value: 1 },
+        players: [{}, {}, {}, {}],
+      }}
       allowedActions={[]}
     />
   );
 }
 
-describe('PlayerPanel waiting-player class', () => {
-  it('adds waiting-player when waiting for claim', () => {
+describe('PlayerPanel waiting discard highlight', () => {
+  it('highlights last discard when waiting for claim', () => {
     const { container } = render(Panel([1]));
-    const div = container.querySelector('.player-panel');
-    expect(div.className).toContain('waiting-player');
+    const tile = container.querySelector('.river .waiting-discard');
+    expect(tile).not.toBeNull();
   });
 });

--- a/web_gui/River.jsx
+++ b/web_gui/River.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
 
-export default function River({ tiles = [], style = {} }) {
+export default function River({
+  tiles = [],
+  style = {},
+  highlightIndex = -1,
+}) {
   const cells = Array.from({ length: 24 }, (_, i) => tiles[i] || null);
   return (
     <div className="river" style={style}>
       {cells.map((t, i) => (
-        <span key={i} className="mj-tile">
+        <span
+          key={i}
+          className={`mj-tile${i === highlightIndex ? ' waiting-discard' : ''}`}
+        >
           {t ?? '\u00a0'}
         </span>
       ))}

--- a/web_gui/River.test.jsx
+++ b/web_gui/River.test.jsx
@@ -10,4 +10,12 @@ describe('River layout', () => {
     expect(cells[0].textContent).toBe('A');
     expect(cells[1].textContent).toBe('B');
   });
+
+  it('highlights specified tile', () => {
+    const { container } = render(
+      <River tiles={['A', 'B']} highlightIndex={1} />,
+    );
+    const cells = container.querySelectorAll('.river .mj-tile');
+    expect(cells[1].className).toContain('waiting-discard');
+  });
 });

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -204,9 +204,10 @@
   background-color: #fff4ce;
 }
 
-.waiting-player .player-header {
-  font-weight: bold;
-  background-color: #d0f0ff;
+
+.waiting-discard {
+  box-shadow: 0 0 4px 2px #d0f0ff;
+  border-radius: 2px;
 }
 
 .player-header .ai-btn {


### PR DESCRIPTION
## Summary
- highlight the latest discard when other players can claim
- adapt tests for new highlight approach

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68706d8de920832abf57f8b9320990c4