### PR TITLE
Fix AI claim timing for Pon calls

### DIFF
--- a/web_gui/GameBoard.autoClaimOrder.test.jsx
+++ b/web_gui/GameBoard.autoClaimOrder.test.jsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState() {
+  return {
+    current_player: 0,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    waiting_for_claims: [1, 2, 3],
+    last_discard: { suit: 'man', value: 1 },
+  };
+}
+
+describe('GameBoard claim ordering', () => {
+  it('sends one auto request when multiple claims available', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = mockState();
+    render(
+      <GameBoard
+        state={state}
+        server="http://s"
+        gameId="1"
+        allowedActions={[[], ['pon'], ['chi'], ['chi']]}
+      />,
+    );
+    await Promise.resolve();
+    const bodies = fetchMock.mock.calls
+      .filter((c) => c[1] && c[1].body)
+      .map((c) => JSON.parse(c[1].body));
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toEqual({ player_index: 1, action: 'auto', ai_type: 'simple' });
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -138,18 +138,18 @@ export default function GameBoard({
         prevWaiting.current = waiting.slice();
         skipSent.current.clear();
       }
-      waiting.forEach((idx) => {
-        if (aiPlayers[idx]) {
-          if (allowedActions[idx]?.length) {
-            const body = {
-              player_index: idx,
-              action: "auto",
-              ai_type: aiTypes[idx],
-            };
-            log("debug", `POST /games/${gameId}/action auto - resolve claims`);
-            sendAction(body, true);
-          }
-        } else if (
+      for (const idx of waiting) {
+        if (aiPlayers[idx] && allowedActions[idx]?.length) {
+          const body = {
+            player_index: idx,
+            action: "auto",
+            ai_type: aiTypes[idx],
+          };
+          log("debug", `POST /games/${gameId}/action auto - resolve claims`);
+          sendAction(body, true);
+          break;
+        }
+        if (
           allowedActions[idx]?.length === 1 &&
           allowedActions[idx][0] === "skip" &&
           !skipSent.current.has(idx)
@@ -159,7 +159,7 @@ export default function GameBoard({
           sendAction(body);
           skipSent.current.add(idx);
         }
-      });
+      }
       return;
     }
     skipSent.current.clear();


### PR DESCRIPTION
## Summary
- prevent multiple AI claim requests when handling discard claims
- add regression test

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6871994438f4832a83670d02b7a49aaf