### PR TITLE
Add automatic conflict retry for GUI actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Future work will expand these components.
 - [x] 409 errors recorded in event history
 - [x] Manual state refresh button on errors
 - [x] Retry icon fetches next actions on 409 conflicts
+- [x] Automatic retry of actions on 409 conflicts
 - [x] Player and action included in 409 error messages
 - [x] Custom engine exceptions with FastAPI handlers
 - [x] Chi option modal when multiple chi choices are available

--- a/docs/game-api.md
+++ b/docs/game-api.md
@@ -97,3 +97,7 @@ turn so clients know whether to play automatically.
 
 The same data is also pushed over the WebSocket as an `allowed_actions` event
 whenever it changes. Waiting for these signals ensures actions are accepted by the server.
+
+Front ends should handle occasional 409 conflicts by querying `next-actions`
+and automatically submitting the indicated player action. The GUI retries up to
+three times before surfacing an error to the user.

--- a/web_gui/Controls.jsx
+++ b/web_gui/Controls.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Button from './Button.jsx';
 import ChiModal from './ChiModal.jsx';
 import { getChiOptions } from './chiOptions.js';
+import { postAction } from './postAction.js';
 
 export function Controls({
   server,
@@ -23,29 +24,18 @@ export function Controls({
 
 
   async function simple(action, payload = {}) {
-    try {
-      log(
-        'debug',
-        `POST /games/${gameId}/action ${action} ${JSON.stringify(payload)} - control button`,
-      );
-      const resp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/action`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ player_index: playerIndex, action, ...payload }),
-      });
-      if (!resp.ok) {
-        let msg = `Action ${action} failed: ${resp.status}`;
-        try {
-          const data = await resp.json();
-          if (data.detail) msg = data.detail;
-        } catch {}
-        onError(msg);
-      } else {
-        setMessage(action);
-      }
-    } catch {
-      onError('Server unreachable');
-    }
+    log(
+      'debug',
+      `POST /games/${gameId}/action ${action} ${JSON.stringify(payload)} - control button`,
+    );
+    const ok = await postAction(
+      server,
+      gameId,
+      { player_index: playerIndex, action, ...payload },
+      log,
+      onError,
+    );
+    if (ok) setMessage(action);
   }
 
   async function shanten() {

--- a/web_gui/postAction.js
+++ b/web_gui/postAction.js
@@ -1,0 +1,36 @@
+export async function postAction(server, gameId, body, log = () => {}, onError = () => {}, retries = 0) {
+  const url = `${server.replace(/\/$/, '')}/games/${gameId}/action`;
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (resp.ok) return true;
+    let msg = `Action ${body.action} failed: ${resp.status}`;
+    let detail = null;
+    try {
+      const data = await resp.json();
+      if (data.detail) detail = data.detail;
+    } catch {}
+    if (detail) msg = detail;
+    log('warn', msg);
+    if (resp.status === 409 && retries < 3) {
+      try {
+        const nextResp = await fetch(`${server.replace(/\/$/, '')}/games/${gameId}/next-actions`);
+        if (nextResp.ok) {
+          const next = await nextResp.json();
+          if (next && next.actions && next.actions.length > 0 && next.player_index != null) {
+            const nextBody = { player_index: next.player_index, action: next.actions[0] };
+            log('debug', `Retrying with ${JSON.stringify(nextBody)}`);
+            return postAction(server, gameId, nextBody, log, onError, retries + 1);
+          }
+        }
+      } catch {}
+    }
+    onError(msg);
+  } catch {
+    onError('Failed to contact server');
+  }
+  return false;
+}

--- a/web_gui/postAction.test.js
+++ b/web_gui/postAction.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { postAction } from './postAction.js';
+
+describe('postAction', () => {
+  it('retries on 409 with next action', async () => {
+    let actionCalls = 0;
+    const fetchMock = vi.fn((url) => {
+      if (url.endsWith('/action')) {
+        actionCalls++;
+        if (actionCalls === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 409,
+            json: () => Promise.resolve({ detail: 'conflict' }),
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (url.endsWith('/next-actions')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ player_index: 1, actions: ['draw'] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    global.fetch = fetchMock;
+    const onError = vi.fn();
+    const ok = await postAction('http://s', '1', { player_index: 0, action: 'skip' }, () => {}, onError);
+    expect(ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `postAction` helper to retry 409 errors
- use `postAction` in GameBoard and Controls
- update tests for new retry behaviour and add coverage for `postAction`
- document automatic retries in README and game API docs

## Testing
- `uv pip install --system -e ./core -e ./cli -e ./web`
- `uv pip install --system flake8 mypy pytest build`
- `python -m build core`
- `python -m build cli`
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6871c0f13824832a862ac53fa39e3268