### PR TITLE
Fix tenhou log player ordering

### DIFF
--- a/tests/core/test_tenhou_log.py
+++ b/tests/core/test_tenhou_log.py
@@ -26,8 +26,8 @@ def test_tenhou_log_includes_all_starting_hands() -> None:
     engine.end_game()
     data = json.loads(events_to_tenhou_json(engine.pop_events()))
     kyoku = data["log"][0]
-    # After meta arrays we have four starting hand arrays
-    hands = kyoku[4:8]
+    # After meta arrays hands appear every three elements
+    hands = [kyoku[i] for i in range(4, 16, 3)]
     assert len(hands[0]) in {13, 14}
     assert all(len(hand) == 13 for hand in hands[1:])
 


### PR DESCRIPTION
## Summary
- update events_to_tenhou_json to maintain per-player [hand,take,dahai]
- output player arrays in hai/take/dahai order
- adjust tenhou log validator for new structure
- update tests for new layout

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_687111b353cc832ab6d6a8785c71f01e