### PR TITLE
Add retry next-actions fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Future work will expand these components.
 - [x] Error modal shows server rejection
 - [x] Conflict detail logged and displayed on 409 errors
 - [x] Manual state refresh button on errors
+- [x] Retry icon fetches next actions on 409 conflicts
 - [x] Player and action included in 409 error messages
 - [x] Custom engine exceptions with FastAPI handlers
 - [x] Chi option modal when multiple chi choices are available

--- a/tests/web_gui/test_index.py
+++ b/tests/web_gui/test_index.py
@@ -215,4 +215,4 @@ def test_event_log_modal_component_exists() -> None:
 def test_error_modal_has_retry_button() -> None:
     text = Path('web_gui/ErrorModal.jsx').read_text()
     assert 'onRetry' in text
-    assert 'Retry state' in text
+    assert 'aria-label="Retry"' in text

--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -123,6 +123,24 @@ export default function App() {
   async function refreshState() {
     if (!gameId) return;
     await fetchGameState(gameId);
+    const next = await getNextActions(server, gameId, log, {
+      requestId: 'retry-next',
+    });
+    if (next && !next.aborted && next.player_index != null) {
+      setGameData((d) => {
+        const arr = [[], [], [], []];
+        arr[next.player_index] = next.actions || [];
+        return { ...d, allowed: arr };
+      });
+      setEvents((evts) => {
+        const evt = {
+          name: 'next_actions',
+          payload: next,
+        };
+        const line = `${formatEvent(evt)} ${eventToMjaiJson(evt)}`;
+        return [...evts.slice(-9), line];
+      });
+    }
     const actions = await getAllAllowedActions(server, gameId, log, {
       requestId: 'retry-actions',
     });

--- a/web_gui/App.test.jsx
+++ b/web_gui/App.test.jsx
@@ -125,7 +125,7 @@ describe('App icons', () => {
   it('renders refresh icon button', () => {
     global.fetch = mockFetch();
     render(<App />);
-    const refreshButton = screen.getByLabelText('Retry');
+    const refreshButton = screen.getAllByLabelText('Retry')[0];
     expect(refreshButton.querySelector('svg')).toBeTruthy();
   });
 

--- a/web_gui/ErrorModal.jsx
+++ b/web_gui/ErrorModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FiRefreshCw } from 'react-icons/fi';
 import Button from './Button.jsx';
 
 export default function ErrorModal({ message, onClose, onRetry = null }) {
@@ -10,8 +11,14 @@ export default function ErrorModal({ message, onClose, onRetry = null }) {
           <p>{message}</p>
           {onRetry && (
             <div className="has-text-centered mt-2">
-              <Button aria-label="Retry state" onClick={onRetry}>
-                Retry
+              <Button
+                aria-label="Retry"
+                onClick={() => {
+                  onClose();
+                  onRetry();
+                }}
+              >
+                <FiRefreshCw />
               </Button>
             </div>
           )}

--- a/web_gui/ErrorModal.test.jsx
+++ b/web_gui/ErrorModal.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import ErrorModal from './ErrorModal.jsx';
+
+describe('ErrorModal retry', () => {
+  it('calls retry and close on click', async () => {
+    const onClose = vi.fn();
+    const onRetry = vi.fn();
+    render(<ErrorModal message="oops" onClose={onClose} onRetry={onRetry} />);
+    const btn = screen.getByLabelText('Retry');
+    expect(btn.querySelector('svg')).toBeTruthy();
+    await userEvent.click(btn);
+    expect(onRetry).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- close error modal when retry clicked
- fetch next actions for conflict recovery
- test ErrorModal retry button
- document retry feature

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687107f8eea4832aac0e93abc107f6a1