### PR TITLE
Fix auto play turn after claims

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -178,9 +178,14 @@ def auto_play_turn(
         assert _engine.state.last_discard is not None
         return _engine.state.last_discard
 
-    if player_index is None:
-        idx = _engine.state.current_player
+    current = _engine.state.current_player
+    if player_index is not None and current != player_index:
+        # Claims advanced the turn to another player; do not play for the
+        # original index. Return the drawn tile for the next player instead.
+        player = _engine.state.players[current]
+        return player.hand.tiles[-1]
 
+    idx = current
     return ai(_engine, idx)
 
 

--- a/tests/core/test_auto_play_turn_claims.py
+++ b/tests/core/test_auto_play_turn_claims.py
@@ -1,0 +1,27 @@
+import pytest
+from core import api, models
+
+
+def test_auto_play_turn_last_skip_does_not_play_wrong_player() -> None:
+    state = api.start_game(["A", "B", "C", "D"])
+    engine = api._engine
+    assert engine is not None
+    engine.pop_events()
+
+    discarder = state.dealer
+    tile = models.Tile("man", 1)
+    for p in state.players:
+        p.hand.tiles = [models.Tile("sou", 9)] * 13
+    state.players[discarder].hand.tiles.append(tile)
+    api.discard_tile(discarder, tile)
+    engine.pop_events()
+
+    api.skip(1)
+    api.skip(2)
+    api.auto_play_turn(3, claim_players=[3])
+
+    events = engine.pop_events()
+    names = [e.name for e in events]
+    assert names[0] == "skip"
+    assert names[-1] == "draw_tile"
+    assert state.current_player == (discarder + 1) % 4


### PR DESCRIPTION
## Summary
- avoid running auto play for wrong player after claim phase
- test auto_play_turn when last claimant skips

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_687191eb3e90832a92330b8daecb9b1a