### PR TITLE
Fix AI auto claim for skip-only players

### DIFF
--- a/web_gui/GameBoard.autoClaimSkip.test.jsx
+++ b/web_gui/GameBoard.autoClaimSkip.test.jsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockState() {
+  return {
+    current_player: 0,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    waiting_for_claims: [1, 2],
+    last_discard: { suit: 'man', value: 1 },
+  };
+}
+
+describe('GameBoard claim phase skipping', () => {
+  it('skips non-claiming players before autoing next claimant', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = mockState();
+    render(
+      <GameBoard
+        state={state}
+        server="http://s"
+        gameId="1"
+        allowedActions={[[], ['skip'], ['pon'], []]}
+      />,
+    );
+    await Promise.resolve();
+    const bodies = fetchMock.mock.calls
+      .filter(c => c[1] && c[1].body)
+      .map(c => JSON.parse(c[1].body));
+    expect(bodies).toContainEqual({ player_index: 1, action: 'skip' });
+    expect(bodies).toContainEqual({ player_index: 2, action: 'auto', ai_type: 'simple' });
+    expect(bodies).toHaveLength(2);
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -139,7 +139,8 @@ export default function GameBoard({
         skipSent.current.clear();
       }
       for (const idx of waiting) {
-        if (aiPlayers[idx] && allowedActions[idx]?.length) {
+        const acts = allowedActions[idx] || [];
+        if (aiPlayers[idx] && acts.some((a) => ["chi", "pon", "kan"].includes(a))) {
           const body = {
             player_index: idx,
             action: "auto",
@@ -149,11 +150,7 @@ export default function GameBoard({
           sendAction(body, true);
           break;
         }
-        if (
-          allowedActions[idx]?.length === 1 &&
-          allowedActions[idx][0] === "skip" &&
-          !skipSent.current.has(idx)
-        ) {
+        if (acts.length === 1 && acts[0] === "skip" && !skipSent.current.has(idx)) {
           const body = { player_index: idx, action: "skip" };
           log("debug", `POST /games/${gameId}/action skip - auto skip`);
           sendAction(body);


### PR DESCRIPTION
## Summary
- avoid sending an `auto` claim when a player only has `skip`
- add regression test for claim skip handling

## Testing
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6871b71cf388832ab2ef363163dd8720