### PR TITLE
Fix dealer starting hand in Tenhou log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,6 @@
   7. `pytest -q`
   8. `npm ci` in `web_gui`
   9. `npx vitest run` in `web_gui`
+
+The Tenhou log format implemented by the project must follow the
+specification in `docs/tenhou-json.md`.

--- a/core/tenhou_log.py
+++ b/core/tenhou_log.py
@@ -81,10 +81,16 @@ def events_to_tenhou_json(events: List[GameEvent]) -> str:
                 [],
             ]
             player_data = []
-            for player in state.players:
+            for idx, player in enumerate(state.players):
+                hand = [tile_to_code(t) for t in player.hand.tiles]
+                takes: list[Any] = []
+                # Dealer is dealt 14 tiles. The extra tile should be recorded as
+                # the first draw rather than in the starting hand array.
+                if idx == dealer and len(hand) == 14:
+                    takes.append(hand.pop())
                 player_data.append([
-                    [tile_to_code(t) for t in player.hand.tiles],
-                    [],
+                    hand,
+                    takes,
                     [],
                 ])
             riichi_pending = [False for _ in state.players]

--- a/tests/core/test_tenhou_log.py
+++ b/tests/core/test_tenhou_log.py
@@ -28,8 +28,7 @@ def test_tenhou_log_includes_all_starting_hands() -> None:
     kyoku = data["log"][0]
     # After meta arrays hands appear every three elements
     hands = [kyoku[i] for i in range(4, 16, 3)]
-    assert len(hands[0]) in {13, 14}
-    assert all(len(hand) == 13 for hand in hands[1:])
+    assert all(len(hand) == 13 for hand in hands)
 
 
 def test_mjai_log_conversion() -> None:


### PR DESCRIPTION
## Summary
- keep Tenhou log dealer start hand at 13 tiles
- move dealer's extra tile to the draw list
- enforce 13-tile starting hands in tests
- clarify spec location in AGENTS instructions

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68719c133e0c832a9677c22501356e93