### PR TITLE
Add test for next turn after skips

### DIFF
--- a/tests/core/test_turn_after_skip.py
+++ b/tests/core/test_turn_after_skip.py
@@ -1,0 +1,30 @@
+from core.mahjong_engine import MahjongEngine
+
+
+def test_turn_advances_after_all_players_skip() -> None:
+    engine = MahjongEngine()
+    engine.pop_events()  # clear start_game/start_kyoku
+
+    discarder = engine.state.dealer
+    tile = engine.state.players[discarder].hand.tiles[-1]
+    engine.discard_tile(discarder, tile)
+
+    engine.skip((discarder + 1) % 4)
+    engine.skip((discarder + 2) % 4)
+    engine.skip((discarder + 3) % 4)
+
+    next_player = (discarder + 1) % 4
+    drawn = engine.state.players[next_player].hand.tiles[-1]
+    engine.discard_tile(next_player, drawn)
+
+    names = [e.name for e in engine.event_history[-7:]]
+    assert names == [
+        "discard",
+        "skip",
+        "skip",
+        "skip",
+        "claims_closed",
+        "draw_tile",
+        "discard",
+    ]
+    assert engine.state.current_player == (next_player + 1) % 4


### PR DESCRIPTION
## Summary
- ensure turn advances after all players skip a discard

## Testing
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68710ca1ad58832a88d9d6b1035d5147