### PR TITLE
Improve action logging

### DIFF
--- a/web/server.py
+++ b/web/server.py
@@ -440,6 +440,11 @@ ACTION_HANDLERS = {
 @app.post("/games/{game_id}/action")
 def game_action(game_id: int, req: ActionRequest) -> dict:
     """Perform a simple game action and return its result."""
+    logger.info(
+        "POST /games/%s/action %s",
+        game_id,
+        {k: v for k, v in req.dict().items() if v is not None},
+    )
     try:
         with manager.use_engine(game_id):
             allowed = api.get_allowed_actions(req.player_index)


### PR DESCRIPTION
## Summary
- log action request body in FastAPI server
- test that action logging includes request details

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6870f4ed5fc0832a966e7674738bdc59