### PR TITLE
Prevent invalid AI auto requests

### DIFF
--- a/web_gui/GameBoard.autoGuard.test.jsx
+++ b/web_gui/GameBoard.autoGuard.test.jsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState(playerIndex = 1) {
+  return {
+    current_player: playerIndex,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    waiting_for_claims: [],
+    last_discard: { suit: 'man', value: 1 },
+  };
+}
+
+describe('GameBoard auto guard', () => {
+  it('skips auto when no longer allowed', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = mockState(1);
+    const { rerender } = render(
+      <GameBoard state={state} server="http://s" gameId="1" aiDelay={500} allowedActions={[['draw'], [], [], []]} />,
+    );
+    await vi.runAllTicks();
+    rerender(
+      <GameBoard state={state} server="http://s" gameId="1" aiDelay={500} allowedActions={[[], [], [], []]} />,
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    const calls = fetchMock.mock.calls.filter(c => c[0].includes('/action'));
+    expect(calls.length).toBe(0);
+    vi.useRealTimers();
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -39,9 +39,24 @@ export default function GameBoard({
   const [aiPlayers, setAiPlayers] = useState([false, true, true, true]);
   const [aiTypes] = useState(["simple", "simple", "simple", "simple"]);
 
+  const allowedRef = useRef(allowedActions);
+  useEffect(() => {
+    allowedRef.current = allowedActions;
+  }, [allowedActions]);
+
   function sendAction(body, delay = false) {
     const url = `${server.replace(/\/$/, "")}/games/${gameId}/action`;
     const fn = async () => {
+      if (body.action === "auto") {
+        const allowed = allowedRef.current[body.player_index] || [];
+        if (!allowed.length) {
+          log(
+            "debug",
+            `Skip auto for player ${body.player_index} - not allowed`
+          );
+          return;
+        }
+      }
       try {
         const resp = await fetch(url, {
           method: "POST",


### PR DESCRIPTION
## Summary
- guard AI auto actions with latest allowed actions
- test that pending auto is skipped when not allowed

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6870d864ee10832abcd4fae82ffdd8e6