### PR TITLE
Remove leftover waiting-player class

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Future work will expand these components.
 - [x] Icon tooltips for peek and sort toggles
 - [x] Favicon with mahjong emoji
 - [x] Highlight active player on board
-- [x] Different color when waiting on calls
+- [x] Discard tile highlighted when waiting on calls
 - [x] 6x4 discard grid rendering
 - [x] Modal error display on failed discard actions
 - [x] Server-side action validation

--- a/tests/web_gui/test_waiting_player.py
+++ b/tests/web_gui/test_waiting_player.py
@@ -3,13 +3,9 @@ from pathlib import Path
 
 def test_waiting_player_css() -> None:
     css = Path('web_gui/style.css').read_text()
-    assert '.waiting-player' in css
-    start = css.index('.waiting-player')
-    block = css[start:css.index('}', start)]
-    assert 'background-color' in block
-    assert '#fff4ce' not in block
+    assert '.waiting-player' not in css
 
 
 def test_player_panel_waiting_class() -> None:
     jsx = Path('web_gui/PlayerPanel.jsx').read_text()
-    assert 'waiting-player' in jsx
+    assert 'waiting-player' not in jsx

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -100,7 +100,7 @@ export default function PlayerPanel({
     return () => controller.abort();
   }, [server, gameId, playerIndex, aiActive]);
   return (
-    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}${!active && isWaiting ? ' waiting-player' : ''}`}>
+    <div className={`${seat} seat player-panel${active ? ' active-player' : ''}`}>
       <div className="player-header">
         <span className="riichi-stick">{player?.riichi ? '|' : '\u00a0'}</span>
         <span className="player-name">

--- a/web_gui/PlayerPanel.waiting.test.jsx
+++ b/web_gui/PlayerPanel.waiting.test.jsx
@@ -22,9 +22,9 @@ function Panel(waiting) {
 }
 
 describe('PlayerPanel waiting-player class', () => {
-  it('adds waiting-player when waiting for claim', () => {
+  it('does not add waiting-player when waiting for claim', () => {
     const { container } = render(Panel([1]));
     const div = container.querySelector('.player-panel');
-    expect(div.className).toContain('waiting-player');
+    expect(div.className).not.toContain('waiting-player');
   });
 });

--- a/web_gui/style.css
+++ b/web_gui/style.css
@@ -204,10 +204,6 @@
   background-color: #fff4ce;
 }
 
-.waiting-player .player-header {
-  font-weight: bold;
-  background-color: #d0f0ff;
-}
 
 .waiting-discard {
   box-shadow: 0 0 0 2px #3399ff;


### PR DESCRIPTION
## Summary
- delete waiting-player CSS class
- stop adding waiting-player to PlayerPanel
- update tests for removed class
- document discard highlight feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6870c45053e4832aa1d0837c65a84acd