### PR TITLE
Sync turn with next_actions event

### DIFF
--- a/web_gui/App.jsx
+++ b/web_gui/App.jsx
@@ -130,7 +130,11 @@ export default function App() {
       setGameData((d) => {
         const arr = [[], [], [], []];
         arr[next.player_index] = next.actions || [];
-        return { ...d, allowed: arr };
+        return {
+          ...d,
+          allowed: arr,
+          state: { ...d.state, current_player: next.player_index },
+        };
       });
       setEvents((evts) => {
         const evt = {

--- a/web_gui/applyEvent.js
+++ b/web_gui/applyEvent.js
@@ -120,6 +120,11 @@ export function applyEvent(state, event) {
     case 'claims_closed':
       newState.waiting_for_claims = [];
       break;
+    case 'next_actions':
+      if (typeof event.payload.player_index === 'number') {
+        newState.current_player = event.payload.player_index;
+      }
+      break;
     case 'skip': {
       if (!Array.isArray(state.waiting_for_claims) || state.waiting_for_claims.length === 0) {
         break;

--- a/web_gui/applyEvent.nextActions.test.js
+++ b/web_gui/applyEvent.nextActions.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { applyEvent } from './applyEvent.js';
+
+function mockState() {
+  return {
+    players: [],
+    current_player: 0,
+    waiting_for_claims: [],
+  };
+}
+
+describe('applyEvent next_actions', () => {
+  it('sets current player from payload', () => {
+    const state = mockState();
+    const evt = { name: 'next_actions', payload: { player_index: 2, actions: ['draw'] } };
+    const next = applyEvent(state, evt);
+    expect(next.current_player).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- update `applyEvent` to set current player when `next_actions` arrives
- update manual refresh to sync `current_player`
- test next_actions handling in `applyEvent`

## Testing
- `npm ci`
- `npx vitest run`
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871172ed4b8832a9518c1c547c83db9