### PR TITLE
Introduce action constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Future work will expand these components.
 - [x] GUI fetches next actions after every event
 - [x] GUI follows next actions from core
 - [x] Meld and win actions via GUI
+- [x] Shared action constants in core.actions
 - [x] Start game via GUI
 - [x] Start round via API
 - [x] Simple shanten-based AI for automated turns (discards tiles that keep shanten and calls pon/chi when it improves the hand)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -18,4 +18,5 @@ __all__ = [
     "rules",
     "shanten_quiz",
     "exceptions",
+    "actions",
 ]

--- a/core/actions.py
+++ b/core/actions.py
@@ -1,0 +1,31 @@
+"""Action name constants used across packages."""
+CHI = "chi"
+PON = "pon"
+KAN = "kan"
+RIICHI = "riichi"
+TSUMO = "tsumo"
+RON = "ron"
+SKIP = "skip"
+DRAW = "draw"
+DISCARD = "discard"
+START_KYOKU = "start_kyoku"
+ADVANCE_HAND = "advance_hand"
+END_GAME = "end_game"
+AUTO = "auto"
+
+# List of valid actions recognized by the API and web server
+VALID_ACTIONS = [
+    DRAW,
+    DISCARD,
+    CHI,
+    PON,
+    KAN,
+    RIICHI,
+    TSUMO,
+    RON,
+    SKIP,
+    START_KYOKU,
+    ADVANCE_HAND,
+    END_GAME,
+    AUTO,
+]

--- a/core/api.py
+++ b/core/api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from .mahjong_engine import MahjongEngine
+from .actions import (CHI, PON, KAN, RIICHI, TSUMO, RON, SKIP, DRAW, DISCARD, START_KYOKU, ADVANCE_HAND, END_GAME, AUTO)
 from . import exceptions
 from .models import GameState, Tile, GameEvent, GameAction
 from .ai import AI_REGISTRY
@@ -305,9 +306,9 @@ def _player_actions(player_index: int) -> list[str]:
     if not state.waiting_for_claims and player_index == state.current_player:
         player = state.players[player_index]
         if len(player.hand.tiles) % 3 == 1:
-            actions.add("draw")
+            actions.add(DRAW)
         else:
-            actions.add("discard")
+            actions.add(DISCARD)
     return sorted(actions)
 
 
@@ -324,7 +325,7 @@ def get_next_actions() -> tuple[int, list[str]]:
         state = _engine.state
         idx = state.waiting_for_claims[0] if state.waiting_for_claims else state.current_player
         actions = _player_actions(idx)
-        if actions == ["draw"]:
+        if actions == [DRAW]:
             _engine.draw_tile(idx)
             continue
         return idx, actions
@@ -335,47 +336,47 @@ def apply_action(action: GameAction) -> object | None:
 
     assert _engine is not None, "Game not started"
 
-    if action.type == "draw":
+    if action.type == DRAW:
         assert action.player_index is not None
         return _engine.draw_tile(action.player_index)
-    if action.type == "discard" and action.tile is not None:
+    if action.type == DISCARD and action.tile is not None:
         assert action.player_index is not None
         _engine.discard_tile(action.player_index, action.tile)
         return None
-    if action.type == "chi" and action.tiles is not None:
+    if action.type == CHI and action.tiles is not None:
         assert action.player_index is not None
         _engine.call_chi(action.player_index, action.tiles)
         return None
-    if action.type == "pon" and action.tiles is not None:
+    if action.type == PON and action.tiles is not None:
         assert action.player_index is not None
         _engine.call_pon(action.player_index, action.tiles)
         return None
-    if action.type == "kan" and action.tiles is not None:
+    if action.type == KAN and action.tiles is not None:
         assert action.player_index is not None
         _engine.call_kan(action.player_index, action.tiles)
         return None
-    if action.type == "riichi":
+    if action.type == RIICHI:
         assert action.player_index is not None
         _engine.declare_riichi(action.player_index)
         return None
-    if action.type == "tsumo" and action.tile is not None:
+    if action.type == TSUMO and action.tile is not None:
         assert action.player_index is not None
         return _engine.declare_tsumo(action.player_index, action.tile)
