### PR TITLE
Add draw handling to Tenhou log

### DIFF
--- a/core/tenhou_log.py
+++ b/core/tenhou_log.py
@@ -14,6 +14,15 @@ _TILE_BASE = {
     "dragon": 44,
 }
 
+# Map engine ryukyoku reasons to Tenhou strings
+_REASON_MAP = {
+    "wall_empty": "全員不聴",
+    "four_winds": "四風連打",
+    "four_riichi": "四家立直",
+    "four_kans": "四槓散了",
+    "nine_terminals": "九種九牌",
+}
+
 
 def tile_to_code(tile: Tile) -> int:
     """Return the numeric tile code used by tenhou.net/6."""
@@ -115,6 +124,20 @@ def events_to_tenhou_json(events: List[GameEvent]) -> str:
                 kyoku.append(takes[i])
                 kyoku.append(dahai[i])
             kyoku.append(["和了", delta, result_info])
+            log.append(kyoku)
+            kyoku = None
+        elif ev.name == "ryukyoku" and kyoku is not None:
+            scores = ev.payload.get("scores", start_scores)
+            delta = [scores[i] - start_scores[i] for i in range(len(scores))]
+            reason_key = ev.payload.get("reason")
+            reason = _REASON_MAP.get(str(reason_key), str(reason_key or "不明"))
+            for i in range(4):
+                kyoku.append(takes[i])
+                kyoku.append(dahai[i])
+            if any(delta):
+                kyoku.append(["流局", delta])
+            else:
+                kyoku.append([reason])
             log.append(kyoku)
             kyoku = None
 

--- a/tests/core/test_tenhou_log.py
+++ b/tests/core/test_tenhou_log.py
@@ -1,5 +1,6 @@
 from core.mahjong_engine import MahjongEngine
 from core.tenhou_log import events_to_tenhou_json, mjai_log_to_tenhou_json
+from core.models import Tile
 import json
 from dataclasses import asdict, is_dataclass
 
@@ -62,3 +63,14 @@ def test_mjai_log_conversion() -> None:
     assert direct["name"] == converted["name"]
     assert direct["rule"] == converted["rule"]
     assert direct["log"][0][4:] == converted["log"][0][4:]
+
+
+def test_events_to_tenhou_json_draw() -> None:
+    engine = MahjongEngine()
+    engine.state.wall.tiles = [Tile("pin", 1)]
+    engine.state.players[engine.state.current_player].hand.tiles.pop()
+    engine.draw_tile(engine.state.current_player)
+    engine.end_game()
+    data = json.loads(events_to_tenhou_json(engine.pop_events()))
+    kyoku = data["log"][0]
+    assert kyoku[-1][0] == "全員不聴"


### PR DESCRIPTION
## Summary
- support `ryukyoku` events when building Tenhou style JSON logs
- map engine draw reasons to Tenhou strings
- test draw serialization in Tenhou logs

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68706f0859e8832ab56a43ec06c613ca