### PR TITLE
Fix Tenhou log draw handling

### DIFF
--- a/core/mahjong_engine.py
+++ b/core/mahjong_engine.py
@@ -1,6 +1,7 @@
 """Mahjong game engine wrapper."""
 from __future__ import annotations
 
+from copy import deepcopy
 from .models import GameState, Tile, Meld, GameEvent
 from .player import Player
 from .actions import CHI, PON, KAN, RIICHI, TSUMO, RON, SKIP
@@ -53,7 +54,7 @@ class MahjongEngine:
         self._claims_open = False
         self.game_over = False
         self._final_state: GameState | None = None
-        self._emit("start_game", {"state": self.state})
+        self._emit("start_game", {"state": deepcopy(self.state)})
         self.start_kyoku(dealer=0, round_number=1)
 
     def _invalidate_cache(self) -> None:
@@ -195,7 +196,7 @@ class MahjongEngine:
         self.deal_initial_hands()
         self._emit(
             "start_kyoku",
-            {"dealer": dealer, "round": round_number, "state": self.state},
+            {"dealer": dealer, "round": round_number, "state": deepcopy(self.state)},
         )
         self._check_nine_terminals(self.state.players[dealer])
 

--- a/tests/core/test_tenhou_log.py
+++ b/tests/core/test_tenhou_log.py
@@ -76,6 +76,23 @@ def test_events_to_tenhou_json_draw() -> None:
     assert kyoku[-1][0] == "全員不聴"
 
 
+def test_events_to_tenhou_json_draw_with_tenpai() -> None:
+    engine = MahjongEngine()
+
+    def fake_is_tenpai(player):
+        idx = engine.state.players.index(player)
+        return idx != 1
+
+    engine._is_tenpai = fake_is_tenpai  # type: ignore
+    engine.state.wall.tiles = [Tile("pin", 1)]
+    engine.state.players[engine.state.current_player].hand.tiles.pop()
+    engine.draw_tile(engine.state.current_player)
+    engine.end_game()
+    data = json.loads(events_to_tenhou_json(engine.pop_events()))
+    kyoku = data["log"][0]
+    assert kyoku[-1] == ["流局", [1000, -3000, 1000, 1000]]
+
+
 def test_events_to_tenhou_json_kyoku_num() -> None:
     engine = MahjongEngine()
     engine.pop_events()  # clear start_game/start_kyoku
@@ -85,7 +102,7 @@ def test_events_to_tenhou_json_kyoku_num() -> None:
     engine.end_game()
     data = json.loads(events_to_tenhou_json(engine.pop_events()))
     kyoku_info = data["log"][0][0]
-    assert kyoku_info == [(3 - 1) * 4 + 2, 1, 0]
+    assert kyoku_info == [(3 - 1) * 4 + 2, 0, 0]
 
 
 def test_dora_indicator_appended_on_kan() -> None:


### PR DESCRIPTION
## Summary
- snapshot game state when emitting `start_game` and `start_kyoku`
- add regression test for draw with tenpai players
- update kyoku metadata expectation

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68719a290868832a9e6e6ab8c8bc375b