-    if action.type == "ron" and action.tile is not None:
+    if action.type == RON and action.tile is not None:
         assert action.player_index is not None
         return _engine.declare_ron(action.player_index, action.tile)
-    if action.type == "skip":
+    if action.type == SKIP:
         assert action.player_index is not None
         _engine.skip(action.player_index)
         return None
-    if action.type == "start_kyoku":
+    if action.type == START_KYOKU:
         assert action.dealer is not None and action.round_number is not None
         _engine.start_kyoku(action.dealer, action.round_number)
         return None
-    if action.type == "advance_hand":
+    if action.type == ADVANCE_HAND:
         _engine.advance_hand(action.player_index)
         return None
-    if action.type == "end_game":
+    if action.type == END_GAME:
         return _engine.end_game()
 
     raise ValueError(f"Unknown action: {action.type}")

--- a/core/player.py
+++ b/core/player.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from .actions import CHI, PON, KAN
 from .models import Hand, Tile
 
 
@@ -38,7 +39,7 @@ class Player:
     def has_open_melds(self) -> bool:
         """Return ``True`` if the player has chi, pon or open kan melds."""
         return any(
-            meld.type in {"chi", "pon", "kan", "added_kan"}
+            meld.type in {CHI, PON, KAN, "added_kan"}
             for meld in self.hand.melds
         )
 

--- a/core/simple_ai.py
+++ b/core/simple_ai.py
@@ -6,6 +6,7 @@ from typing import Iterable
 
 from mahjong.shanten import Shanten
 
+from .actions import CHI, PON
 from .mahjong_engine import MahjongEngine
 from .models import Tile
 from .rules import _tile_to_index
@@ -96,7 +97,7 @@ def claim_meld(engine: MahjongEngine, player_index: int) -> bool:
         value = _calculate_shanten(remaining)
         if value < best_value:
             best_value = value
-            best_action = ("pon", [same[0], same[1], last_tile])
+            best_action = (PON, [same[0], same[1], last_tile])
 
     # Chi candidate
     if (last_player + 1) % len(state.players) == player_index and last_tile.suit in {"man", "pin", "sou"}:
@@ -121,12 +122,12 @@ def claim_meld(engine: MahjongEngine, player_index: int) -> bool:
                     best_value = value
                     meld_tiles = [*needed, last_tile]
                     meld_tiles.sort(key=lambda t: t.value)
-                    best_action = ("chi", meld_tiles)
+                    best_action = (CHI, meld_tiles)
 
     if best_action is None or best_value >= current:
         return False
 
-    if best_action[0] == "pon":
+    if best_action[0] == PON:
         engine.call_pon(player_index, best_action[1])
     else:
         engine.call_chi(player_index, best_action[1])

--- a/tests/core/test_ai_adapter.py
+++ b/tests/core/test_ai_adapter.py
@@ -1,3 +1,4 @@
+from core.actions import DISCARD, END_GAME
 from core.ai_adapter import (
     game_state_to_json,
     json_to_game_state,
@@ -66,26 +67,26 @@ def test_json_to_action() -> None:
     msg = '{"type": "discard", "tile": {"suit": "pin", "value": 3}}'
     action = json_to_action(msg)
     assert isinstance(action, models.GameAction)
-    assert action.type == "discard"
+    assert action.type == DISCARD
     assert action.tile and action.tile.value == 3
 
 
 def test_action_to_json_roundtrip() -> None:
     action = models.GameAction(
-        type="discard",
+        type=DISCARD,
         player_index=0,
         tile=models.Tile("pin", 5),
     )
     msg = action_to_json(action)
     restored = json_to_action(msg)
-    assert restored.type == "discard"
+    assert restored.type == DISCARD
     assert restored.tile and restored.tile.value == 5
 
 
 def test_send_and_receive_event() -> None:
     ai = DummyAI()
     event = GameEvent(
-        name="end_game",
+        name=END_GAME,
         payload={"scores": [25000, 24000, 23000, 26000]},
     )
     send_event_to_ai(event, ai)

--- a/tests/core/test_allowed_actions_cache.py
+++ b/tests/core/test_allowed_actions_cache.py
@@ -1,3 +1,4 @@
+from core.actions import CHI, SKIP
 from core import api, models
 
 
@@ -11,5 +12,5 @@ def test_allowed_actions_cache_invalidated_on_discard() -> None:
     state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 3)]
 
     actions = api.get_allowed_actions(1)
