### PR TITLE
Implement EngineManager and integrate into web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Future work will expand these components.
 - [x] configurable ruleset
 - [x] detailed event log (player actions and backend responses)
 - [x] current player tracking
+- [x] Multiple concurrent game instances via EngineManager
 - [x] Wait for all players to skip before next draw
 - [x] `claims_closed` event emitted when the claim window ends
 - [x] `round_end` event emitted between hands

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -18,4 +18,5 @@ __all__ = [
     "rules",
     "shanten_quiz",
     "exceptions",
+    "engine_manager",
 ]

--- a/core/engine_manager.py
+++ b/core/engine_manager.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Dict, Iterator, Tuple
+
+from .mahjong_engine import MahjongEngine
+from .models import GameEvent, GameState
+from . import api
+
+
+class EngineManager:
+    """Manage multiple MahjongEngine instances keyed by game id."""
+
+    def __init__(self) -> None:
+        self._engines: Dict[int, MahjongEngine] = {}
+        self._next_id: int = 1
+
+    def create_game(self, players: list[str], *, max_rounds: int = 8) -> Tuple[int, GameState]:
+        """Create a new game and return its id and initial state."""
+        engine = MahjongEngine(max_rounds=max_rounds)
+        for i, name in enumerate(players):
+            if i < len(engine.state.players):
+                engine.state.players[i].name = name
+        game_id = self._next_id
+        self._next_id += 1
+        self._engines[game_id] = engine
+        api._engine = engine
+        return game_id, engine.state
+
+    def get_engine(self, game_id: int) -> MahjongEngine:
+        return self._engines[game_id]
+
+    def get_state(self, game_id: int) -> GameState:
+        return self.get_engine(game_id).state
+
+    def pop_events(self, game_id: int) -> list[GameEvent]:
+        engine = self.get_engine(game_id)
+        events = engine.events[:]
+        engine.events.clear()
+        return events
+
+    @contextmanager
+    def use_engine(self, game_id: int) -> Iterator[None]:
+        engine = self.get_engine(game_id)
+        prev = api._engine
+        api._engine = engine
+        try:
+            yield
+        finally:
+            api._engine = prev
+
+    def record_next_actions(self, game_id: int, player_index: int, actions: list[str]) -> None:
+        engine = self.get_engine(game_id)
+        payload = {"player_index": player_index, "actions": actions}
+        last = engine.event_history[-1] if engine.event_history else None
+        if (
+            last is None
+            or last.name != "next_actions"
+            or last.payload.get("player_index") != player_index
+            or last.payload.get("actions") != actions
+        ):
+            evt = GameEvent(name="next_actions", payload=payload)
+            engine.events.append(evt)
+            engine.event_history.append(evt)

--- a/tests/core/test_engine_manager.py
+++ b/tests/core/test_engine_manager.py
@@ -1,0 +1,20 @@
+from core.engine_manager import EngineManager
+
+
+def test_create_game_returns_id_and_state() -> None:
+    mgr = EngineManager()
+    game_id, state = mgr.create_game(["A", "B", "C", "D"])
+    assert game_id == 1
+    assert len(state.players) == 4
+    next_id, _ = mgr.create_game(["E", "F", "G", "H"])
+    assert next_id == 2
+
+
+def test_record_next_actions_deduplicates() -> None:
+    mgr = EngineManager()
+    gid, _ = mgr.create_game(["A", "B", "C", "D"])
+    mgr.record_next_actions(gid, 0, ["draw"])
+    engine = mgr.get_engine(gid)
+    assert any(e.name == "next_actions" for e in engine.events)
+    mgr.record_next_actions(gid, 0, ["draw"])
+    assert sum(1 for e in engine.event_history if e.name == "next_actions") == 1

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from web.server import manager
+from core import api
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager() -> None:
+    manager._engines.clear()
+    manager._next_id = 1
+    api._engine = None  # type: ignore[assignment]

--- a/web/server.py
+++ b/web/server.py
@@ -10,12 +10,12 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from core import api, models, shanten_quiz
+from core.engine_manager import EngineManager
 from core.exceptions import InvalidActionError, NotYourTurnError
 from core.models import GameEvent
 
 app = FastAPI()
-# very small in-memory id tracker until multi-game support exists
-_next_game_id = 1
+manager = EngineManager()
 _ws_connections: set[WebSocket] = set()
 logger = logging.getLogger(__name__)
 
@@ -93,33 +93,28 @@ def health() -> dict[str, str]:
 @app.post("/games")
 def create_game(req: CreateGameRequest) -> dict:
     """Create a new game and return its id and state."""
