### PR TITLE
Fix auto-play request conditions

### DIFF
--- a/web_gui/GameBoard.autodraw.test.jsx
+++ b/web_gui/GameBoard.autodraw.test.jsx
@@ -26,7 +26,14 @@ describe('GameBoard auto draw', () => {
     fetchMock.mockClear();
     state.current_player = 1;
     state.waiting_for_claims = [1, 2, 3];
-    rerender(<GameBoard state={state} server="http://s" gameId="1" />);
+    rerender(
+      <GameBoard
+        state={state}
+        server="http://s"
+        gameId="1"
+        allowedActions={[[], ['chi'], ['chi'], ['chi']]}
+      />,
+    );
     await Promise.resolve();
     const bodies = fetchMock.mock.calls
       .filter(c => c[1] && c[1].body)

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -120,13 +120,15 @@ export default function GameBoard({
       }
       waiting.forEach((idx) => {
         if (aiPlayers[idx]) {
-          const body = {
-            player_index: idx,
-            action: "auto",
-            ai_type: aiTypes[idx],
-          };
-          log("debug", `POST /games/${gameId}/action auto - resolve claims`);
-          sendAction(body, true);
+          if (allowedActions[idx]?.length) {
+            const body = {
+              player_index: idx,
+              action: "auto",
+              ai_type: aiTypes[idx],
+            };
+            log("debug", `POST /games/${gameId}/action auto - resolve claims`);
+            sendAction(body, true);
+          }
         } else if (
           allowedActions[idx]?.length === 1 &&
           allowedActions[idx][0] === "skip" &&


### PR DESCRIPTION
## Summary
- prevent AI clients from sending auto actions when no options are allowed yet
- adjust autodraw test to provide allowed actions

## Testing
- `uv pip install -e ./core -e ./cli -e ./web`
- `uv pip install flake8 mypy pytest build`
- `.venv/bin/python -m build core`
- `.venv/bin/python -m build cli`
- `.venv/bin/flake8`
- `.venv/bin/mypy core web cli`
- `.venv/bin/pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6870bf7441d0832a96eecddb87e0ebba