-    assert "chi" in actions and "skip" in actions
+    assert CHI in actions and SKIP in actions
 

--- a/tests/core/test_allowed_actions_ron.py
+++ b/tests/core/test_allowed_actions_ron.py
@@ -1,3 +1,4 @@
+from core.actions import RON
 from core.mahjong_engine import MahjongEngine
 from core.rules import RuleSet
 from core.models import Tile

--- a/tests/core/test_allowed_actions_skip.py
+++ b/tests/core/test_allowed_actions_skip.py
@@ -1,3 +1,5 @@
+from core.actions import SKIP
+from core.actions import SKIP
 from core import api, models
 
 
@@ -6,7 +8,7 @@ def test_skip_not_offered_when_no_claims() -> None:
     assert state.waiting_for_claims == []
     for i in range(4):
         actions = api.get_allowed_actions(i)
-        assert "skip" not in actions
+        assert SKIP not in actions
 
 
 def test_skip_offered_to_all_waiting_players() -> None:
@@ -16,6 +18,6 @@ def test_skip_offered_to_all_waiting_players() -> None:
     for i in range(1, 4):
         assert i in state.waiting_for_claims
         actions = api.get_allowed_actions(i)
-        assert "skip" in actions
+        assert SKIP in actions
     assert 0 not in state.waiting_for_claims
-    assert "skip" not in api.get_allowed_actions(0)
+    assert SKIP not in api.get_allowed_actions(0)

--- a/tests/core/test_allowed_actions_tsumo.py
+++ b/tests/core/test_allowed_actions_tsumo.py
@@ -1,3 +1,4 @@
+from core.actions import TSUMO
 from core.mahjong_engine import MahjongEngine
 from core.rules import RuleSet
 from mahjong.hand_calculating.hand_response import HandResponse

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -1,3 +1,4 @@
+from core.actions import CHI, PON, KAN, RIICHI, SKIP
 from core import api, models, practice
 
 
@@ -43,7 +44,7 @@ def test_call_pon() -> None:
     caller.hand.tiles.extend([models.Tile("pin", 1), models.Tile("pin", 1)])
     api.call_pon(0, [models.Tile("pin", 1), models.Tile("pin", 1), tile])
     assert len(caller.hand.melds) == 1
-    assert caller.hand.melds[0].type == "pon"
+    assert caller.hand.melds[0].type == PON
 
 
 def test_call_chi_missing_discard() -> None:
@@ -56,7 +57,7 @@ def test_call_chi_missing_discard() -> None:
     caller.hand.tiles.extend([models.Tile("man", 1), models.Tile("man", 2)])
     api.call_chi(1, [models.Tile("man", 1), models.Tile("man", 2)])
     assert len(caller.hand.melds) == 1
-    assert caller.hand.melds[0].type == "chi"
+    assert caller.hand.melds[0].type == CHI
 
 
 def test_call_chi_replaces_discard_instance() -> None:
@@ -86,7 +87,7 @@ def test_call_kan_missing_discard() -> None:
     caller.hand.tiles.extend([models.Tile("pin", 5) for _ in range(3)])
     api.call_kan(1, [models.Tile("pin", 5)] * 3)
     assert len(caller.hand.melds) == 1
-    assert caller.hand.melds[0].type == "kan"
+    assert caller.hand.melds[0].type == KAN
 
 
 def test_call_kan_replaces_discard_instance() -> None:
@@ -184,7 +185,7 @@ def test_get_allowed_actions_api() -> None:
     api.discard_tile(0, discard_tile)
     state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 3)]
     actions = api.get_allowed_actions(1)
