### PR TITLE
Fix draw action error handling

### DIFF
--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -77,6 +77,16 @@ def test_draw_action_endpoint() -> None:
     assert "suit" in tile and "value" in tile
 
 
+def test_draw_without_discard_returns_409() -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    resp = client.post(
+        "/games/1/action",
+        json={"player_index": 0, "action": "draw"},
+    )
+    assert resp.status_code == 409
+    assert resp.json() == {"detail": "Cannot draw before discarding"}
+
+
 def test_discard_action_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     state = api.get_state()

--- a/web/server.py
+++ b/web/server.py
@@ -296,6 +296,9 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
             tile = api.draw_tile(req.player_index)
         except IndexError:
             raise HTTPException(status_code=409, detail="Wall is empty")
+        except ValueError as err:
+            # engine enforces draw/discard sequence
+            raise HTTPException(status_code=409, detail=str(err))
         return asdict(tile)
     # invalid discards raise ValueError from the engine
     if req.action == "discard" and req.tile:


### PR DESCRIPTION
## Summary
- return 409 when the engine raises an error while drawing
- test for the new draw error behavior

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6870c2f3f324832aa128030542a88abb