### PR TITLE
Improve logging for 409 conflicts

### DIFF
--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -87,6 +87,17 @@ def test_draw_without_discard_returns_409() -> None:
     assert resp.json() == {"detail": "Cannot draw before discarding"}
 
 
+def test_draw_without_discard_logs_conflict(caplog: pytest.LogCaptureFixture) -> None:
+    client.post("/games", json={"players": ["A", "B", "C", "D"]})
+    with caplog.at_level(logging.INFO):
+        resp = client.post(
+            "/games/1/action",
+            json={"player_index": 0, "action": "draw"},
+        )
+    assert resp.status_code == 409
+    assert any("409 conflict" in rec.message for rec in caplog.records)
+
+
 def test_discard_action_endpoint() -> None:
     client.post("/games", json={"players": ["A", "B", "C", "D"]})
     state = api.get_state()


### PR DESCRIPTION
## Summary
- log player and action when a request results in HTTP 409
- test that invalid draw attempts are logged

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6870cae59b54832a8b40c3044481b102