### PR TITLE
Add kan dora tracking and ura-dora output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Future work will expand these components.
 - [x] Convert MJAI logs to Tenhou format
 - [x] Tenhou log validator
 - [x] Meld notation in Tenhou log
+- [x] Dora and ura dora indicators in Tenhou log
 - [ ] Yaku details in Tenhou log
 - [x] RuleSet interface for scoring
 - [x] Local single-player play via CLI

--- a/docs/tenhou-json.md
+++ b/docs/tenhou-json.md
@@ -74,7 +74,8 @@ and losing players, a hand value string and the yaku.
 Our implementation currently supports only a subset of this
 specification:
 
-- Ura dora markers are always empty.
+- Dora indicators from kan draws are appended to the indicator list.
+- Ura dora markers are included when a hand is won.
 - The result array stores only score deltas and a simple win record
   without detailed point strings or yaku information.
 


### PR DESCRIPTION
## Summary
- update tenhou log serialization to append new dora on kan draws
- include ura-dora indicators on win events
- document new functionality in README and tenhou-json spec
- test dora and ura-dora logging

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_687111b5d7b0832ab766aaf6c55c2f64