### PR TITLE
Include draw/discard in allowed actions

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -282,8 +282,7 @@ def get_allowed_actions(player_index: int) -> list[str]:
     """Return allowed actions for ``player_index`` in the current game."""
 
     assert _engine is not None, "Game not started"
-    engine = _engine
-    return engine.get_allowed_actions(player_index)
+    return _player_actions(player_index)
 
 
 def get_chi_options(player_index: int) -> list[list[Tile]]:
@@ -298,7 +297,7 @@ def get_all_allowed_actions() -> list[list[str]]:
 
     assert _engine is not None, "Game not started"
     return [
-        _engine.get_allowed_actions(i) for i in range(len(_engine.state.players))
+        _player_actions(i) for i in range(len(_engine.state.players))
     ]
 
 

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -90,5 +90,8 @@ know which player is expected to act and what actions they may take:
   a single player.
 - `GET /games/{id}/allowed-actions` returns the allowed actions for all players.
 
+The allowed actions lists include `draw` or `discard` when it is that player's
+turn so clients know whether to play automatically.
+
 The same data is also pushed over the WebSocket as an `allowed_actions` event
 whenever it changes. Waiting for these signals ensures actions are accepted by the server.

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -203,7 +203,7 @@ def test_allowed_actions_offer_riichi_on_turn() -> None:
     state = api.start_game(["A", "B", "C", "D"])
     state.players[0].hand.tiles = TENPAI_TILES.copy()
     actions = api.get_allowed_actions(0)
-    assert actions == [RIICHI]
+    assert RIICHI in actions and "discard" in actions
 
 
 def test_allowed_actions_exclude_riichi_when_not_tenpai() -> None:


### PR DESCRIPTION
## Summary
- expose draw/discard via API get_allowed_actions
- include draw/discard in get_all_allowed_actions
- document allowed-actions response
- update riichi allowed actions test

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m build web`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci --prefix web_gui`
- `(cd web_gui && npx --no-install vitest run)`

------
https://chatgpt.com/codex/tasks/task_e_68719536cb2c832aa5147fea2eb37997