### PR TITLE
Add manual state refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Future work will expand these components.
 - [x] Debug logging of GUI API calls
 - [x] Error modal shows server rejection
 - [x] Conflict detail logged and displayed on 409 errors
+- [x] Manual state refresh button on errors
 - [x] Player and action included in 409 error messages
 - [x] Custom engine exceptions with FastAPI handlers
 - [x] Chi option modal when multiple chi choices are available

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -210,3 +210,9 @@ def test_result_modal_has_log_options() -> None:
 def test_event_log_modal_component_exists() -> None:
     modal = Path('web_gui/EventLogModal.jsx')
     assert modal.is_file(), 'EventLogModal.jsx missing'
+
+
+def test_error_modal_has_retry_button() -> None:
+    text = Path('web_gui/ErrorModal.jsx').read_text()
+    assert 'onRetry' in text
+    assert 'Retry state' in text

--- a/web_gui/ErrorModal.jsx
+++ b/web_gui/ErrorModal.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
+import Button from './Button.jsx';
 
-export default function ErrorModal({ message, onClose }) {
+export default function ErrorModal({ message, onClose, onRetry = null }) {
   return (
     <div className={`modal ${message ? 'is-active' : ''}`}>
       <div className="modal-background" onClick={onClose}></div>
       <div className="modal-content">
         <div className="box">
           <p>{message}</p>
+          {onRetry && (
+            <div className="has-text-centered mt-2">
+              <Button aria-label="Retry state" onClick={onRetry}>
+                Retry
+              </Button>
+            </div>
+          )}
         </div>
       </div>
       <button

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -21,6 +21,7 @@ export default function GameBoard({
   showLog = null,
   downloadTenhou = null,
   downloadMjai = null,
+  onRetry = null,
 }) {
   const players = state?.players ?? [];
   const south = players[0];
@@ -371,6 +372,7 @@ export default function GameBoard({
           activePlayer={state?.current_player}
           aiActive={aiPlayers[2]}
           toggleAI={toggleAI}
+          onRetry={onRetry}
         />
         <PlayerPanel
           seat="west"
@@ -387,6 +389,7 @@ export default function GameBoard({
           activePlayer={state?.current_player}
           aiActive={aiPlayers[1]}
           toggleAI={toggleAI}
+          onRetry={onRetry}
         />
         <PlayerPanel
           seat="east"
@@ -403,6 +406,7 @@ export default function GameBoard({
           activePlayer={state?.current_player}
           aiActive={aiPlayers[3]}
           toggleAI={toggleAI}
+          onRetry={onRetry}
         />
         <PlayerPanel
           seat="south"
@@ -428,6 +432,7 @@ export default function GameBoard({
           toggleAI={toggleAI}
           selectingRiichi={selectingRiichi}
           onRiichi={startRiichi}
+          onRetry={onRetry}
         />
       </div>
       <ResultModal
@@ -438,7 +443,11 @@ export default function GameBoard({
         onDownloadTenhou={downloadTenhou}
         onDownloadMjai={downloadMjai}
       />
-      <ErrorModal message={error} onClose={() => setError(null)} />
+      <ErrorModal
+        message={error}
+        onClose={() => setError(null)}
+        onRetry={onRetry}
+      />
     </>
   );
 }

--- a/web_gui/PlayerPanel.jsx
+++ b/web_gui/PlayerPanel.jsx
@@ -34,6 +34,7 @@ export default function PlayerPanel({
   log = () => {},
   allowedActions = [],
   selectingRiichi = false,
+  onRetry = null,
 }) {
   const waiting = state?.waiting_for_claims ?? [];
   const isWaiting = waiting.includes(playerIndex);
@@ -144,7 +145,11 @@ export default function PlayerPanel({
         selectingRiichi={selectingRiichi}
       />
       {error && (
-        <ErrorModal message={error} onClose={() => setError(null)} />
+        <ErrorModal
+          message={error}
+          onClose={() => setError(null)}
+          onRetry={onRetry}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add Retry button and callback to ErrorModal
- plumb onRetry up through PlayerPanel, GameBoard, and App
- implement refreshState in App to fetch the latest state and allowed actions
- document the new GUI capability
- update tests for ErrorModal button

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68710373a79c832a95d1f0dab95a85ef