-    assert "chi" in actions and "pon" not in actions and "skip" in actions
+    assert CHI in actions and PON not in actions and SKIP in actions
 
 
 TENPAI_TILES = [
@@ -202,7 +203,7 @@ def test_allowed_actions_offer_riichi_on_turn() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     state.players[0].hand.tiles = TENPAI_TILES.copy()
     actions = api.get_allowed_actions(0)
-    assert actions == ["riichi"]
+    assert actions == [RIICHI]
 
 
 def test_allowed_actions_exclude_riichi_when_not_tenpai() -> None:
@@ -216,7 +217,7 @@ def test_allowed_actions_exclude_riichi_when_not_tenpai() -> None:
     ]
     state.players[0].hand.tiles = tiles
     actions = api.get_allowed_actions(0)
-    assert "riichi" not in actions
+    assert RIICHI not in actions
 
 
 def test_allowed_actions_exclude_riichi_with_open_meld() -> None:
@@ -224,10 +225,10 @@ def test_allowed_actions_exclude_riichi_with_open_meld() -> None:
     player = state.players[0]
     player.hand.tiles = TENPAI_TILES.copy()
     player.hand.melds.append(
-        models.Meld(tiles=[models.Tile("man", 1)] * 3, type="pon")
+        models.Meld(tiles=[models.Tile("man", 1)] * 3, type=PON)
     )
     actions = api.get_allowed_actions(0)
-    assert "riichi" not in actions
+    assert RIICHI not in actions
 
 
 def test_allowed_actions_exclude_riichi_for_other_players() -> None:
@@ -235,4 +236,4 @@ def test_allowed_actions_exclude_riichi_for_other_players() -> None:
     for p in state.players:
         p.hand.tiles = TENPAI_TILES.copy()
     actions = api.get_allowed_actions(1)
-    assert "riichi" not in actions
+    assert RIICHI not in actions

--- a/tests/core/test_apply_action.py
+++ b/tests/core/test_apply_action.py
@@ -1,3 +1,4 @@
+from core.actions import DRAW, DISCARD, START_KYOKU
 import pytest
 from core import api, models
 
@@ -8,10 +9,10 @@ def test_apply_action_draw_discard() -> None:
     tile = models.Tile(suit="sou", value=9)
     state.wall.tiles.append(tile)
     state.players[0].hand.tiles.pop()
-    draw = models.GameAction(type="draw", player_index=0)
+    draw = models.GameAction(type=DRAW, player_index=0)
     result = api.apply_action(draw)
     assert result == tile
-    discard = models.GameAction(type="discard", player_index=0, tile=tile)
+    discard = models.GameAction(type=DISCARD, player_index=0, tile=tile)
     api.apply_action(discard)
     assert tile in state.players[0].river
 
@@ -25,7 +26,7 @@ def test_apply_action_unknown() -> None:
 
 def test_apply_action_start_kyoku() -> None:
     api.start_game(["A", "B", "C", "D"])
-    action = models.GameAction(type="start_kyoku", dealer=1, round_number=2)
+    action = models.GameAction(type=START_KYOKU, dealer=1, round_number=2)
     api.apply_action(action)
     state = api.get_state()
     assert state.dealer == 1

--- a/tests/core/test_claim_window.py
+++ b/tests/core/test_claim_window.py
@@ -1,3 +1,4 @@
+from core.actions import CHI, PON
 from core import api, models
 
 
@@ -8,10 +9,10 @@ def test_claim_options_removed_after_draw() -> None:
     api.discard_tile(0, discard)
     state.players[1].hand.tiles = [models.Tile("man", 1), models.Tile("man", 2)] + [models.Tile("pin", 1)] * 11
     actions = api.get_allowed_actions(1)
-    assert "chi" in actions
+    assert CHI in actions
     api.skip(1)
     api.skip(2)
     api.skip(3)
     actions_after = api.get_allowed_actions(1)
-    assert "chi" not in actions_after
-    assert "pon" not in actions_after
+    assert CHI not in actions_after
+    assert PON not in actions_after

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -1,3 +1,4 @@
+from core.actions import PON
 import pytest
 from core.mahjong_engine import MahjongEngine
 from core.exceptions import InvalidActionError
@@ -90,7 +91,7 @@ def test_call_pon_adds_meld() -> None:
     caller.hand.tiles.extend([Tile("man", 1), Tile("man", 1)])
     engine.call_pon(1, [Tile("man", 1), Tile("man", 1), tile])
     assert len(caller.hand.melds) == 1
