### PR TITLE
Implement event queue for WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Future work will expand these components.
 - [x] Allowed actions API
 - [x] Combined allowed actions endpoint
 - [x] Allowed actions pushed via WebSocket events
+- [x] Engine event queue for immediate WebSocket updates
 - [x] Next actions API
 - [x] Next actions logged to event history
 - [x] GUI fetches next actions after every event

--- a/core/api.py
+++ b/core/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
 from .models import GameState, Tile, GameEvent, GameAction
+import asyncio
 from .ai import AI_REGISTRY
 from . import practice, shanten_quiz
 from mahjong.hand_calculating.hand_response import HandResponse
@@ -205,6 +206,18 @@ def pop_events() -> list[GameEvent]:
     """Retrieve and clear pending engine events."""
     assert _engine is not None, "Game not started"
     return _engine.pop_events()
+
+
+def register_observer() -> asyncio.Queue[GameEvent]:
+    """Return a queue that receives future events."""
+    assert _engine is not None, "Game not started"
+    return _engine.register_observer()
+
+
+def unregister_observer(queue: asyncio.Queue[GameEvent]) -> None:
+    """Detach ``queue`` from the engine."""
+    if _engine is not None:
+        _engine.unregister_observer(queue)
 
 
 def get_tenhou_log() -> str:


### PR DESCRIPTION
## Summary
- add observer queue for events in `MahjongEngine`
- register/unregister observer helpers in `core.api`
- await event queue in `web.server` WebSocket handler
- document engine event queue feature
- verify WebSocket pushes events without delay

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `/root/.pyenv/versions/3.12.10/bin/flake8`
- `/root/.pyenv/versions/3.12.10/bin/mypy core web cli`
- `/root/.pyenv/versions/3.12.10/bin/pytest -q`
- `npm ci --prefix web_gui`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6870d10a1e18832aaa7815e876ece7c9