### PR TITLE
Add async event queue and websocket observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Future work will expand these components.
 - [x] Allowed actions API
 - [x] Combined allowed actions endpoint
 - [x] Allowed actions pushed via WebSocket events
+- [x] Engine event queue for WebSocket notifications
 - [x] Next actions API
 - [x] Next actions logged to event history
 - [x] GUI fetches next actions after every event

--- a/core/api.py
+++ b/core/api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
+import asyncio
 from . import exceptions
 from .models import GameState, Tile, GameEvent, GameAction
 from .ai import AI_REGISTRY
@@ -10,6 +11,18 @@ from mahjong.hand_calculating.hand_response import HandResponse
 
 # Singleton engine instance used by interfaces
 _engine: MahjongEngine | None = None
+
+
+def register_observer(queue: asyncio.Queue[GameEvent]) -> None:
+    """Register ``queue`` to receive engine events."""
+    assert _engine is not None, "Game not started"
+    _engine.register_observer(queue)
+
+
+def unregister_observer(queue: asyncio.Queue[GameEvent]) -> None:
+    """Remove ``queue`` from the observer list."""
+    assert _engine is not None, "Game not started"
+    _engine.unregister_observer(queue)
 
 
 def start_game(player_names: list[str], *, max_rounds: int = 8) -> GameState:


### PR DESCRIPTION
## Summary
- queue engine events to subscribed observers
- push events to WebSocket clients without polling
- test that WebSocket events arrive immediately
- document new engine queue capability

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `python -m pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx -y vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_6870d792db90832a80115b53f4604c49