### PR TITLE
Add riichi and ippatsu scoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Future work will expand these components.
 - [x] Enforce tsumogiri after riichi
 - [x] Riichi event includes player score and stick count
 - [x] Ippatsu flag tracking for riichi wins
+- [x] Riichi & ippatsu yaku scoring
 - [x] Validate closed-hand tenpai requirement for riichi
  - [x] action dispatch helper
   - [x] seat wind tracking

--- a/core/rules.py
+++ b/core/rules.py
@@ -8,6 +8,7 @@ from mahjong.hand_calculating.hand import HandCalculator
 from mahjong.hand_calculating.hand_config import HandConfig
 from mahjong.hand_calculating.hand_response import HandResponse
 from mahjong.tile import TilesConverter
+from mahjong.constants import EAST, SOUTH, WEST, NORTH
 
 from .models import Tile, Meld
 
@@ -36,6 +37,10 @@ class RuleSet:
         win_tile: Tile,
         *,
         is_tsumo: bool = True,
+        is_riichi: bool = False,
+        is_ippatsu: bool = False,
+        seat_wind: str | None = None,
+        round_wind: str | None = None,
     ) -> HandResponse:
         """Return scoring for the given hand."""
         raise NotImplementedError
@@ -54,6 +59,10 @@ class StandardRuleSet(RuleSet):
         win_tile: Tile,
         *,
         is_tsumo: bool = True,
+        is_riichi: bool = False,
+        is_ippatsu: bool = False,
+        seat_wind: str | None = None,
+        round_wind: str | None = None,
     ) -> HandResponse:
         counts = [0] * 34
         for t in hand_tiles:
@@ -66,7 +75,19 @@ class StandardRuleSet(RuleSet):
             _tile_to_index(win_tile), tiles_136
         )
         assert win_tile_136 is not None, "Winning tile not found in hand"
-        config = HandConfig(is_tsumo=is_tsumo)
+        wind_map = {
+            "east": EAST,
+            "south": SOUTH,
+            "west": WEST,
+            "north": NORTH,
+        }
+        config = HandConfig(
+            is_tsumo=is_tsumo,
+            is_riichi=is_riichi,
+            is_ippatsu=is_ippatsu,
+            player_wind=wind_map.get(seat_wind) if seat_wind else None,
+            round_wind=wind_map.get(round_wind) if round_wind else None,
+        )
         return self.calculator.estimate_hand_value(
             tiles_136, win_tile_136, config=config
         )

--- a/tests/core/test_allowed_actions_ron.py
+++ b/tests/core/test_allowed_actions_ron.py
@@ -6,12 +6,12 @@ from mahjong.hand_calculating.hand_response import HandResponse
 
 
 class AlwaysWinRules(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=1, cost={"total": 8000})
 
 
 class NeverWinRules(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=0)
 
 

--- a/tests/core/test_allowed_actions_tsumo.py
+++ b/tests/core/test_allowed_actions_tsumo.py
@@ -5,12 +5,12 @@ from mahjong.hand_calculating.hand_response import HandResponse
 
 
 class AlwaysWinRules(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=1, cost={"total": 8000})
 
 
 class NeverWinRules(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=0)
 
 

--- a/tests/core/test_honba_scoring.py
+++ b/tests/core/test_honba_scoring.py
@@ -5,7 +5,7 @@ from mahjong.hand_calculating.hand_response import HandResponse
 
 
 class ScoringRuleSet(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=1, cost={"total": 8000})
 
 

--- a/tests/core/test_mahjong_engine.py
+++ b/tests/core/test_mahjong_engine.py
@@ -218,12 +218,12 @@ def test_ron_updates_scores_and_emits_event() -> None:
 
 
 class DummyRuleSet(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=1)
 
 
 class ScoringRuleSet(RuleSet):
-    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True):
+    def calculate_score(self, hand_tiles, melds, win_tile, *, is_tsumo=True, **_):
         return HandResponse(han=1, cost={"total": 8000})
 
 

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -15,6 +15,7 @@ class DummyRuleSet(RuleSet):
         win_tile: Tile,
         *,
         is_tsumo: bool = True,
+        **_: object,
     ) -> HandResponse:
         self.called_with = (hand_tiles[:], melds[:], win_tile, is_tsumo)
         return HandResponse(han=0)
@@ -42,3 +43,59 @@ def test_standard_ruleset_scoring() -> None:
     player.hand.tiles = tiles
     result = engine.calculate_score(0, tiles[-1])
     assert isinstance(result, HandResponse)
+
+
+def test_engine_passes_flags_to_ruleset() -> None:
+    class CaptureRuleSet(RuleSet):
+        def __init__(self) -> None:
+            self.kwargs: dict[str, object] | None = None
+
+        def calculate_score(
+            self,
+            hand_tiles: list[Tile],
+            melds: list[Meld],
+            win_tile: Tile,
+            *,
+            is_tsumo: bool = True,
+            **kwargs: object,
+        ) -> HandResponse:
+            self.kwargs = kwargs
+            return HandResponse(han=1)
+
+    ruleset = CaptureRuleSet()
+    engine = MahjongEngine(ruleset=ruleset)
+    engine.state.round_number = 5  # south round
+    player = engine.state.players[0]
+    player.seat_wind = "south"
+    player.riichi = True
+    player.ippatsu_available = True
+    tile = Tile("man", 3)
+    player.hand.tiles.append(tile)
+    engine.calculate_score(0, tile, is_tsumo=False)
+    assert ruleset.kwargs == {
+        "is_riichi": True,
+        "is_ippatsu": True,
+        "seat_wind": "south",
+        "round_wind": "south",
+    }
+
+
+def test_riichi_and_ippatsu_scoring() -> None:
+    ruleset = StandardRuleSet()
+    engine = MahjongEngine(ruleset=ruleset)
+    engine.state.round_number = 1
+    player = engine.state.players[0]
+    player.seat_wind = "east"
+    tiles = (
+        [Tile("man", v) for v in range(1, 10)]
+        + [Tile("pin", 1), Tile("pin", 2), Tile("pin", 3)]
+        + [Tile("wind", 1), Tile("wind", 1)]
+    )
+    player.hand.tiles = tiles
+    player.riichi = True
+    player.ippatsu_available = True
+    win_tile = tiles[11]
+    result = engine.calculate_score(0, win_tile)
+    yaku_names = [y.name for y in result.yaku]
+    assert "Riichi" in yaku_names
+    assert "Ippatsu" in yaku_names


### PR DESCRIPTION
## Summary
- extend `StandardRuleSet.calculate_score` to include riichi/ippatsu and wind info
- pass these flags from `MahjongEngine.calculate_score`
- adjust tests for new signature and add coverage for the new behaviour
- document the new feature in README

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_6871120091f4832a8da9aae2bc356ee8