-    global _next_game_id
-    if req.max_rounds is not None:
-        state = api.start_game(req.players, max_rounds=req.max_rounds)
-    else:
-        state = api.start_game(req.players)
-    game_id = _next_game_id
-    _next_game_id += 1
+    rounds = req.max_rounds if req.max_rounds is not None else 8
+    game_id, state = manager.create_game(req.players, max_rounds=rounds)
     return {"id": game_id, **asdict(state)}
 
 
 @app.get("/games/{game_id}")
 def get_game(game_id: int) -> dict:
     """Return basic game state for the given game id."""
-    # For now we ignore game_id and return the singleton engine state
     try:
-        return asdict(api.get_state())
-    except AssertionError:
+        with manager.use_engine(game_id):
+            return asdict(api.get_state())
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
 
 
 @app.get("/games/{game_id}/log")
 def get_log(game_id: int) -> dict:
     """Return the Tenhou-format log for the current game."""
-    _ = game_id  # placeholder for future multi-game support
     try:
-        data = api.get_tenhou_log()
-    except AssertionError:
+        with manager.use_engine(game_id):
+            data = api.get_tenhou_log()
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     return {"log": data}
 
@@ -128,10 +123,10 @@ def get_log(game_id: int) -> dict:
 def get_mjai_log(game_id: int) -> dict:
     """Return the MJAI-format event log for the current game."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        data = api.get_mjai_log()
-    except AssertionError:
+        with manager.use_engine(game_id):
+            data = api.get_mjai_log()
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     return {"log": data}
 
@@ -140,10 +135,10 @@ def get_mjai_log(game_id: int) -> dict:
 def get_events(game_id: int) -> dict:
     """Return raw event history."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        events = [asdict(e) for e in api.get_event_history()]
-    except AssertionError:
+        with manager.use_engine(game_id):
+            events = [asdict(e) for e in api.get_event_history()]
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     return {"events": events}
 
@@ -192,10 +187,10 @@ def shanten_quiz_check(req: QuizRequest) -> dict:
 def shanten_number(game_id: int, player_index: int) -> dict:
     """Return the shanten number for ``player_index`` in the current game."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        state = api.get_state()
-    except AssertionError:
+        with manager.use_engine(game_id):
+            state = api.get_state()
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     try:
         tiles = state.players[player_index].hand.tiles
@@ -209,10 +204,10 @@ def shanten_number(game_id: int, player_index: int) -> dict:
 def allowed_actions(game_id: int, player_index: int) -> dict:
     """Return allowed actions for ``player_index``."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        actions = api.get_allowed_actions(player_index)
-    except AssertionError:
+        with manager.use_engine(game_id):
+            actions = api.get_allowed_actions(player_index)
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     except IndexError:
         raise HTTPException(status_code=404, detail="Player not found")
@@ -223,10 +218,10 @@ def allowed_actions(game_id: int, player_index: int) -> dict:
 def chi_options(game_id: int, player_index: int) -> dict:
     """Return chi tile pairs for ``player_index``."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        options = api.get_chi_options(player_index)
-    except AssertionError:
+        with manager.use_engine(game_id):
+            options = api.get_chi_options(player_index)
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     except IndexError:
         raise HTTPException(status_code=404, detail="Player not found")
@@ -241,10 +236,10 @@ def chi_options(game_id: int, player_index: int) -> dict:
 def allowed_actions_all(game_id: int) -> dict:
     """Return allowed actions for all players."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        actions = api.get_all_allowed_actions()
-    except AssertionError:
+        with manager.use_engine(game_id):
+            actions = api.get_all_allowed_actions()
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     return {"actions": actions}
 
@@ -253,34 +248,22 @@ def allowed_actions_all(game_id: int) -> dict:
 def next_actions(game_id: int) -> dict:
     """Return the next actor index and their allowed actions."""
 
-    _ = game_id  # placeholder for future multi-game support
     try:
-        idx, actions = api.get_next_actions()
-    except AssertionError:
+        with manager.use_engine(game_id):
+            idx, actions = api.get_next_actions()
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
-    if api._engine is not None:
-        payload = {"player_index": idx, "actions": actions}
-        last = api._engine.event_history[-1] if api._engine.event_history else None
-        if (
-            last is None
-            or last.name != "next_actions"
-            or last.payload.get("player_index") != idx
-            or last.payload.get("actions") != actions
-        ):
-            evt = GameEvent(name="next_actions", payload=payload)
-            api._engine.events.append(evt)
-            api._engine.event_history.append(evt)
+    manager.record_next_actions(game_id, idx, actions)
     return {"player_index": idx, "actions": actions}
 
 
 @app.post("/games/{game_id}/start-kyoku")
 async def start_kyoku_route(game_id: int, req: StartKyokuRequest) -> dict:
     """Start a new hand and notify connected clients."""
