### PR TITLE
Fix AI auto discard for next player

### DIFF
--- a/web_gui/GameBoard.autoDiscardAfterDraw.test.jsx
+++ b/web_gui/GameBoard.autoDiscardAfterDraw.test.jsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockPlayers() {
+  return new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] }));
+}
+
+describe('GameBoard auto discard flow', () => {
+  it('auto discards after auto draw on same turn', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const players = mockPlayers();
+    const state = {
+      current_player: 1,
+      players,
+      wall: { tiles: [] },
+      waiting_for_claims: [],
+      last_discard: { suit: 'man', value: 1 },
+    };
+    const { rerender } = render(
+      <GameBoard state={state} server="http://s" gameId="1" allowedActions={[[], ['draw'], [], []]} />,
+    );
+    await Promise.resolve();
+    // after draw action
+    players[1].hand.tiles.push({ suit: 'man', value: 1 });
+    state.players = players;
+    state.current_player = 1;
+    rerender(
+      <GameBoard state={state} server="http://s" gameId="1" allowedActions={[[], ['discard'], [], []]} />,
+    );
+    await Promise.resolve();
+    const bodies = fetchMock.mock.calls
+      .filter(c => c[1] && c[1].body)
+      .map(c => JSON.parse(c[1].body));
+    expect(bodies.at(-1)).toEqual({ player_index: 1, action: 'auto', ai_type: 'simple' });
+  });
+});

--- a/web_gui/GameBoard.consecutiveAutoDiscard.test.jsx
+++ b/web_gui/GameBoard.consecutiveAutoDiscard.test.jsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameBoard from './GameBoard.jsx';
+
+function mockPlayers() {
+  return new Array(4).fill(0).map(() => ({ hand: { tiles: Array(13), melds: [] }, river: [] }));
+}
+
+describe('GameBoard consecutive auto discard', () => {
+  it('auto discards for next player after auto draw', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = fetchMock;
+    const players = mockPlayers();
+    const state = {
+      current_player: 2,
+      players,
+      wall: { tiles: [] },
+      waiting_for_claims: [],
+      last_discard: { suit: 'man', value: 1 },
+    };
+    const { rerender } = render(
+      <GameBoard state={state} server="http://s" gameId="1" allowedActions={[[], [], ['draw'], []]} />,
+    );
+    await Promise.resolve();
+    players[2].hand.tiles.push({ suit: 'man', value: 1 });
+    state.players = players;
+    rerender(
+      <GameBoard state={state} server="http://s" gameId="1" allowedActions={[[], [], ['discard'], []]} />,
+    );
+    await Promise.resolve();
+    const body = JSON.parse(fetchMock.mock.calls.at(-1)[1].body);
+    expect(body).toEqual({ player_index: 2, action: 'auto', ai_type: 'simple' });
+  });
+});

--- a/web_gui/GameBoard.toggleAI.test.jsx
+++ b/web_gui/GameBoard.toggleAI.test.jsx
@@ -46,8 +46,8 @@ describe('GameBoard AI toggle mid-turn', () => {
     expect(fetchMock.mock.calls.filter(c => c[1] && c[1].body).length).toBe(1);
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       player_index: 0,
-      action: 'discard',
-      tile: { suit: 'man', value: 1 },
+      action: 'auto',
+      ai_type: 'simple',
     });
   });
 });


### PR DESCRIPTION
## Summary
- reset prev player after auto draw so following discard triggers
- test consecutive auto discard for sequential turns

## Testing
- `flake8`
- `mypy core web cli`
- `pytest -q`
- `npm ci` in `web_gui`
- `npx vitest run` in `web_gui`


------
https://chatgpt.com/codex/tasks/task_e_6871c9fe54d8832a8cf4e5e981df950b