### PR TITLE
Fix auto claim race issue

### DIFF
--- a/web_gui/GameBoard.claimCleanup.test.jsx
+++ b/web_gui/GameBoard.claimCleanup.test.jsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function startState() {
+  return {
+    current_player: 3,
+    players: new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] })),
+    wall: { tiles: [] },
+    waiting_for_claims: [1],
+    last_discard: { suit: 'man', value: 1 },
+  };
+}
+
+describe('GameBoard claim cleanup', () => {
+  it('does not send extra auto after claims close', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const state = startState();
+    const { rerender } = render(
+      <GameBoard
+        state={state}
+        server="http://s"
+        gameId="1"
+        allowedActions={[[], ['pon'], [], []]}
+      />,
+    );
+    await Promise.resolve();
+    fetchMock.mockClear();
+    state.waiting_for_claims = [];
+    state.current_player = 0;
+    rerender(
+      <GameBoard
+        state={state}
+        server="http://s"
+        gameId="1"
+        allowedActions={[['draw'], [], [], []]}
+      />,
+    );
+    await Promise.resolve();
+    const calls = fetchMock.mock.calls.filter(c => c[1] && c[1].body);
+    expect(calls.length).toBe(0);
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -140,9 +140,9 @@ export default function GameBoard({
     if (waiting.length > 0) {
       claimsRecentlyClosed.current = true;
       if (JSON.stringify(waiting) !== JSON.stringify(prevWaiting.current)) {
-        prevWaiting.current = waiting.slice();
         skipSent.current.clear();
       }
+      prevWaiting.current = waiting.slice();
       for (const idx of waiting) {
         const acts = allowedActions[idx] || [];
         if (aiPlayers[idx] && acts.some((a) => ["chi", "pon", "kan"].includes(a))) {
@@ -164,11 +164,11 @@ export default function GameBoard({
       }
       return;
     }
-    skipSent.current.clear();
     if (prevWaiting.current.length > 0) {
       claimsRecentlyClosed.current = true;
+      skipSent.current.clear();
     }
-    prevWaiting.current = [];
+    prevWaiting.current = waiting;
 
     if (claimsRecentlyClosed.current) {
       claimsRecentlyClosed.current = false;


### PR DESCRIPTION
## Summary
- guard against duplicate auto actions when claim phase ends
- test claim cleanup logic

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6871c5206258832ab23e0e5181a70af3