### PR TITLE
Fix GUI claim wait handling

### DIFF
--- a/web_gui/GameBoard.claimsClosed.test.jsx
+++ b/web_gui/GameBoard.claimsClosed.test.jsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState(waiting = [], player = 1) {
+  return {
+    current_player: player,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    waiting_for_claims: waiting,
+    last_discard: { suit: 'man', value: 1 },
+  };
+}
+
+describe('GameBoard claims handling', () => {
+  it('waits for claims to close before sending draw', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+  const state = mockState([1], 1);
+  const { rerender } = render(
+    <GameBoard
+      state={state}
+      server="http://s"
+      gameId="1"
+      allowedActions={[["skip"], [], [], []]}
+    />,
+  );
+  await Promise.resolve();
+  fetchMock.mockClear();
+  state.waiting_for_claims = [];
+  rerender(
+    <GameBoard
+      state={state}
+      server="http://s"
+      gameId="1"
+      allowedActions={[[], ["draw"], [], []]}
+    />,
+  );
+  await Promise.resolve();
+  const calls = fetchMock.mock.calls.filter(c => c[1] && c[1].body);
+  const actions = calls.map(c => JSON.parse(c[1].body).action);
+  expect(actions).not.toContain('draw');
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -31,6 +31,7 @@ export default function GameBoard({
 
   const prevPlayer = useRef(null);
   const prevWaiting = useRef([]);
+  const claimsRecentlyClosed = useRef(false);
   const skipSent = useRef(new Set());
   const prevCounts = useRef([]);
   const lastDrawPlayer = useRef(null);
@@ -132,6 +133,7 @@ export default function GameBoard({
     }
     const waiting = state?.waiting_for_claims ?? [];
     if (waiting.length > 0) {
+      claimsRecentlyClosed.current = true;
       if (JSON.stringify(waiting) !== JSON.stringify(prevWaiting.current)) {
         prevWaiting.current = waiting.slice();
         skipSent.current.clear();
@@ -161,7 +163,15 @@ export default function GameBoard({
       return;
     }
     skipSent.current.clear();
+    if (prevWaiting.current.length > 0) {
+      claimsRecentlyClosed.current = true;
+    }
     prevWaiting.current = [];
+
+    if (claimsRecentlyClosed.current) {
+      claimsRecentlyClosed.current = false;
+      return;
+    }
 
     const current = state?.current_player;
     if (current == null || current === prevPlayer.current) return;


### PR DESCRIPTION
## Summary
- prevent automatic actions immediately after claims window ends
- add regression test verifying no premature draw

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx --no-install vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_68710b29a5f4832aac3fde6c0e49aede