-
-    _ = game_id  # placeholder for future multi-game support
     try:
-        state = api.start_kyoku(req.dealer, req.round)
-    except AssertionError:
+        with manager.use_engine(game_id):
+            state = api.start_kyoku(req.dealer, req.round)
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
 
     event = {
@@ -456,52 +439,53 @@ ACTION_HANDLERS = {
 @app.post("/games/{game_id}/action")
 def game_action(game_id: int, req: ActionRequest) -> dict:
     """Perform a simple game action and return its result."""
-    _ = game_id  # placeholder for future multi-game support
     try:
-        allowed = api.get_allowed_actions(req.player_index)
-    except AssertionError:
+        with manager.use_engine(game_id):
+            allowed = api.get_allowed_actions(req.player_index)
+            if req.action in {"chi", "pon", "kan", "riichi", "skip"} and req.action not in allowed:
+                logger.info(
+                    "Player %s attempted disallowed action %s (allowed=%s)",
+                    req.player_index,
+                    req.action,
+                    allowed,
+                )
+                _raise_conflict(
+                    req.player_index,
+                    req.action,
+                    f"Action not allowed: player {req.player_index} attempted {req.action}. allowed={allowed}",
+                )
+
+            handler = ACTION_HANDLERS.get(req.action)
+            if not handler:
+                raise HTTPException(status_code=400, detail="Unknown action")
+            return handler(req)
+    except KeyError:
         raise HTTPException(status_code=404, detail="Game not started")
     except IndexError:
         raise HTTPException(status_code=404, detail="Player not found")
-    if req.action in {"chi", "pon", "kan", "riichi", "skip"} and req.action not in allowed:
-        logger.info(
-            "Player %s attempted disallowed action %s (allowed=%s)",
-            req.player_index,
-            req.action,
-            allowed,
-        )
-        _raise_conflict(
-            req.player_index,
-            req.action,
-            f"Action not allowed: player {req.player_index} attempted {req.action}. allowed={allowed}",
-        )
-
-    handler = ACTION_HANDLERS.get(req.action)
-    if not handler:
-        raise HTTPException(status_code=400, detail="Unknown action")
-    return handler(req)
 
 
 @app.websocket("/ws/{game_id}")
 async def game_events(websocket: WebSocket, game_id: int) -> None:
     """Stream game events to the client."""
-    _ = game_id  # placeholder for future multi-game support
     await websocket.accept()
     _ws_connections.add(websocket)
     prev_actions: list[list[str]] | None = None
     try:
         # send initial allowed actions if a game is running
         try:
-            prev_actions = api.get_all_allowed_actions()
+            with manager.use_engine(game_id):
+                prev_actions = api.get_all_allowed_actions()
             await websocket.send_json(
                 {"name": "allowed_actions", "payload": {"actions": prev_actions}}
             )
-        except AssertionError:
+        except KeyError:
             prev_actions = None
         while True:
             try:
-                events = api.pop_events()
-            except AssertionError:
+                with manager.use_engine(game_id):
+                    events = api.pop_events()
+            except KeyError:
                 events = []
             for event in events:
                 await websocket.send_json(asdict(event))
@@ -509,8 +493,9 @@ async def game_events(websocket: WebSocket, game_id: int) -> None:
                     prev_actions = None
                 if event.name == "discard":
                     try:
-                        updated = api.get_all_allowed_actions()
-                    except AssertionError:
+                        with manager.use_engine(game_id):
+                            updated = api.get_all_allowed_actions()
+                    except KeyError:
                         updated = None
                     if updated is not None:
                         prev_actions = updated
@@ -518,8 +503,9 @@ async def game_events(websocket: WebSocket, game_id: int) -> None:
                             {"name": "allowed_actions", "payload": {"actions": updated}}
                         )
             try:
-                actions = api.get_all_allowed_actions()
-            except AssertionError:
+                with manager.use_engine(game_id):
+                    actions = api.get_all_allowed_actions()
+            except KeyError:
                 actions = None
             if actions is not None and actions != prev_actions:
                 prev_actions = actions


### PR DESCRIPTION
## Summary
- add `EngineManager` to manage multiple game engines
- expose context manager and `record_next_actions` helper
- refactor `web/server.py` to use the manager instead of the global engine
- ensure tests reset the manager and add engine manager tests
- document engine manager feature in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_6870d70d2774832ab313998ac70157c1