-    assert caller.hand.melds[0].type == "pon"
+    assert caller.hand.melds[0].type == PON
     assert tile not in discarder.river
 
 

--- a/tests/core/test_meld_validation.py
+++ b/tests/core/test_meld_validation.py
@@ -1,3 +1,4 @@
+from core.actions import CHI
 import pytest
 from core.mahjong_engine import MahjongEngine
 from core.models import Tile
@@ -15,7 +16,7 @@ def test_call_chi_consumes_discard() -> None:
     caller.hand.tiles.extend([Tile("man", 1), Tile("man", 2)])
     engine.call_chi(1, [Tile("man", 1), Tile("man", 2), tile])
     assert len(caller.hand.melds) == 1
-    assert caller.hand.melds[0].type == "chi"
+    assert caller.hand.melds[0].type == CHI
     assert tile not in discarder.river
 
 

--- a/tests/core/test_player.py
+++ b/tests/core/test_player.py
@@ -1,3 +1,4 @@
+from core.actions import PON
 from core.player import Player
 from core import models
 from core.models import Tile
@@ -47,6 +48,6 @@ def test_has_open_melds() -> None:
     player = Player(name="Test")
     assert not player.has_open_melds()
     player.hand.melds.append(
-        models.Meld(tiles=[models.Tile("man", 1)] * 3, type="pon")
+        models.Meld(tiles=[models.Tile("man", 1)] * 3, type=PON)
     )
     assert player.has_open_melds()

--- a/tests/core/test_riichi_validation.py
+++ b/tests/core/test_riichi_validation.py
@@ -1,3 +1,4 @@
+from core.actions import PON
 import pytest
 from core.mahjong_engine import MahjongEngine
 from core.exceptions import InvalidActionError
@@ -35,7 +36,7 @@ def test_riichi_rejected_with_open_meld() -> None:
     player = engine.state.players[0]
     player.hand.tiles = _tenpai_tiles()
     player.hand.melds.append(
-        Meld(tiles=[Tile("man", 1)] * 3, type="pon")
+        Meld(tiles=[Tile("man", 1)] * 3, type=PON)
     )
     with pytest.raises(InvalidActionError):
         engine.declare_riichi(0)

--- a/web/server.py
+++ b/web/server.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from core import api, models, shanten_quiz
+from core.actions import (CHI, PON, KAN, RIICHI, TSUMO, RON, SKIP, DRAW, DISCARD, AUTO)
 from core.exceptions import InvalidActionError, NotYourTurnError
 from core.models import GameEvent
 
@@ -440,16 +441,16 @@ def _auto(req: ActionRequest) -> dict:
 
 
 ACTION_HANDLERS = {
-    "draw": _draw,
-    "discard": _discard,
-    "chi": _chi,
-    "pon": _pon,
-    "kan": _kan,
-    "riichi": _riichi,
-    "tsumo": _tsumo,
-    "ron": _ron,
-    "skip": _skip,
-    "auto": _auto,
+    DRAW: _draw,
+    DISCARD: _discard,
+    CHI: _chi,
+    PON: _pon,
+    KAN: _kan,
+    RIICHI: _riichi,
+    TSUMO: _tsumo,
+    RON: _ron,
+    SKIP: _skip,
+    AUTO: _auto,
 }
 
 
@@ -463,7 +464,7 @@ def game_action(game_id: int, req: ActionRequest) -> dict:
         raise HTTPException(status_code=404, detail="Game not started")
     except IndexError:
         raise HTTPException(status_code=404, detail="Player not found")
-    if req.action in {"chi", "pon", "kan", "riichi", "skip"} and req.action not in allowed:
+    if req.action in {CHI, PON, KAN, RIICHI, SKIP} and req.action not in allowed:
         logger.info(
             "Player %s attempted disallowed action %s (allowed=%s)",
             req.player_index,


### PR DESCRIPTION
## Summary
- add `core.actions` module with action name constants
- update core and web to use the constants
- expose valid actions and adjust tests
- document new module in README

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx --yes vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_6870d71e43f4832a821ed4b2b7ba4570