### PR TITLE
Improve auto disallowed message

### DIFF
--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -78,7 +78,8 @@ left to each interface implementation.
 The engine enforces turn order and only allows actions that are valid at the current moment.
 If a player tries to act when it is not their turn or performs a disallowed action,
 the `/games/{id}/action` endpoint responds with **HTTP 409** and a short message such as
-`"Player 1 attempted draw on player 0's turn"` or `"Action not allowed: player 2 attempted auto. allowed players=[1]"`.
+`"Player 1 attempted draw on player 0's turn"` or
+`"Action not allowed: player 2 attempted auto. allowed players=[1] allowed actions={1: ['draw']}"`.
 
 Before sending an action, clients should consult one of the following endpoints to
 know which player is expected to act and what actions they may take:

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -410,6 +410,8 @@ def test_auto_action_wrong_turn_returns_409() -> None:
         json={"player_index": wrong, "action": AUTO, "ai_type": "simple"},
     )
     assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert "allowed actions" in detail
 
 
 def test_auto_action_claim_phase_checks_player() -> None:

--- a/web/server.py
+++ b/web/server.py
@@ -421,8 +421,10 @@ def _auto(req: ActionRequest) -> dict:
         state.waiting_for_claims if state.waiting_for_claims else [state.current_player]
     )
     if req.player_index not in allowed_players:
+        allowed_actions = {p: api.get_allowed_actions(p) for p in allowed_players}
         raise InvalidActionError(
-            f"Action not allowed: player {req.player_index} attempted auto. allowed players={allowed_players}"
+            "Action not allowed: player %s attempted auto. allowed players=%s "
+            "allowed actions=%s" % (req.player_index, allowed_players, allowed_actions)
         )
     try:
         tile = api.auto_play_turn(


### PR DESCRIPTION
## Summary
- include allowed actions with allowed players when auto action is rejected
- update docs to document the new message
- test that error detail contains allowed actions

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_68719ab837ac832abdbbcd4be3146916