### PR TITLE
Fix AI auto discard after draw

### DIFF
--- a/web_gui/GameBoard.autoDiscardAfterDraw.test.jsx
+++ b/web_gui/GameBoard.autoDiscardAfterDraw.test.jsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockPlayers() {
+  return new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] }));
+}
+
+describe('GameBoard auto discard flow', () => {
+  it('auto discards after auto draw on same turn', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const players = mockPlayers();
+    const state = {
+      current_player: 1,
+      players,
+      wall: { tiles: [] },
+      waiting_for_claims: [],
+      last_discard: { suit: 'man', value: 1 },
+    };
+    const { rerender } = render(
+      <GameBoard state={state} server="http://s" gameId="1" allowedActions={[[], ['draw'], [], []]} />,
+    );
+    await Promise.resolve();
+    // after draw action
+    players[1].hand.tiles.push({ suit: 'man', value: 1 });
+    state.players = players;
+    state.current_player = 1;
+    rerender(
+      <GameBoard state={state} server="http://s" gameId="1" allowedActions={[[], ['discard'], [], []]} />,
+    );
+    await Promise.resolve();
+    const bodies = fetchMock.mock.calls
+      .filter(c => c[1] && c[1].body)
+      .map(c => JSON.parse(c[1].body));
+    expect(bodies.at(-1)).toEqual({ player_index: 1, action: 'auto', ai_type: 'simple' });
+  });
+});

--- a/web_gui/GameBoard.jsx
+++ b/web_gui/GameBoard.jsx
@@ -80,24 +80,7 @@ export default function GameBoard({
       arr[idx] = enable;
       return arr;
     });
-    if (
-      enable &&
-      idx === state?.current_player &&
-      gameId &&
-      hasDrawnTile(state?.players?.[idx], idx) &&
-      (allowedActions[idx]?.includes("discard") ?? false)
-    ) {
-      const tiles = state.players[idx].hand.tiles;
-      const tile = tiles[tiles.length - 1];
-      log(
-        "debug",
-        `POST /games/${gameId}/action discard - enable AI autoplays`,
-      );
-      sendAction(
-        { player_index: idx, action: "discard", tile },
-        true,
-      );
-    }
+    // automatic discard will be triggered by the effect hook
   }
 
   useEffect(() => {
@@ -157,11 +140,11 @@ export default function GameBoard({
     }
 
     const current = state?.current_player;
-    if (current == null || current === prevPlayer.current) return;
+    const drew = lastDrawPlayer.current === current;
+    if (current == null || (!drew && current === prevPlayer.current)) return;
     const tiles = state?.players?.[current]?.hand?.tiles ?? [];
     const last = state?.last_discard;
     const count = tiles.length;
-    const drew = lastDrawPlayer.current === current;
     const allowed = allowedActions[current] || [];
     prevPlayer.current = current;
     if (count % 3 === 1 && last && allowed.includes("draw")) {

--- a/web_gui/GameBoard.toggleAI.test.jsx
+++ b/web_gui/GameBoard.toggleAI.test.jsx
@@ -46,8 +46,8 @@ describe('GameBoard AI toggle mid-turn', () => {
     expect(fetchMock.mock.calls.filter(c => c[1] && c[1].body).length).toBe(1);
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       player_index: 0,
-      action: 'discard',
-      tile: { suit: 'man', value: 1 },
+      action: 'auto',
+      ai_type: 'simple',
     });
   });
 });


### PR DESCRIPTION
## Summary
- allow auto discard after auto draw in GameBoard
- avoid duplicate discard calls when toggling AI
- test auto discard flow
- update AI toggle test for new behavior

## Testing
- `python -m flake8`
- `python -m mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6871c9fe54d8832a8cf4e5e981df950b